### PR TITLE
release: prebuilt GUI installers + bump to 0.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,3 +189,155 @@ jobs:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ─── Desktop GUI installers ───────────────────────────────────────────
+  # Builds the Tauri 2 desktop app on each native runner. .msi/.dmg/.deb/
+  # .AppImage outputs from `tauri.conf.json:bundle.targets = "all"` get
+  # renamed to `netscli-gui-{os}-{arch}.{ext}`, sigstore-signed, and
+  # uploaded alongside the CLI binaries on the same release.
+  #
+  # macOS .dmg ships UNSIGNED — users see "unverified developer" on first
+  # launch and must right-click → Open. Notarization (paid Apple Developer
+  # cert) is tracked separately. Linux ARM64 + Windows ARM64 GUI builds
+  # are out of matrix scope for v0.2.1 to keep CI budget reasonable.
+  gui:
+    name: Build GUI installer
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset_prefix: netscli-gui-linux-x86_64
+            bundle_dir: bundle
+            bundle_globs: "deb/*.deb appimage/*.AppImage"
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            asset_prefix: netscli-gui-macos-aarch64
+            bundle_dir: bundle
+            bundle_globs: "dmg/*.dmg"
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            asset_prefix: netscli-gui-macos-x86_64
+            bundle_dir: bundle
+            bundle_globs: "dmg/*.dmg"
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            asset_prefix: netscli-gui-windows-x86_64
+            bundle_dir: bundle
+            bundle_globs: "msi/*.msi"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+          targets: ${{ matrix.target }}
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/netscli-gui/package-lock.json
+
+      # Tauri 2 needs the same GTK/WebKit stack the lint job already
+      # installs in ci.yml. Mirror it here so the bundle step can link.
+      - name: Install Linux GUI dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
+            librsvg2-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev
+
+      - name: npm ci
+        run: npm ci
+        working-directory: apps/netscli-gui
+
+      - name: tauri build
+        run: npm run tauri -- build --target ${{ matrix.target }}
+        working-directory: apps/netscli-gui
+
+      # Tauri puts bundles under apps/netscli-gui/src-tauri/target/<TARGET>/
+      # release/bundle/{deb,appimage,dmg,msi}/. Rename each artifact to a
+      # predictable name then sigstore-sign it.
+      - name: Collect, rename, and sign GUI artifacts
+        shell: bash
+        env:
+          ASSET_PREFIX: ${{ matrix.asset_prefix }}
+          BUNDLE_GLOBS: ${{ matrix.bundle_globs }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          BUNDLE_ROOT="apps/netscli-gui/src-tauri/target/${TARGET}/release/bundle"
+          OUT_DIR="${RUNNER_TEMP}/gui-out"
+          mkdir -p "${OUT_DIR}"
+          # Walk each glob, copy with the canonical asset name preserving
+          # the file extension. Tauri produces e.g. NetsCLI_0.2.1_amd64.deb;
+          # we want netscli-gui-linux-x86_64.deb.
+          for glob in ${BUNDLE_GLOBS}; do
+            for src in ${BUNDLE_ROOT}/${glob}; do
+              [ -e "${src}" ] || continue
+              ext="${src##*.}"
+              dst="${OUT_DIR}/${ASSET_PREFIX}.${ext}"
+              cp "${src}" "${dst}"
+              echo "Collected ${src} -> ${dst}"
+            done
+          done
+          ls -la "${OUT_DIR}"
+
+      - name: Generate SHA256
+        shell: bash
+        env:
+          ASSET_PREFIX: ${{ matrix.asset_prefix }}
+        run: |
+          set -euo pipefail
+          OUT_DIR="${RUNNER_TEMP}/gui-out"
+          cd "${OUT_DIR}"
+          for f in ${ASSET_PREFIX}.*; do
+            [ -f "$f" ] || continue
+            if command -v sha256sum >/dev/null 2>&1; then
+              sha256sum "$f" > "${f}.sha256"
+            else
+              shasum -a 256 "$f" > "${f}.sha256"
+            fi
+          done
+          ls -la
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Sign GUI artifacts (sigstore keyless)
+        shell: bash
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+          ASSET_PREFIX: ${{ matrix.asset_prefix }}
+        run: |
+          set -euo pipefail
+          OUT_DIR="${RUNNER_TEMP}/gui-out"
+          cd "${OUT_DIR}"
+          for f in ${ASSET_PREFIX}.*; do
+            # Skip the sha256 + any pre-existing sig/pem on re-runs.
+            case "$f" in
+              *.sha256|*.sig|*.pem) continue ;;
+            esac
+            cosign sign-blob --yes \
+              --output-signature "${f}.sig" \
+              --output-certificate "${f}.pem" \
+              "$f"
+          done
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            ${{ runner.temp }}/gui-out/${{ matrix.asset_prefix }}.*
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ version and release together.
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-04-30
+
+### Added
+- Prebuilt desktop GUI installers attached to every release: `.msi`
+  (Windows x86_64), `.dmg` (macOS aarch64 + x86_64), `.deb` and
+  `.AppImage` (Linux x86_64). Each is sigstore-signed alongside the
+  CLI binaries. macOS `.dmg` ships unsigned for now; right-click →
+  Open to bypass Gatekeeper, or run
+  `xattr -dr com.apple.quarantine /Applications/NetsCLI.app`.
+- `--concurrency <N>` (alias `-j <N>`) global CLI flag for tuning
+  in-flight network operations. Default stays at 256; clamped to
+  [1, 1024]. Useful on fragile home gateways that can't keep up with
+  hundreds of simultaneous probes.
+
+### Changed
+- Bumped `pnet_packet`, `pnet_transport`, `pnet_datalink`, and
+  `pnet_sys` from 0.34 to 0.35.
+- Bumped `sysinfo` from 0.30 to 0.38. New `Networks::refresh(true)`
+  semantics drop hot-unplugged interfaces from the cached map rather
+  than retaining stale RX/TX stats.
+
+### Notes
+- `ipnetwork` stayed at 0.20 because `pnet_datalink 0.35` still pins
+  it transitively; will revisit when upstream pnet relaxes the
+  constraint.
+
 ## [0.2.0] — 2026-04-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "netscli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-gui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ipnet",
  "netscli-core",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-mcp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "ipnet",

