### PR TITLE
site: feature prebuilt GUI installers on the Desktop surface card

### DIFF
--- a/site/src/components/Surfaces.astro
+++ b/site/src/components/Surfaces.astro
@@ -13,6 +13,16 @@ const { surfaces, copy } = site;
           <div class="surface-text">
             <h3>{s.title}</h3>
             <p set:html={s.body} />
+            {s.downloads && (
+              <div class="surface-downloads">
+                {s.downloads.map((d) => (
+                  <a class="surface-download-btn" href={d.url} download>
+                    <span class="dl-label">{d.label}</span>
+                    {d.hint && <span class="dl-hint">{d.hint}</span>}
+                  </a>
+                ))}
+              </div>
+            )}
           </div>
           <div class="surface-visual">
             {s.image ? (

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -73,6 +73,20 @@ export interface SurfaceCard {
   codeHtml?: string;
   /** If true, flips text and visual sides for alternating rhythm. */
   flip?: boolean;
+  /** Optional per-platform download buttons rendered below the body.
+   *  Used by the Desktop card to surface .msi / .dmg / .deb / .AppImage
+   *  installers from the latest GitHub release. */
+  downloads?: SurfaceDownload[];
+}
+
+export interface SurfaceDownload {
+  /** Visible button label, e.g. "Windows (.msi)". */
+  label: string;
+  /** Direct download URL. Use the /releases/latest/download/ form so
+   *  the buttons auto-track the latest release without site updates. */
+  url: string;
+  /** Optional secondary line below the label, e.g. "Apple Silicon". */
+  hint?: string;
 }
 
 export type Platform = 'windows' | 'macos' | 'linux';
@@ -249,7 +263,7 @@ export const site: SiteData = {
     {
       title: 'Desktop app',
       body:
-        "A standalone desktop application for when you'd rather not open a terminal. Scan ports, discover hosts, look up DNS records, inspect your ARP table. <em>Currently build-from-source only — prebuilt installers (.msi / .dmg / .AppImage / .deb) are tracked for a future release; package managers above install the CLI/TUI binary.</em>",
+        "A standalone desktop application for when you'd rather not open a terminal. Scan ports, discover hosts, look up DNS records, inspect your ARP table. Prebuilt installers attached to every <a href=\"https://github.com/fstubner/netscli/releases/latest\">GitHub release</a> &mdash; sigstore-signed, no build-from-source needed.",
       image: {
         src: '/gui-scan.png',
         webp: '/gui-scan.webp',
@@ -258,6 +272,33 @@ export const site: SiteData = {
         width: 1375,
         height: 1000,
       },
+      downloads: [
+        {
+          label: 'Windows',
+          hint: '.msi',
+          url: 'https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-windows-x86_64.msi',
+        },
+        {
+          label: 'macOS',
+          hint: 'Apple Silicon .dmg',
+          url: 'https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-macos-aarch64.dmg',
+        },
+        {
+          label: 'macOS',
+          hint: 'Intel .dmg',
+          url: 'https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-macos-x86_64.dmg',
+        },
+        {
+          label: 'Linux',
+          hint: '.deb',
+          url: 'https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-linux-x86_64.deb',
+        },
+        {
+          label: 'Linux',
+          hint: '.AppImage',
+          url: 'https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-linux-x86_64.AppImage',
+        },
+      ],
     },
   ],
 

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -367,7 +367,7 @@ export const site: SiteData = {
       'netscli --help',
     ],
     binariesNote:
-      'Or grab binaries from <a href="https://github.com/fstubner/netscli/releases/latest" style="color:#ccc;text-decoration:underline;text-underline-offset:3px">the latest release</a>.',
+      'Or grab CLI binaries and desktop installers (<code>.msi</code> / <code>.dmg</code> / <code>.deb</code> / <code>.AppImage</code>) from <a href="https://github.com/fstubner/netscli/releases/latest" style="color:#ccc;text-decoration:underline;text-underline-offset:3px">the latest release</a>.',
   },
 
   faq: [

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -338,3 +338,27 @@ footer a:hover{color:#ccc}
   .install-content{grid-column:1;grid-row:auto}
   .try{grid-column:1;grid-row:auto;margin-top:24px}
 }
+
+/* Per-platform download buttons inside a surface card body. Used by the
+   Desktop card to surface .msi / .dmg / .deb / .AppImage installers from
+   the latest release without leaving the page. */
+.surface-downloads{
+  display:flex;flex-wrap:wrap;gap:8px;margin-top:18px;
+}
+.surface-download-btn{
+  display:inline-flex;flex-direction:column;align-items:flex-start;gap:2px;
+  padding:9px 14px;border-radius:8px;
+  background:rgba(10,174,122,.10);border:1px solid rgba(10,174,122,.45);
+  color:#0aae7a;font-size:.85rem;font-weight:500;text-decoration:none;
+  transition:background .15s,color .15s,border-color .15s;
+}
+.surface-download-btn:hover{
+  background:rgba(10,174,122,.20);
+  border-color:rgba(10,174,122,.6);
+  color:#1ec88c;
+}
+.surface-download-btn .dl-label{font-size:.85rem;line-height:1.2}
+.surface-download-btn .dl-hint{
+  font-size:.7rem;color:#7a7a7a;font-weight:400;line-height:1.2;
+}
+.surface-download-btn:hover .dl-hint{color:#9a9a9a}


### PR DESCRIPTION
## Summary

After PR [#30](https://github.com/fstubner/netscli/pull/30) wired Tauri GUI installers into release.yml, the landing page still didn't expose them anywhere. Visitors had to dig through the GitHub releases page to find the desktop app. This PR adds five download buttons directly on the Desktop surface card.

## What changed

\`\`\`
Before:
  Desktop app
  A standalone desktop application... Currently build-from-source only —
  prebuilt installers (.msi / .dmg / .AppImage / .deb) are tracked for
  a future release; package managers above install the CLI/TUI binary.

After:
  Desktop app
  A standalone desktop application... Prebuilt installers attached to
  every GitHub release — sigstore-signed, no build-from-source needed.

  [Windows .msi]  [macOS Apple Silicon .dmg]  [macOS Intel .dmg]
  [Linux .deb]    [Linux .AppImage]
\`\`\`

- New \`downloads?: SurfaceDownload[]\` field on \`SurfaceCard\`. Optional, only the Desktop card uses it today.
- New \`SurfaceDownload\` interface (label + url + optional hint).
- \`Surfaces.astro\` renders a \`.surface-downloads\` button row below the card body when present.
- New CSS in the brand-green palette matching \`.has-copy.always-show\`. Buttons wrap onto multiple rows on mobile.
- Buttons point at \`/releases/latest/download/<asset>\` so they auto-track each new release with no site update.

## Layout review (covered in this pass per the user's ask)

Verified via \`preview_eval\` on a running dev server:
- ✓ Section order: Surfaces → Install (Get started) → FAQ
- ✓ Surfaces alternate flip pattern: \`[true, false, true, false]\` (TUI flipped, CLI default, MCP flipped, Desktop default)
- ✓ Desktop card now has \`.surface-downloads\` (5 buttons rendered)
- ✓ Install grid still has 3 OS tabs with auto-detected default
- ✓ FAQ count: 10 (matches expected after the SEO additions)
- ✓ Mobile (375px): download buttons wrap onto multiple rows cleanly

## Note on URL liveness

The buttons go live the moment v0.2.1 is published. Until then they 404 because v0.2.0 doesn't have GUI assets. Plan: land this PR first, then publish v0.2.1 in a separate step (the release.yml run will populate the assets).

## Test plan

- [x] \`npm run build\` clean
- [x] \`preview_eval\` confirms button structure + URLs
- [x] Desktop body no longer mentions build-from-source caveat
- [x] Mobile breakpoint wraps buttons cleanly
- [ ] CI passes