### PR TITLE
audit: ignore RUSTSEC-2026-0119 (hickory-proto, not reachable in our usage)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -13,6 +13,15 @@ ignore = [
   # which is never compiled (we enable sqlx's `sqlite` feature only).
   "RUSTSEC-2023-0071",
 
+  # hickory-proto O(n²) name compression on message ENCODING. Triggered
+  # when crafting outbound DNS messages with many compressed names; we
+  # only use hickory as a stub resolver (small outbound queries, focus is
+  # decoding responses) so the encoding hot path isn't reachable in our
+  # call graph. Fix is hickory-proto 0.26.1, which requires a hickory-
+  # resolver 0.24 -> 0.26 major bump (TokioAsyncResolver -> generic
+  # Resolver<Provider>) — tracked as a separate dedicated PR.
+  "RUSTSEC-2026-0119",
+
   # -- Soundness warnings (transitive, not reachable via our usage) -----
 
   # rand 0.7.3 unsoundness with a custom logger calling rand::rng().


### PR DESCRIPTION
## Summary

cargo-audit now reports a real advisory (the parser bug from earlier weeks is gone — that was masking this):

\`\`\`
ID:       RUSTSEC-2026-0119
URL:      https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-q2qq-hmj6-3wpp
Severity: medium
Summary:  CPU exhaustion during message encoding due to O(n²) name compression
Solution: Upgrade to >=0.26.1
\`\`\`

## Why ignore vs. upgrade

The advisory hot path is **outbound message encoding** — specifically when crafting DNS messages that contain many compressed names. Our use of hickory in \`crates/netscli-core/src/dns.rs\` is purely stub-resolver: one query per hostname (no compressed name pile), focus is decoding inbound responses. The quadratic encoding blowup isn't reachable from any of our call sites.

Tried the upgrade: \`hickory-resolver 0.24 -> 0.26\` is a major API refactor. The old \`TokioAsyncResolver\` type is gone, replaced by a generic \`Resolver<TokioConnectionProvider>\`. \`dns.rs\` has 12 type-inference call sites that need rewriting against the new builder API. That's a focused dedicated PR — not appropriate to mix into "fix the audit red dot."

## What changes

One entry in \`.cargo/audit.toml\` with the rationale inline so future reviewers see why it's ignored rather than rubber-stamped, and so when the hickory upgrade lands the entry can be removed alongside it.

## Test plan

- [x] cargo-audit locally now ignores the advisory (the suppress is in audit.toml format)
- [ ] CI's audit job goes green