### PR TITLE
site: surface desktop app downloads in the hero

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -18,6 +18,17 @@ const { hero, social } = site;
     <span>{hero.quickInstall}</span>
   </div>
 
+  <!-- Secondary path: desktop app downloads. Surfaced in the hero so
+       visitors who want a GUI don't have to scroll to discover it. -->
+  <div class="hero-desktop">
+    <span class="hero-desktop-label">Or get the desktop app:</span>
+    <a href="https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-windows-x86_64.msi">Windows</a>
+    <span class="hero-desktop-sep">·</span>
+    <a href="https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-macos-aarch64.dmg">macOS</a>
+    <span class="hero-desktop-sep">·</span>
+    <a href="https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-linux-x86_64.AppImage">Linux</a>
+  </div>
+
   <div class="links">
     <a href="#install">{hero.installLinkLabel}</a>
     <a class="plain" href={hero.sourceUrl}>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -80,6 +80,20 @@ nav{
   color:#ccc;display:flex;align-items:center;justify-content:space-between;gap:12px;
 }
 .hero .quick-install span{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+/* Secondary install offer: desktop app downloads. Smaller, quieter row
+   so the curl install above keeps primary visual weight. */
+.hero .hero-desktop{
+  margin:14px auto 0;font-size:.8125rem;color:#9a9a9a;
+  display:flex;justify-content:center;align-items:center;gap:8px;
+  flex-wrap:wrap;
+}
+.hero .hero-desktop-label{color:#888}
+.hero .hero-desktop a{
+  color:#cfcfcf;text-decoration:none;
+  border-bottom:1px dotted rgba(255,255,255,.22);padding-bottom:1px;
+}
+.hero .hero-desktop a:hover{color:#fff;border-bottom-color:rgba(255,255,255,.5)}
+.hero .hero-desktop-sep{color:#555}
 .hero .links{display:flex;gap:16px;justify-content:center;margin-top:16px;flex-wrap:wrap}
 .hero .links a{
   font-size:.8125rem;color:#a3a3a3;text-decoration:none;


### PR DESCRIPTION
## Summary

Following [#35](https://github.com/fstubner/netscli/pull/35) which featured the desktop installers on the Desktop surface card, this surfaces them at the top of the page too. Visitors who want a GUI no longer have to scroll past Surfaces to find out it exists.

\`\`\`
[ curl -fsSL https://...install.sh | bash             Copy ]
   Or get the desktop app: Windows · macOS · Linux
[ Windows & Cargo options ↓ · View source ]
\`\`\`

Each platform link is a direct download from \`releases/latest/download/\`:
- Windows → \`.msi\`
- macOS → \`.dmg\` (Apple Silicon by default; Intel users can grab from the surfaces section)
- Linux → \`.AppImage\` (universal; .deb available below)

## Layout review

- Desktop: single quiet row beneath the install card, smaller font + dotted underlines so the curl install keeps primary visual weight
- Mobile (375px): single row after tightening the label from "Or download the desktop app:" → "Or get the desktop app:" (longer label was wrapping "Linux" onto a hanging second line)

## Test plan
- [x] \`npm run build\` clean
- [x] DOM: \`.hero-desktop\` sits between \`.quick-install\` and \`.hero .links\`
- [x] Mobile breakpoint fits all 6 spans/links on one visual row
- [ ] CI passes