### PR TITLE
site: retint install section to brand green

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -276,7 +276,7 @@ footer a:hover{color:#ccc}
   border-bottom:2px solid transparent;margin-bottom:-1px;transition:color .15s;
 }
 .os-tab:hover{color:#ccc}
-.os-tab.active{color:#fafafa;border-bottom-color:#0ea5e9;font-weight:500}
+.os-tab.active{color:#fafafa;border-bottom-color:#0aae7a;font-weight:500}
 .os-panel{display:none}
 .os-panel.active{display:block}
 .reco{
@@ -297,7 +297,7 @@ footer a:hover{color:#ccc}
 .alt-label{font-size:.85rem;color:#bcbcbc}
 .alt-cmd{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.82rem;
-  color:#9aceeb;word-break:break-all;padding-right:50px;
+  color:#ccc;word-break:break-all;padding-right:50px;
 }
 .footer-note{margin-top:14px;font-size:.8125rem;color:#777}
 .footer-note a{color:#9a9a9a;text-decoration:underline;text-underline-offset:3px}
@@ -318,11 +318,18 @@ footer a:hover{color:#ccc}
 .try-cmd .p{color:#555;user-select:none}
 .try-cmd .t{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1}
 
-/* Always-visible Copy variant for the recommended hero card. */
+/* Always-visible Copy variant for the recommended hero card.
+   Tinted with the site's brand-green accent rgba(10,174,122,*). */
 .has-copy.always-show .copy-btn{
-  opacity:1;background:#102532;border-color:#1e3a5f;color:#9aceeb;
+  opacity:1;
+  background:rgba(10,174,122,.12);
+  border-color:rgba(10,174,122,.45);
+  color:#0aae7a;
 }
-.has-copy.always-show .copy-btn:hover{background:#15334a;color:#bce0f5}
+.has-copy.always-show .copy-btn:hover{
+  background:rgba(10,174,122,.20);
+  color:#1ec88c;
+}
 
 /* Mobile: stack the grid into one column, Try it drops below. */
 @media(max-width:800px){


### PR DESCRIPTION
## Summary
- Active OS tab underline: sky-blue → brand green (`#0ea5e9` → `#0aae7a`)
- Always-visible Copy button on the recommended hero: blue tint stack → green tint (`rgba(10,174,122,*)` + `#0aae7a` text)
- Alternative-row monospace color: `#9aceeb` → `#ccc` (neutral, matches existing `.cmd` palette)

The OS-tabbed install section that just landed used sky-blue accents that didn't appear anywhere else on the site. The rest of netscli.com has a single accent color: brand green `rgba(10,174,122,*)` (logo glow, hero hover, etc). This brings the install section into line.

## Test plan
- [x] `npm run build` clean
- [x] Verified in `astro dev`: tab underline now green, Copy button green-tinted, alt-row text neutral grey
- [x] No HTML or JS changes (CSS only)
- [ ] CI passes