### PR TITLE
cli: add --concurrency / -j global flag for tuning in-flight ops

### DIFF
--- a/apps/netscli-cli/src/args.rs
+++ b/apps/netscli-cli/src/args.rs
@@ -4,6 +4,12 @@ use clap_complete::Shell;
 #[derive(Parser)]
 #[command(name = "netscli", version, about = "Modern network scanner", long_about = None)]
 pub struct Cli {
+    /// Max in-flight network operations (default 256; clamped to [1, 1024];
+    /// mDNS discovery sub-caps internally at 32). Lower this on fragile home
+    /// gateways that struggle with hundreds of simultaneous probes.
+    #[arg(short = 'j', long, global = true, value_name = "N")]
+    pub concurrency: Option<usize>,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }

--- a/apps/netscli-cli/src/main.rs
+++ b/apps/netscli-cli/src/main.rs
@@ -24,7 +24,8 @@ use dirs::home_dir;
 use formatter::Formatter;
 use mac_address::MacAddress;
 use netscli_core::{
-    parse_ports_checked, Database, NetworkManager, Ops, PcapCancelToken, PingScanner,
+    parse_ports_checked, Database, NetworkManager, Ops, OpsConfig, PcapCancelToken, PingScanner,
+    DEFAULT_CONCURRENCY,
 };
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
@@ -92,7 +93,10 @@ async fn main() -> Result<()> {
     }
 
     let db = try_init_db().await;
-    let ops = Ops::default();
+    let ops = Ops::new(OpsConfig {
+        concurrency: cli.concurrency.unwrap_or(DEFAULT_CONCURRENCY),
+        ..Default::default()
+    });
     let local_addr = netscli_core::detect_default_ipv4_addr().map(|ip| ip.to_string());
 
     if let Some(command) = &cli.command {
@@ -534,7 +538,7 @@ async fn main() -> Result<()> {
             }
         }
     } else {
-        run_tui().await?;
+        run_tui(cli.concurrency.unwrap_or(DEFAULT_CONCURRENCY)).await?;
     }
 
     Ok(())
@@ -741,7 +745,7 @@ async fn init_db() -> Result<Database> {
     Ok(db)
 }
 
-async fn run_tui() -> Result<()> {
+async fn run_tui(concurrency: usize) -> Result<()> {
     let db = try_init_db().await.map(std::sync::Arc::new);
     enable_raw_mode()?;
     let stdout = io::stdout();
@@ -753,7 +757,10 @@ async fn run_tui() -> Result<()> {
     let mut app = TuiApp::new();
     app.settings = crate::tui_settings::load_settings();
     app.apply_settings();
-    let ops = Ops::default();
+    let ops = Ops::new(OpsConfig {
+        concurrency,
+        ..Default::default()
+    });
     let mut task: Option<tokio::task::JoinHandle<Vec<Line<'static>>>> = None;
     let tick_rate = std::time::Duration::from_millis(100);
     let mut last_nav_at: Option<Instant> = None;

--- a/crates/netscli-core/src/ops.rs
+++ b/crates/netscli-core/src/ops.rs
@@ -54,7 +54,11 @@ pub struct Ops {
 impl Ops {
     pub fn new(cfg: OpsConfig) -> Self {
         let mut cfg = cfg;
-        cfg.concurrency = cfg.concurrency.max(1);
+        // Clamp [1, 1024]. Lower bound prevents semaphore deadlock; upper
+        // bound matches the MCP server's existing per-call clamp at
+        // server.rs:68 and stops users from triggering kernel ephemeral-port
+        // exhaustion on aggressive --concurrency values.
+        cfg.concurrency = cfg.concurrency.clamp(1, 1024);
         cfg.scan_timeout_ms = cfg.scan_timeout_ms.max(1);
         cfg.ping_timeout_ms = cfg.ping_timeout_ms.max(1);
         cfg.dns_timeout_ms = cfg.dns_timeout_ms.max(1);

--- a/crates/netscli-core/tests/config_safety.rs
+++ b/crates/netscli-core/tests/config_safety.rs
@@ -20,6 +20,17 @@ fn ops_new_clamps_zero_values() {
     assert_eq!(cfg.dns_timeout_ms, 1);
 }
 
+#[test]
+fn ops_new_clamps_concurrency_upper_bound() {
+    let cfg = OpsConfig {
+        concurrency: 9999,
+        ..Default::default()
+    };
+
+    let ops = Ops::new(cfg);
+    assert_eq!(ops.config().concurrency, 1024);
+}
+
 #[tokio::test]
 async fn resolve_host_ip_with_timeout_accepts_literal_ip() {
     let ip = netscli_core::ops::resolve_host_ip_with_timeout("127.0.0.1", 1)


### PR DESCRIPTION
## Summary

Adds a top-level \`--concurrency <N>\` (alias \`-j <N>\`) flag so users on fragile home gateways can dial down from the 256 default without rebuilding.

\`\`\`
netscli --concurrency 32 discover
netscli scan 1.1.1.1 -p 22,80,443 -j 64
netscli sweep 192.168.1.0/24 -j 16  # for routers that cap NAT table
\`\`\`

\`global = true\` on the clap arg propagates the flag to every subcommand. Tested via \`netscli discover --help\` showing the flag.

## What changed

- **args.rs**: \`Cli\` struct gets a \`concurrency: Option<usize>\` field with \`#[arg(short = 'j', long, global = true)]\`.
- **main.rs**: both \`Ops::default()\` sites (cli + tui) now use \`Ops::new(OpsConfig { concurrency: cli.concurrency.unwrap_or(DEFAULT_CONCURRENCY), ..Default::default() })\`. \`run_tui()\` takes a \`concurrency: usize\` parameter so the TUI honors the flag too.
- **ops.rs::Ops::new**: now clamps to \`[1, 1024]\` (was \`[1, ∞)\`). Upper bound matches the MCP server's existing per-call clamp at server.rs:68 and stops aggressive \`--concurrency 99999\` calls from triggering kernel ephemeral-port exhaustion.
- **config_safety.rs**: new test \`ops_new_clamps_concurrency_upper_bound\` asserts 9999 → 1024.

## Test plan

- [x] \`cargo build -p netscli\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test -p netscli-core --test config_safety\` — 5/5 pass including the new clamp test
- [x] \`netscli --help\` lists the flag
- [x] \`netscli discover --help\` shows it (proves global = true)
- [ ] CI passes