### PR TITLE
deps: bump pnet stack 0.34 -> 0.35 (closes #21, #23)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,18 +3267,18 @@ dependencies = [
 
 [[package]]
 name = "pnet_base"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cf6fb3ab38b68d01ab2aea03ed3d1132b4868fa4e06285f29f16da01c5f4c"
+checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
 dependencies = [
  "no-std-net",
 ]
 
 [[package]]
 name = "pnet_datalink"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5854abf0067ebbd3967f7d45ebc8976ff577ff0c7bd101c4973ae3c70f98fe"
+checksum = "e79e70ec0be163102a332e1d2d5586d362ad76b01cec86f830241f2b6452a7b7"
 dependencies = [
  "ipnetwork",
  "libc",
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_macros"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688b17499eee04a0408aca0aa5cba5fc86401d7216de8a63fdf7a4c227871804"
+checksum = "13325ac86ee1a80a480b0bc8e3d30c25d133616112bb16e86f712dcf8a71c863"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3301,18 +3301,18 @@ dependencies = [
 
 [[package]]
 name = "pnet_macros_support"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea925b72f4bd37f8eab0f221bbe4c78b63498350c983ffa9dd4bcde7e030f56"
+checksum = "eed67a952585d509dd0003049b1fc56b982ac665c8299b124b90ea2bdb3134ab"
 dependencies = [
  "pnet_base",
 ]
 
 [[package]]
 name = "pnet_packet"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a005825396b7fe7a38a8e288dbc342d5034dac80c15212436424fef8ea90ba"
+checksum = "4c96ebadfab635fcc23036ba30a7d33a80c39e8461b8bd7dc7bb186acb96560f"
 dependencies = [
  "glob",
  "pnet_base",
@@ -3322,9 +3322,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_sys"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417c0becd1b573f6d544f73671070b039051e5ad819cc64aa96377b536128d00"
+checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
 dependencies = [
  "libc",
  "winapi",
@@ -3332,9 +3332,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_transport"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2637e14d7de974ee2f74393afccbc8704f3e54e6eb31488715e72481d1662cc3"
+checksum = "5f604d98bc2a6591cf719b58d3203fd882bdd6bf1db696c4ac97978e9f4776bf"
 dependencies = [
  "libc",
  "pnet_base",

--- a/crates/netscli-core/Cargo.toml
+++ b/crates/netscli-core/Cargo.toml
@@ -24,8 +24,8 @@ serde_json.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 ipnet.workspace = true
-pnet_packet = "0.34"
-pnet_transport = "0.34"
+pnet_packet = "0.35"
+pnet_transport = "0.35"
 ipnetwork = "0.20"
 hickory-resolver = { version = "0.24", features = ["tokio-runtime"] }
 sysinfo = "0.30"
@@ -42,8 +42,8 @@ pcap = { version = "1.1", optional = true }
 mdns-sd = { version = "0.13", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-pnet_sys = "0.34"
-pnet_datalink = "0.34"
+pnet_sys = "0.35"
+pnet_datalink = "0.35"
 
 [target.'cfg(windows)'.dependencies]
 ipconfig = "0.3"


### PR DESCRIPTION
## Summary

Closes [#21](https://github.com/fstubner/netscli/pull/21) (pnet_datalink) and [#23](https://github.com/fstubner/netscli/pull/23) (pnet_transport). Dependabot opened them separately, but the pnet ecosystem versions move in lockstep — \`pnet_packet\`, \`pnet_transport\`, \`pnet_datalink\`, and \`pnet_sys\` all need to bump together.

## What changed

- \`pnet_packet = "0.34"\` → \`"0.35"\`
- \`pnet_transport = "0.34"\` → \`"0.35"\`
- \`pnet_datalink = "0.34"\` → \`"0.35"\`
- \`pnet_sys = "0.34"\` → \`"0.35"\`

0.35 brought no source-incompatible API changes for our use of \`transport_channel\`, \`TransportChannelType::Layer3\`, \`icmp_packet_iter\`, or \`pnet_datalink::interfaces\`. Clippy is clean across the workspace at \`-D warnings\`.

## Note on ipnetwork (#22)

[#22](https://github.com/fstubner/netscli/pull/22) (ipnetwork 0.20 → 0.21.1) **cannot be merged right now**. \`pnet_datalink 0.35.0\` still transitively pins \`ipnetwork = ^0.20\`. Cargo can't resolve a single shared version when our top-level says 0.21 but pnet's says 0.20. We'll revisit once upstream pnet relaxes its ipnetwork constraint. I'll close #22 with a comment pointing here.

## Test plan

- [x] \`cargo build -p netscli-core\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean (workspace)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --all\` clean
- [ ] CI passes (Windows pnet path is the riskier one)