### PR TITLE
site+docs: lead with TUI on landing page; README accuracy fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ I wanted my AI agent to answer questions about my local network. Things
 like "what's the IP of the device that just joined" or "is port 22 open
 on 192.168.1.42". Existing tools work but they aren't great to drive from
 an agent. Half a dozen CLI invocations, brittle output parsing, no shared
-context. So I built an MCP server first. `netscli serve`, nine tools,
-JSON-RPC over stdio, structured results.
+context. So I built an MCP server first. `netscli serve`, nine tools by
+default (ten in the `-pcap` build), JSON-RPC over stdio, structured results.
 
 Then the TUI. Coding agents like Claude Code have put real work into
 autocomplete, command history, in-place progress, and mouse selection
@@ -106,10 +106,10 @@ brew install netscli
 ### Winget (Windows)
 
 ```powershell
-winget install fstubner.netscli
+winget install netscli
 ```
 
-Ships preinstalled on Windows 10/11. Source: [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs/tree/master/manifests/f/fstubner/netscli).
+Resolves from the official [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs/tree/master/manifests/f/fstubner/netscli) repo (winget ships preinstalled on Windows 10/11).
 
 ### Scoop (Windows)
 
@@ -182,6 +182,8 @@ cargo install --git https://github.com/fstubner/netscli netscli
 
 ### GUI Application
 
