### PR TITLE
release: automate publish to crates.io / Homebrew / Scoop / Winget / AUR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,168 @@
+name: Publish to package managers
+
+# Fans out from a single GitHub release to every downstream registry:
+# crates.io, Homebrew tap, Scoop bucket, Winget (microsoft/winget-pkgs),
+# AUR (netscli-bin). Each job is independent — one failure doesn't block
+# the others, and each is re-runnable from the Actions tab.
+#
+# Triggers:
+#   - On `release: published` (canonical path: flip a draft to public).
+#   - On `workflow_dispatch` with a tag input (re-run a specific job
+#     after fixing a transient failure).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v0.2.1). Must already exist as a published release with assets attached.'
+        required: true
+        type: string
+
+# Resolve the tag once at the workflow level so every job sees the same
+# version regardless of trigger.
+env:
+  TAG: ${{ github.event.inputs.tag || github.ref_name }}
+
+jobs:
+  # ─── crates.io ──────────────────────────────────────────────────────
+  # Bottom-up publish (netscli-core → netscli-mcp → netscli). Sleep
+  # between each to let the index update; downstream crates' resolvers
+  # otherwise can't see the just-published version.
+  crates-io:
+    name: crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+
+      - name: Install libpcap (workspace builds need pkg-config + libpcap headers)
+        run: sudo apt-get update && sudo apt-get install -y libpcap-dev pkg-config
+
+      - name: cargo publish (netscli-core)
+        run: cargo publish -p netscli-core --token "$CARGO_TOKEN"
+        env:
+          CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io index (netscli-core)
+        run: sleep 90
+
+      - name: cargo publish (netscli-mcp)
+        run: cargo publish -p netscli-mcp --token "$CARGO_TOKEN"
+        env:
+          CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io index (netscli-mcp)
+        run: sleep 90
+
+      - name: cargo publish (netscli)
+        run: cargo publish -p netscli --token "$CARGO_TOKEN"
+        env:
+          CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # ─── Homebrew tap ───────────────────────────────────────────────────
+  homebrew:
+    name: Homebrew tap
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.TAG }}
+      - name: Update fstubner/homebrew-tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: bash scripts/release/publish-homebrew.sh "$TAG"
+
+  # ─── Scoop bucket ───────────────────────────────────────────────────
+  scoop:
+    name: Scoop bucket
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.TAG }}
+      - name: Update fstubner/scoop-bucket
+        env:
+          GH_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+        run: bash scripts/release/publish-scoop.sh "$TAG"
+
+  # ─── Winget (microsoft/winget-pkgs) ────────────────────────────────
+  # Forks microsoft/winget-pkgs under the user's account, generates a
+  # 0.X.Y/ manifest folder from the release, opens a PR. Moderator
+  # approval lands it on the public catalog.
+  winget:
+    name: Winget
+    runs-on: windows-latest
+    steps:
+      - name: Submit netscli to microsoft/winget-pkgs
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: fstubner.netscli
+          version: ${{ env.TAG }}
+          installers-regex: 'netscli-windows-x86_64\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}
+
+  # ─── AUR (netscli-bin) ─────────────────────────────────────────────
+  # Pre-step computes SHA256s from release assets and renders a fresh
+  # PKGBUILD with the bumped version. The deploy action then SSH-pushes
+  # to aur.archlinux.org and regenerates .SRCINFO server-side.
+  aur:
+    name: AUR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Wait for Linux release assets + compute SHA256s
+        id: shas
+        env:
+          TAG: ${{ env.TAG }}
+        run: |
+          set -euo pipefail
+          BASE="https://github.com/fstubner/netscli/releases/download/${TAG}"
+          for arch in x86_64 aarch64; do
+            url="${BASE}/netscli-linux-${arch}.sha256"
+            echo "→ ${url}"
+            for i in {1..30}; do
+              if curl -fsSL --head "$url" >/dev/null 2>&1; then break; fi
+              echo "  not yet; retry in 30s ($i/30)"
+              sleep 30
+            done
+            sha=$(curl -fsSL "$url" | awk '{print $1}')
+            echo "${arch}=${sha}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Render bumped PKGBUILD
+        env:
+          TAG: ${{ env.TAG }}
+          SHA_X86_64: ${{ steps.shas.outputs.x86_64 }}
+          SHA_AARCH64: ${{ steps.shas.outputs.aarch64 }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          sed -E \
+            -e "s|^pkgver=.*|pkgver=${version}|" \
+            -e "s|^sha256sums_x86_64=.*|sha256sums_x86_64=('${SHA_X86_64}')|" \
+            -e "s|^sha256sums_aarch64=.*|sha256sums_aarch64=('${SHA_AARCH64}')|" \
+            packaging/aur/PKGBUILD > /tmp/PKGBUILD
+          echo "--- rendered ---"
+          cat /tmp/PKGBUILD
+
+      - name: Push to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v2.7.0
+        with:
+          pkgname: netscli-bin
+          pkgbuild: /tmp/PKGBUILD
+          commit_username: Felix Stubner
+          commit_email: felix.stubner@gmail.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "netscli ${{ env.TAG }}"
+          updpkgsums: false

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,65 @@
+# Release process
+
+netscli ships through five distribution channels. As of v0.2.1 every step
+after "publish the GitHub release" is automated by
+[`.github/workflows/publish.yml`](../.github/workflows/publish.yml).
+
+## One-time secret setup
+
+Before the first automated release runs, add these secrets at
+**GitHub → Settings → Secrets and variables → Actions → New repository secret**:
+
+| Secret | Where to get it | Used by |
+|--------|-----------------|---------|
+| `CARGO_REGISTRY_TOKEN` | [crates.io → Account Settings → API Tokens](https://crates.io/settings/tokens) → "New Token" with `publish-update` scope (limit to `netscli-core`, `netscli-mcp`, `netscli` if you want least-privilege) | `crates-io` job |
+| `HOMEBREW_TAP_TOKEN` | [github.com/settings/tokens](https://github.com/settings/tokens) → fine-grained or classic PAT with `Contents: Read & Write` on `fstubner/homebrew-tap` | `homebrew` job |
+| `SCOOP_BUCKET_TOKEN` | Same shape as Homebrew but for `fstubner/scoop-bucket`. May reuse the same PAT if scoped widely. | `scoop` job |
+| `WINGET_TOKEN` | Classic PAT with `public_repo` scope. The releaser action forks `microsoft/winget-pkgs` under your account and opens a PR — needs to write to your fork. | `winget` job |
+| `AUR_SSH_PRIVATE_KEY` | The private half of the `~/.ssh/aur` key already registered with your AUR account (we generated this earlier). Paste the full file content (`-----BEGIN OPENSSH PRIVATE KEY-----` through `-----END OPENSSH PRIVATE KEY-----` inclusive). | `aur` job |
+
+## The release flow
+
+1. **Bump versions + CHANGELOG**, merge to main. (Already done for v0.2.1
+   via [#30](https://github.com/fstubner/netscli/pull/30).)
+2. **Tag and draft the release.** Either `gh release create vX.Y.Z --draft
+   --generate-notes` or use the web UI's "Draft a new release" button.
+3. **Promote the draft to public.** This is the one human action that
+   stays in the loop.
+   ```bash
+   gh release edit vX.Y.Z --draft=false --repo fstubner/netscli
+   ```
+   This single event fires both `release.yml` (builds binaries + GUI
+   installers, attaches them to the release) and `publish.yml` (fans out
+   to package managers).
+4. **Watch the dashboard.** From the release page or the Actions tab:
+   - `Release` workflow: 13 CLI assets + 4 GUI installers attached.
+   - `Publish to package managers` workflow: 5 jobs, one per channel.
+
+   The `homebrew`, `scoop`, and `aur` jobs poll for asset availability
+   (up to 15 minutes) so they tolerate the parallel race against
+   `release.yml`.
+
+5. **If something fails**, re-run just that job from the Actions tab —
+   `workflow_dispatch` accepts a tag input so you can re-run a specific
+   channel without rebuilding binaries or re-running the others.
+
+## What still needs human attention
+
+- **Winget moderator approval.** The action opens a PR to
+  `microsoft/winget-pkgs`; a community moderator merges it within a few
+  hours to days. CLA must be signed once per account (you've done this).
+- **GUI-channel manifests** (Homebrew Cask, separate Winget GUI entry,
+  Scoop extras, AUR `netscli-gui-bin`). These are CLI-only today; adding
+  GUI-channel manifests is a separate setup PR that lands once the first
+  GUI installer release is verified to work end-to-end (planned post-v0.2.1).
+
+## Action pin policy
+
+The two third-party actions used by this workflow are referenced by
+version tag, not commit SHA:
+- `vedantmgoyal2009/winget-releaser@v2`
+- `KSXGitHub/github-actions-deploy-aur@v2.7.0`
+
+These are stable, widely-used actions; pinning to SHA is on the radar
+but not blocking. If you want stricter supply-chain hygiene, swap each
+`@vN` for the matching `@<sha>` and let Dependabot bump them.

--- a/scripts/release/publish-homebrew.sh
+++ b/scripts/release/publish-homebrew.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Updates fstubner/homebrew-tap's Formula/netscli.rb to point at the new
+# release. Computes SHA256 for each platform asset, sed's the formula in
+# place, and pushes a single commit to the tap.
+#
+# Required environment:
+#   GH_TOKEN — PAT with `repo` scope on fstubner/homebrew-tap.
+# Required argument:
+#   $1 — tag, e.g. "v0.2.1".
+
+set -euo pipefail
+
+TAG="${1:?usage: publish-homebrew.sh <tag>}"
+VERSION="${TAG#v}"
+
+BASE="https://github.com/fstubner/netscli/releases/download/${TAG}"
+ASSETS=(
+  "netscli-macos-aarch64"
+  "netscli-macos-x86_64"
+  "netscli-linux-aarch64"
+  "netscli-linux-x86_64"
+)
+
+# Wait for each .sha256 to materialise. release.yml runs in parallel with
+# publish.yml — the homebrew job can race past the cosign-sign step on
+# release builds that take 3-5 minutes (musl, ARM64 cross-compile). Up to
+# 15 minutes of polling is enough for the slowest matrix entry.
+wait_for_asset() {
+  local url="$1"
+  local i
+  for i in {1..30}; do
+    if curl -fsSL --head "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    echo "  not yet; retry in 30s ($i/30)"
+    sleep 30
+  done
+  echo "ERROR: $url never became available" >&2
+  return 1
+}
+
+declare -A SHA
+for asset in "${ASSETS[@]}"; do
+  url="${BASE}/${asset}.sha256"
+  echo "→ ${url}"
+  wait_for_asset "$url"
+  SHA[$asset]=$(curl -fsSL "$url" | awk '{print $1}')
+done
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+git clone --depth 1 \
+  "https://x-access-token:${GH_TOKEN}@github.com/fstubner/homebrew-tap.git" \
+  "$WORKDIR/tap"
+cd "$WORKDIR/tap"
+git config user.name  "netscli release bot"
+git config user.email "noreply@netscli.com"
+
+formula="Formula/netscli.rb"
+
+# Bump the version line.
+sed -i -E "s|^  version \"[^\"]+\"|  version \"${VERSION}\"|" "$formula"
+
+# Replace the sha256 line that follows each url line containing the asset.
+# awk reads url line, prints it, reads the sha256 line, substitutes its
+# value, prints it. Other lines pass through.
+for asset in "${ASSETS[@]}"; do
+  awk -v asset="$asset" -v new="${SHA[$asset]}" '
+    $0 ~ asset {
+      print
+      getline
+      sub(/sha256 "[^"]+"/, "sha256 \"" new "\"")
+      print
+      next
+    }
+    { print }
+  ' "$formula" > "$formula.tmp" && mv "$formula.tmp" "$formula"
+done
+
+# Sanity check: formula has exactly 4 sha256 lines after editing.
+got=$(grep -c '^      sha256 "' "$formula" || true)
+if [[ "$got" -ne 4 ]]; then
+  echo "ERROR: expected 4 sha256 lines in formula, got ${got}" >&2
+  cat "$formula" >&2
+  exit 1
+fi
+
+git diff
+git add "$formula"
+git commit -m "netscli ${VERSION}"
+git push origin HEAD
+
+echo "✓ Homebrew tap updated to ${VERSION}"

--- a/scripts/release/publish-scoop.sh
+++ b/scripts/release/publish-scoop.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Updates fstubner/scoop-bucket's bucket/netscli.json to point at the new
+# release. Single-asset (windows-x86_64.exe), so simpler than the Homebrew
+# script — version + url + hash, all swapped via jq.
+#
+# Required environment:
+#   GH_TOKEN — PAT with `repo` scope on fstubner/scoop-bucket.
+# Required argument:
+#   $1 — tag, e.g. "v0.2.1".
+
+set -euo pipefail
+
+TAG="${1:?usage: publish-scoop.sh <tag>}"
+VERSION="${TAG#v}"
+
+BASE="https://github.com/fstubner/netscli/releases/download/${TAG}"
+ASSET="netscli-windows-x86_64.exe"
+
+# Same race condition as Homebrew: poll until the asset .sha256 exists.
+url="${BASE}/${ASSET}.sha256"
+echo "→ ${url}"
+for i in {1..30}; do
+  if curl -fsSL --head "$url" >/dev/null 2>&1; then
+    break
+  fi
+  echo "  not yet; retry in 30s ($i/30)"
+  sleep 30
+done
+
+sha=$(curl -fsSL "$url" | awk '{print $1}')
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+git clone --depth 1 \
+  "https://x-access-token:${GH_TOKEN}@github.com/fstubner/scoop-bucket.git" \
+  "$WORKDIR/bucket"
+cd "$WORKDIR/bucket"
+git config user.name  "netscli release bot"
+git config user.email "noreply@netscli.com"
+
+manifest="bucket/netscli.json"
+asset_url="${BASE}/${ASSET}#/netscli.exe"
+
+jq --arg ver "$VERSION" \
+   --arg url "$asset_url" \
+   --arg sha "$sha" '
+     .version = $ver
+     | .architecture["64bit"].url  = $url
+     | .architecture["64bit"].hash = $sha
+   ' "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+
+git diff
+git add "$manifest"
+git commit -m "netscli ${VERSION}"
+git push origin HEAD
+
+echo "✓ Scoop bucket updated to ${VERSION}"


### PR DESCRIPTION
## Summary

Every release today is followed by five manual chores after `gh release edit --draft=false`:

1. `cargo publish` × 3 (in dependency order)
2. Update fstubner/homebrew-tap formula with new SHA256s
3. Update fstubner/scoop-bucket manifest with new SHA256
4. Submit a PR to microsoft/winget-pkgs
5. Push a new PKGBUILD to AUR

This PR replaces all of that with a single workflow that fans out from the `release: published` event. After this lands, the entire release flow becomes:

\`\`\`bash
gh release edit v0.2.1 --draft=false --repo fstubner/netscli
\`\`\`

That's it. Five package managers update themselves.

## What's in here

- \`.github/workflows/publish.yml\` — 5 parallel jobs (crates-io, homebrew, scoop, winget, aur). Each reads the tag from \`github.event.release.tag_name\` (or \`workflow_dispatch\` input for re-runs), so a single secret-failed job can be re-run from the Actions tab without rebuilding binaries.
- \`scripts/release/publish-homebrew.sh\` — clones the tap, polls for the 4 platform .sha256 files (15-min budget covering the slowest release.yml matrix entry), edits the formula via sed + awk, sanity-checks 4 sha256 lines remain, pushes one commit.
- \`scripts/release/publish-scoop.sh\` — single-asset jq edit, same race-tolerant polling.
- \`docs/RELEASE.md\` — secret setup table, release checklist, action-pin policy, what's deferred.

## Required one-time setup (before first auto-run)

5 repo secrets to add (full instructions in [\`docs/RELEASE.md\`](docs/RELEASE.md)):

| Secret | Purpose |
|--------|---------|
| \`CARGO_REGISTRY_TOKEN\` | crates.io publish |
| \`HOMEBREW_TAP_TOKEN\` | push to fstubner/homebrew-tap |
| \`SCOOP_BUCKET_TOKEN\` | push to fstubner/scoop-bucket |
| \`WINGET_TOKEN\` | fork microsoft/winget-pkgs + open PR |
| \`AUR_SSH_PRIVATE_KEY\` | SSH push to aur.archlinux.org |

## Test plan

- [x] Bash scripts pass \`bash -n\` syntax check
- [x] YAML parses cleanly; all 5 jobs declared
- [x] Homebrew awk substitution verified against the existing formula — only the targeted sha256 line gets replaced; the other 3 platforms' SHAs are preserved
- [x] Sanity-check pattern \`grep -c '^      sha256 "'\` matches the expected 4 lines on the existing formula
- [ ] First end-to-end run happens on v0.2.1 (after secrets are configured)

## What's deferred to a follow-up PR

GUI-channel manifests (Homebrew Cask, Winget \`fstubner.netscli.gui\`, Scoop extras, AUR \`netscli-gui-bin\`). Those don't exist yet — they'll land in a separate setup PR once v0.2.1 ships and we've verified the prebuilt installer URLs resolve.