### PR TITLE
release: v0.2.4 fix GUI bundle path + AUR action version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,7 +163,10 @@ jobs:
           cat packaging/aur/PKGBUILD
 
       - name: Push to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v2.7.0
+        # v2.7.0 had a `bash: --command: invalid option` regression in
+        # its container entrypoint; v4.1.3 has the same input shape and
+        # is the current stable.
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: netscli-bin
           pkgbuild: packaging/aur/PKGBUILD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,10 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
-          BUNDLE_ROOT="apps/netscli-gui/src-tauri/target/${TARGET}/release/bundle"
+          # Cargo workspaces use the workspace-root `target/` regardless
+          # of the cwd cargo was invoked from. Tauri puts its bundles in
+          # target/<TARGET>/release/bundle/{deb,appimage,dmg,msi}/.
+          BUNDLE_ROOT="target/${TARGET}/release/bundle"
           OUT_DIR="${RUNNER_TEMP}/gui-out"
           mkdir -p "${OUT_DIR}"
           # Walk each glob, copy with the canonical asset name preserving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ version and release together.
 
 ## [Unreleased]
 
+## [0.2.4] — 2026-05-03
+
+### Fixed
+- **GUI bundle path** in release.yml's GUI matrix was rooted at
+  `apps/netscli-gui/src-tauri/target/${TARGET}/release/bundle/`. Cargo
+  workspaces actually use the **workspace-root** `target/` directory
+  regardless of which subcrate's directory cargo was invoked from, so
+  Tauri's bundle output lives at `target/${TARGET}/release/bundle/`.
+  v0.2.3 built the `.deb` / `.dmg` / `.msi` correctly but the collect
+  step found an empty bundle dir and skipped everything; sigstore-sign
+  then failed trying to sign nothing.
+- **AUR deploy action** (`KSXGitHub/github-actions-deploy-aur`) was
+  pinned to `@v2.7.0` (April 2024), which has a `bash: --command:
+  invalid option` regression in its container entrypoint. Bumped to
+  `@v4.1.3` (current stable, same input shape).
+
+### Notes on v0.2.3
+- CLI release shipped: 44 assets, sigstore-signed, on the v0.2.3
+  release page.
+- Homebrew, Scoop, Winget, and crates.io all updated to 0.2.3.
+- AUR is still on the previous version (failed to push).
+- 0 GUI installers attached to v0.2.3 release.
+
 ## [0.2.3] — 2026-05-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "netscli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-gui"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "ipnet",
  "netscli-core",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-mcp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "ipnet",

--- a/apps/netscli-cli/Cargo.toml
+++ b/apps/netscli-cli/Cargo.toml
@@ -3,7 +3,7 @@
 # consistency, but the published crate is just `netscli` so users can
 # `cargo install netscli` (matching the produced binary name).
 name = "netscli"
-version = "0.2.3"
+version = "0.2.4"
 description = "Interactive TUI and CLI for network discovery, scanning, and diagnostics"
 authors.workspace = true
 license.workspace = true
@@ -25,8 +25,8 @@ clap_mangen = "0.2"
 ratatui = "0.29.0"
 crossterm = "0.27"
 tui-textarea = "0.4"
-netscli-core = { path = "../../crates/netscli-core", version = "0.2.3", default-features = false, features = ["db", "mdns"] }
-netscli-mcp = { path = "../../crates/netscli-mcp", version = "0.2.3", features = ["mdns"] }
+netscli-core = { path = "../../crates/netscli-core", version = "0.2.4", default-features = false, features = ["db", "mdns"] }
+netscli-mcp = { path = "../../crates/netscli-mcp", version = "0.2.4", features = ["mdns"] }
 serde_yaml_ng = "0.10"
 dirs = "5.0"
 mac_address = "1.1.8"

--- a/apps/netscli-gui/package.json
+++ b/apps/netscli-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netscli-gui",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "NetsCLI GUI - Modern network scanner with beautiful desktop interface",
   "private": true,
   "type": "module",

--- a/apps/netscli-gui/src-tauri/Cargo.toml
+++ b/apps/netscli-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-gui"
-version = "0.2.3"
+version = "0.2.4"
 description = "Tauri 2.0 desktop GUI for network discovery, scanning, and diagnostics"
 authors.workspace = true
 license.workspace = true

--- a/apps/netscli-gui/src-tauri/tauri.conf.json
+++ b/apps/netscli-gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "NetsCLI",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "identifier": "com.netscli.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/crates/netscli-core/Cargo.toml
+++ b/crates/netscli-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-core"
-version = "0.2.3"
+version = "0.2.4"
 description = "Core networking library: discovery, scanning, DNS, ARP, PCAP, and OUI resolution"
 authors.workspace = true
 license.workspace = true

--- a/crates/netscli-mcp/Cargo.toml
+++ b/crates/netscli-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-mcp"
-version = "0.2.3"
+version = "0.2.4"
 description = "Model Context Protocol (MCP) server exposing netscli-core tools to LLM agents"
 authors.workspace = true
 license.workspace = true
@@ -17,7 +17,7 @@ thiserror.workspace = true
 ipnet.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-netscli-core = { path = "../netscli-core", version = "0.2.3", default-features = false }
+netscli-core = { path = "../netscli-core", version = "0.2.4", default-features = false }
 
 [features]
 default = ["mdns"]

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -447,5 +447,5 @@ export const site: SiteData = {
     cloudflareToken: 'c03201f65f6d41aa843c81f259a1ac06',
   },
 
-  version: '0.2.3',
+  version: '0.2.4',
 };


### PR DESCRIPTION
## Summary

v0.2.3 made progress (Tauri version skew fixed, GUI builds compiled) but two infrastructure bugs prevented the GUI installers and AUR push from completing:

### GUI bundle path

- v0.2.3's GUI matrix **successfully compiled** \`.deb\` / \`.dmg\` / \`.msi\` bundles
- The collect step looked in \`apps/netscli-gui/src-tauri/target/<TARGET>/release/bundle/\`
- That directory was empty because Cargo workspaces always write to the **workspace-root** \`target/\` directory regardless of cwd
- sigstore-sign then failed: "no such file or directory"
- **Fix**: \`BUNDLE_ROOT="target/<TARGET>/release/bundle"\` (workspace-relative)

### AUR action regression

- Pinned to \`KSXGitHub/github-actions-deploy-aur@v2.7.0\` (April 2024)
- v2.7.0 has a \`bash: --command: invalid option\` regression in its container entrypoint
- **Fix**: bump to \`@v4.1.3\` (current stable, identical input shape)

## What stays from v0.2.3

CLI binaries are on the v0.2.3 release page; Homebrew/Scoop/Winget/crates.io all updated to 0.2.3. After this lands and v0.2.4 is cut, those bump to 0.2.4 and AUR catches up to 0.2.4 directly.

## Test plan

- [x] Local Tauri build still succeeds (verified during v0.2.3 prep)
- [x] \`cargo build --locked --release -p netscli\` clean
- [ ] CI passes
- [ ] After merge: cut v0.2.4; release.yml's GUI matrix attaches assets; publish.yml's AUR job pushes successfully