--- a/README.md
+++ b/README.md
@@ -182,7 +182,13 @@ cargo install --git https://github.com/fstubner/netscli netscli
 
 ### GUI Application
 
-> **Heads up:** the desktop app is currently build-from-source only. None of the package managers above (Homebrew / Winget / Scoop / AUR / install scripts) ship the GUI — they install the CLI/TUI binary. Prebuilt GUI installers (`.msi`, `.dmg`, `.AppImage`, `.deb`) are tracked for a future release.
+Prebuilt installers are attached to every [GitHub release](https://github.com/fstubner/netscli/releases/latest) as of v0.2.1:
+
+- **Windows**: `netscli-gui-windows-x86_64.msi` — double-click to install. WebView2 ships preinstalled on Windows 10/11; if the app fails to start, [install the Evergreen runtime](https://developer.microsoft.com/microsoft-edge/webview2/).
+- **macOS**: `netscli-gui-macos-aarch64.dmg` (Apple Silicon) or `netscli-gui-macos-x86_64.dmg` (Intel). Currently **unsigned** — first launch will show "unverified developer". Right-click → Open to bypass Gatekeeper, or run `xattr -dr com.apple.quarantine /Applications/NetsCLI.app`. Notarized build is tracked separately.
+- **Linux**: `netscli-gui-linux-x86_64.deb` (Debian/Ubuntu) or `netscli-gui-linux-x86_64.AppImage` (any distro; `chmod +x` and run).
+
+To build from source instead:
 
 ```bash
 cd apps/netscli-gui
@@ -190,9 +196,6 @@ npm install
 npm run tauri build
 # Installers created in src-tauri/target/release/bundle/
 ```
-
-**Windows note:** the desktop app requires the WebView2 runtime. Most Windows 10/11 systems already have it; if the app does not start, install the Evergreen runtime: https://developer.microsoft.com/microsoft-edge/webview2/.
-The CLI installer (`scripts/install.ps1`) does not install WebView2 because it is only required for the desktop GUI.
 
 **Output:**
 - **macOS**: `.app` bundle in `src-tauri/target/release/bundle/macos/`

--- a/apps/netscli-cli/Cargo.toml
+++ b/apps/netscli-cli/Cargo.toml
@@ -3,7 +3,7 @@
 # consistency, but the published crate is just `netscli` so users can
 # `cargo install netscli` (matching the produced binary name).
 name = "netscli"
-version = "0.2.0"
+version = "0.2.1"
 description = "Interactive TUI and CLI for network discovery, scanning, and diagnostics"
 authors.workspace = true
 license.workspace = true
@@ -25,8 +25,8 @@ clap_mangen = "0.2"
 ratatui = "0.29.0"
 crossterm = "0.27"
 tui-textarea = "0.4"
-netscli-core = { path = "../../crates/netscli-core", version = "0.2.0", default-features = false, features = ["db", "mdns"] }
-netscli-mcp = { path = "../../crates/netscli-mcp", version = "0.2.0", features = ["mdns"] }
+netscli-core = { path = "../../crates/netscli-core", version = "0.2.1", default-features = false, features = ["db", "mdns"] }
+netscli-mcp = { path = "../../crates/netscli-mcp", version = "0.2.1", features = ["mdns"] }
 serde_yaml_ng = "0.10"
 dirs = "5.0"
 mac_address = "1.1.8"

--- a/apps/netscli-gui/package.json
+++ b/apps/netscli-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netscli-gui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "NetsCLI GUI - Modern network scanner with beautiful desktop interface",
   "private": true,
   "type": "module",

--- a/apps/netscli-gui/src-tauri/Cargo.toml
+++ b/apps/netscli-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-gui"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tauri 2.0 desktop GUI for network discovery, scanning, and diagnostics"
 authors.workspace = true
 license.workspace = true

--- a/apps/netscli-gui/src-tauri/tauri.conf.json
+++ b/apps/netscli-gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "NetsCLI",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.netscli.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/crates/netscli-core/Cargo.toml
+++ b/crates/netscli-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-core"
-version = "0.2.0"
+version = "0.2.1"
 description = "Core networking library: discovery, scanning, DNS, ARP, PCAP, and OUI resolution"
 authors.workspace = true
 license.workspace = true

--- a/crates/netscli-mcp/Cargo.toml
+++ b/crates/netscli-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Model Context Protocol (MCP) server exposing netscli-core tools to LLM agents"
 authors.workspace = true
 license.workspace = true
@@ -17,7 +17,7 @@ thiserror.workspace = true
 ipnet.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-netscli-core = { path = "../netscli-core", version = "0.2.0", default-features = false }
+netscli-core = { path = "../netscli-core", version = "0.2.1", default-features = false }
 
 [features]
 default = ["mdns"]

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -381,5 +381,5 @@ export const site: SiteData = {
     cloudflareToken: 'c03201f65f6d41aa843c81f259a1ac06',
   },
 
-  version: '0.2.0',
+  version: '0.2.1',
 };


### PR DESCRIPTION
## Summary

Ships prebuilt desktop GUI installers (.msi / .dmg / .deb / .AppImage) attached to every release, fixing the longstanding gap that none of the package managers nor the GitHub release ship the GUI today. Bumps the workspace to 0.2.1 in preparation for the cut.

## What changed

- **release.yml** gets a new \`gui\` job alongside the existing \`release\` (CLI) job. The matrix builds Tauri bundles on native runners, renames outputs to \`netscli-gui-{os}-{arch}.{ext}\`, generates SHA256s, sigstore-signs via \`cosign\`, and uploads to the same release.

  | Runner | Target | Outputs |
  |---|---|---|
  | ubuntu-latest | x86_64-unknown-linux-gnu | .deb + .AppImage |
  | macos-latest | aarch64-apple-darwin | .dmg |
  | macos-latest | x86_64-apple-darwin | .dmg |
  | windows-latest | x86_64-pc-windows-msvc | .msi |

- **Version bump 0.2.0 → 0.2.1** across:
  - \`apps/netscli-cli/Cargo.toml\` + dependent path-version specs
  - \`apps/netscli-gui/package.json\`, \`src-tauri/Cargo.toml\`, \`src-tauri/tauri.conf.json\`
  - \`crates/netscli-core/Cargo.toml\`, \`crates/netscli-mcp/Cargo.toml\`
  - \`site/src/data/site.ts\` (\`version\` field used in JSON-LD)

- **CHANGELOG.md** new 0.2.1 section: GUI installers shipped, --concurrency flag, sysinfo + pnet stack bumps, ipnetwork-blocked-by-pnet note.

- **README** GUI Application section rewritten — was "build from source only"; now lists each prebuilt installer with the macOS unsigned-Gatekeeper workaround inline.

## Out of matrix scope (deferred)

- Linux ARM64 GUI builds — most Linux desktops are still x86_64
- Windows ARM64 .msi — Tauri 2 ARM64 support has been spotty
- macOS notarization — needs a paid Apple Developer cert ($99/yr); right-click → Open works fine in the meantime

## Test plan

- [x] \`cargo build -p netscli\` clean at 0.2.1
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] Site builds clean and renders \`0.2.1\` in JSON-LD
- [ ] CI passes (release.yml YAML lints; the actual Tauri build matrix only runs on \`release: published\` or \`workflow_dispatch\`, so it'll be exercised when v0.2.1 is cut)
- [ ] After merge, draft v0.2.1 release and verify GUI assets attach