### PR TITLE
site: restore alternating left/right rhythm in surfaces section

### DIFF
--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -214,6 +214,7 @@ export const site: SiteData = {
         width: 1640,
         height: 930,
       },
+      flip: true,
     },
     {
       title: 'Command line',


### PR DESCRIPTION
## Summary

After [#25](https://github.com/fstubner/netscli/pull/25) reordered the surfaces (TUI → CLI → MCP → Desktop), the layout pattern ended up A, A, B, A instead of alternating. Adds \`flip: true\` to the Terminal UI card so it becomes B, A, B, A — every-other-card visual rhythm is back.

\`\`\`
Before: Terminal UI ◐ | Command line ◐ | MCP server ◑ | Desktop app ◐
After:  Terminal UI ◑ | Command line ◐ | MCP server ◑ | Desktop app ◐
                     ↑                                ↑
                 visual swaps                     visual swaps
\`\`\`

One-line change. Verified via \`preview_eval\` on a running dev server: each surface alternates the \`.flip\` class.

## Test plan
- [x] \`npm run build\` clean
- [x] DOM inspection confirms alternation: \`[flip, no-flip, flip, no-flip]\`
- [ ] CI passes