### PR TITLE
release: v0.2.2 lockfile fix + workspace bump (recovers v0.2.1 release.yml failure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ version and release together.
 
 ## [Unreleased]
 
+## [0.2.2] — 2026-05-03
+
+### Fixed
+- Cargo.lock was out of sync with Cargo.toml at the v0.2.1 tag —
+  `tokio 1.52.1` (bumped in #17) requires `socket2 >= 0.6.3`
+  transitively, but Dependabot only regenerated the direct-dep entries
+  in the lock. CI's lint paths use `cargo build` (no `--locked`) so
+  this slipped through; release.yml uses `--locked` to guarantee
+  reproducible builds, and all 17 release builds for v0.2.1 failed at
+  the lockfile check.
+- 0.2.2 regenerates the lockfile so `socket2 0.6.3` is recorded
+  alongside the existing `0.5.10`. No application code changes.
+
+### Notes on v0.2.1
+- Released to crates.io but the GitHub release page has no attached
+  binaries (release.yml never produced any). `cargo install netscli`
+  works because cargo regenerates the lockfile per-user; downloads
+  from the GitHub release / package managers should use 0.2.2.
+- 0.2.1 is left in place as crates.io history rather than yanked.
+
 ## [0.2.1] — 2026-04-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,7 +2045,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "widestring",
  "windows-registry",
  "windows-result 0.4.1",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "netscli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-gui"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ipnet",
  "netscli-core",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-mcp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "ipnet",

--- a/apps/netscli-cli/Cargo.toml
+++ b/apps/netscli-cli/Cargo.toml
@@ -3,7 +3,7 @@
 # consistency, but the published crate is just `netscli` so users can
 # `cargo install netscli` (matching the produced binary name).
 name = "netscli"
-version = "0.2.1"
+version = "0.2.2"
 description = "Interactive TUI and CLI for network discovery, scanning, and diagnostics"
 authors.workspace = true
 license.workspace = true
@@ -25,8 +25,8 @@ clap_mangen = "0.2"
 ratatui = "0.29.0"
 crossterm = "0.27"
 tui-textarea = "0.4"
-netscli-core = { path = "../../crates/netscli-core", version = "0.2.1", default-features = false, features = ["db", "mdns"] }
-netscli-mcp = { path = "../../crates/netscli-mcp", version = "0.2.1", features = ["mdns"] }
+netscli-core = { path = "../../crates/netscli-core", version = "0.2.2", default-features = false, features = ["db", "mdns"] }
+netscli-mcp = { path = "../../crates/netscli-mcp", version = "0.2.2", features = ["mdns"] }
 serde_yaml_ng = "0.10"
 dirs = "5.0"
 mac_address = "1.1.8"

--- a/apps/netscli-gui/package.json
+++ b/apps/netscli-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netscli-gui",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "NetsCLI GUI - Modern network scanner with beautiful desktop interface",
   "private": true,
   "type": "module",

--- a/apps/netscli-gui/src-tauri/Cargo.toml
+++ b/apps/netscli-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-gui"
-version = "0.2.1"
+version = "0.2.2"
 description = "Tauri 2.0 desktop GUI for network discovery, scanning, and diagnostics"
 authors.workspace = true
 license.workspace = true

--- a/apps/netscli-gui/src-tauri/tauri.conf.json
+++ b/apps/netscli-gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "NetsCLI",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.netscli.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/crates/netscli-core/Cargo.toml
+++ b/crates/netscli-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-core"
-version = "0.2.1"
+version = "0.2.2"
 description = "Core networking library: discovery, scanning, DNS, ARP, PCAP, and OUI resolution"
 authors.workspace = true
 license.workspace = true

--- a/crates/netscli-mcp/Cargo.toml
+++ b/crates/netscli-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-mcp"
-version = "0.2.1"
+version = "0.2.2"
 description = "Model Context Protocol (MCP) server exposing netscli-core tools to LLM agents"
 authors.workspace = true
 license.workspace = true
@@ -17,7 +17,7 @@ thiserror.workspace = true
 ipnet.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-netscli-core = { path = "../netscli-core", version = "0.2.1", default-features = false }
+netscli-core = { path = "../netscli-core", version = "0.2.2", default-features = false }
 
 [features]
 default = ["mdns"]

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -447,5 +447,5 @@ export const site: SiteData = {
     cloudflareToken: 'c03201f65f6d41aa843c81f259a1ac06',
   },
 
-  version: '0.2.1',
+  version: '0.2.2',
 };


### PR DESCRIPTION
## Summary

[v0.2.1's release workflow failed all 17 builds](https://github.com/fstubner/netscli/actions/runs/25286987601) with:

\`\`\`
error: the lock file Cargo.lock needs to be updated but --locked was passed to prevent this
\`\`\`

Root cause: Dependabot's [#17](https://github.com/fstubner/netscli/pull/17) (tokio 1.48 → 1.52.1) updated only the direct-dep entries in Cargo.lock. tokio 1.52.1 transitively requires \`socket2 >= 0.6.3\` but our committed lockfile still had \`0.6.1\`. CI lint paths use plain \`cargo build\` (no \`--locked\`) so the drift slipped through; release.yml's strict \`--locked\` flag caught it during the publish.

## What's fixed

- **Cargo.lock regenerated** — \`socket2 0.6.3\` recorded alongside the existing \`0.5.10\`. No application source changes.
- **Workspace bumped 0.2.1 → 0.2.2** across all 7 version-bearing files (Cargo.toml × 4, package.json, tauri.conf.json, site.ts).
- **CHANGELOG** gets a 0.2.2 \`Fixed\` entry plus an explanatory note on v0.2.1's status.

## Status of v0.2.1

- crates.io ✅ has 0.2.1 (publish.yml's \`crates-io\` job succeeded). \`cargo install netscli\` works because cargo regenerates the lockfile per-user.
- GitHub release v0.2.1 ❌ has 0 assets (release.yml never produced any).
- Package managers (Homebrew/Scoop/Winget/AUR) ❌ never updated to 0.2.1.

After this lands, cutting v0.2.2 attaches all assets and fans out to all 5 channels properly. v0.2.1 stays in place as crates.io history rather than yanked.

## Test plan

- [x] \`cargo build --release -p netscli\` clean (Windows)
- [x] \`cargo build --locked --release -p netscli\` clean (Windows) — was the failing command in v0.2.1's CI
- [ ] CI passes on ubuntu/macos/windows