+> **Heads up:** the desktop app is currently build-from-source only. None of the package managers above (Homebrew / Winget / Scoop / AUR / install scripts) ship the GUI — they install the CLI/TUI binary. Prebuilt GUI installers (`.msi`, `.dmg`, `.AppImage`, `.deb`) are tracked for a future release.
+
 ```bash
 cd apps/netscli-gui
 npm install
@@ -250,6 +252,7 @@ netscli
 - `/reverse <ip>` - Reverse DNS (PTR) lookup
 - `/arp` - Show/manage ARP table with vendor information
 - `/interfaces` - List network interfaces
+- `/mdns` - Discover devices on the local network via mDNS/DNS-SD (Bonjour)
 - `/config` - Interactive TUI settings (saved to `~/.netscli/tui-settings.json`)
 - `/export [md|json] [--output <path>]` - Export the current session output
 - `/pcap ...` - Packet capture (pcap-enabled builds only; run `/pcap --check` to list interfaces)
@@ -414,7 +417,7 @@ systemctl --user enable --now netscli-mcp.service
 
 ### Available Tools
 
-The MCP server exposes 10 tools:
+The MCP server exposes 9 tools by default (10 in `-pcap` builds, where `capture_pcap` is also available):
 1. `discover_network` - Discover live hosts on a network subnet
 2. `scan_ports` - Scan TCP ports on a host
 3. `ping_host` - Ping a host with statistics

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -154,7 +154,7 @@ export const site: SiteData = {
       'network scanner, rust, cli, tui, mcp server, model context protocol, port scan, host discovery, dns lookup, arp table, bonjour, mdns, packet capture, claude, cursor, ai agent, network tool, cross-platform',
     siteName: 'netscli',
     author: { name: 'Felix Stubner', url: 'https://github.com/fstubner' },
-    ogImage: 'https://netscli.com/gui-dashboard.png',
+    ogImage: 'https://netscli.com/assets/tui-discover.png',
     faviconPath: '/favicon.svg',
     themeColor: '#111',
   },
@@ -171,16 +171,16 @@ export const site: SiteData = {
     badge: 'Open source · MIT · Rust · Windows, Linux, macOS',
     heading: 'A network scanner you can talk to',
     subhead:
-      'Discover hosts, scan ports, resolve DNS, capture packets. Use it from a terminal, a desktop app, or let your AI agent call the MCP server or the CLI directly.',
+      'Discover hosts, scan ports, resolve DNS, capture packets. Drive it from an interactive terminal UI with autocomplete, the command line, or let your AI agent call the MCP server directly.',
     quickInstall:
       'curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash',
     installLinkLabel: 'Windows & Cargo options ↓',
-    heroImage: '/gui-dashboard.png',
-    heroImageWebp: '/gui-dashboard.webp',
+    heroImage: '/assets/tui-discover.png',
+    heroImageWebp: '/assets/tui-discover.webp',
     heroImageAlt:
-      "netscli desktop app dashboard on Windows showing the default network interface, live traffic rates, and a table of detected network interfaces",
-    heroImageWidth: 1375,
-    heroImageHeight: 1000,
+      'netscli terminal UI running /discover: list of live hosts on the local subnet with IP addresses, hostnames, and response times',
+    heroImageWidth: 1640,
+    heroImageHeight: 930,
     sourceUrl: 'https://github.com/fstubner/netscli',
   },
 
@@ -203,19 +203,6 @@ export const site: SiteData = {
 
   surfaces: [
     {
-      title: 'Desktop app',
-      body:
-        "A standalone desktop application for when you'd rather not open a terminal. Scan ports, discover hosts, look up DNS records, inspect your ARP table. Available for Windows, Linux, and macOS.",
-      image: {
-        src: '/gui-scan.png',
-        webp: '/gui-scan.webp',
-        alt:
-          'netscli desktop app port scan view: scanning 1.1.1.1 for ports 80 and 443 returns both as open with http and https service labels',
-        width: 1375,
-        height: 1000,
-      },
-    },
-    {
       title: 'Terminal UI',
       body:
         'An interactive terminal interface. Type <code>/</code> to see available commands, use tab to autocomplete, arrow keys to browse history. The status bar shows your IP and live traffic rates.',
@@ -224,10 +211,9 @@ export const site: SiteData = {
         webp: '/assets/tui-discover.webp',
         alt:
           'netscli terminal UI running /discover: list of live hosts on the local subnet with IP addresses, hostnames, and response times',
-        width: 1200,
-        height: 680,
+        width: 1640,
+        height: 930,
       },
-      flip: true,
     },
     {
       title: 'Command line',
@@ -247,7 +233,7 @@ export const site: SiteData = {
     {
       title: 'MCP server',
       body:
-        'Run <code>netscli serve</code> and point Claude Desktop or Cursor at it. Your agent gets 10 tools — host discovery, port scanning, DNS, ARP, mDNS, and more — over standard JSON-RPC.',
+        'Run <code>netscli serve</code> and point Claude Desktop or Cursor at it. Your agent gets nine tools — host discovery, port scanning, DNS, ARP, mDNS, and more — over standard JSON-RPC. The pcap-enabled build adds a tenth tool for packet capture.',
       codeHtml: `<span style="color:#888">// claude_desktop_config.json</span>
 <span style="color:#555">{</span>
   <span style="color:#7c9fc7">"mcpServers"</span>: <span style="color:#555">{</span>
@@ -258,6 +244,19 @@ export const site: SiteData = {
   <span style="color:#555">}</span>
 <span style="color:#555">}</span>`,
       flip: true,
+    },
+    {
+      title: 'Desktop app',
+      body:
+        "A standalone desktop application for when you'd rather not open a terminal. Scan ports, discover hosts, look up DNS records, inspect your ARP table. <em>Currently build-from-source only — prebuilt installers (.msi / .dmg / .AppImage / .deb) are tracked for a future release; package managers above install the CLI/TUI binary.</em>",
+      image: {
+        src: '/gui-scan.png',
+        webp: '/gui-scan.webp',
+        alt:
+          'netscli desktop app port scan view: scanning 1.1.1.1 for ports 80 and 443 returns both as open with http and https service labels',
+        width: 1375,
+        height: 1000,
+      },
     },
   ],
 


### PR DESCRIPTION
## Summary

Two coupled changes:

1. **Landing page now leads with the TUI**, not the desktop app. The desktop app currently isn't installable via any of the documented package managers (Homebrew / Winget / Scoop / AUR / install scripts) — they all ship the CLI/TUI binary, and no prebuilt GUI installers are attached to the GitHub release. Featuring the desktop app in the hero set an expectation that those installs don't fulfill.

2. **README accuracy pass** cross-referenced against the actual code (not other docs). Found contradictions and a missing TUI command.

## Landing page (site/src/data/site.ts)

- Hero image swapped: \`/gui-dashboard.*\` → \`/assets/tui-discover.*\`
- Hero subhead drops "desktop app" mention; leads with TUI / CLI / MCP
- OG image (social sharing previews) updated to TUI screenshot
- Surfaces reordered: **Terminal UI → Command line → MCP server → Desktop app** (desktop now last with an inline build-from-source caveat)
- MCP server card text: "10 tools" → "nine by default (ten with pcap)" — matches \`server.rs\` actual count

## README

- L36 / L417 contradiction: "nine tools" vs "10 tools" → both clarified (default has 9, pcap build has 10; verified against \`crates/netscli-mcp/src/server.rs:347\`)
- Winget command: \`winget install fstubner.netscli\` → \`winget install netscli\` (uses the Moniker)
- Wording: "Ships preinstalled on Windows 10/11" referred to netscli — rephrased to clarify winget itself is what's preinstalled
- TUI command list was missing \`/mdns\` (added — verified against \`apps/netscli-cli/src/tui.rs:164\`)
- GUI Application install section: added heads-up that the desktop app is currently build-from-source only

## Test plan

- [x] \`npm run build\` clean
- [x] Browser preview: hero shows TUI, surfaces in new order, Desktop card last with caveat copy
- [x] All install commands and tool counts verified against the actual code
- [ ] CI passes