### PR TITLE
packaging: GUI installer manifest templates (Cask, Winget GUI, Scoop, AUR)

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -48,17 +48,39 @@ Before the first automated release runs, add these secrets at
 - **Winget moderator approval.** The action opens a PR to
   `microsoft/winget-pkgs`; a community moderator merges it within a few
   hours to days. CLA must be signed once per account (you've done this).
-- **GUI-channel manifests** (Homebrew Cask, separate Winget GUI entry,
-  Scoop extras, AUR `netscli-gui-bin`). These are CLI-only today; adding
-  GUI-channel manifests is a separate setup PR that lands once the first
-  GUI installer release is verified to work end-to-end (planned post-v0.2.1).
+- **GUI-channel manifests** are kept under
+  [`packaging/`](../packaging/) as templates (Homebrew Cask, separate
+  Winget GUI manifest, Scoop extras, AUR `netscli-gui-bin`). The
+  one-time setup is below; subsequent releases auto-update the
+  destinations via `publish.yml`'s gui-channel jobs once they're
+  enabled.
+
+## One-time GUI-channel setup
+
+After v0.2.4 (the first release with prebuilt GUI installers), the
+templates in `packaging/` need to be pushed/submitted to their
+respective destinations once. After that, future releases re-stamp
+the SHAs automatically.
+
+| Destination | Source template | First-time action |
+|-------------|-----------------|-------------------|
+| `fstubner/homebrew-tap` Cask | `packaging/homebrew/Casks/netscli.rb` | Copy into `Casks/netscli.rb` of the tap repo, commit, push |
+| `microsoft/winget-pkgs` GUI manifest | `packaging/winget/gui/0.2.4/` | `wingetcreate submit` or PR the 3 yaml files into `manifests/f/fstubner/netscli.gui/0.2.4/` |
+| `fstubner/scoop-bucket` GUI extras | `packaging/scoop/netscli-gui.json` | Copy into `bucket/netscli-gui.json` of the bucket repo, commit, push |
+| AUR `netscli-gui-bin` | `packaging/aur/netscli-gui-bin/PKGBUILD` | `git clone ssh://aur@aur.archlinux.org/netscli-gui-bin.git`, copy PKGBUILD in, regenerate `.SRCINFO`, push |
+
+After all four are live, advertise the install commands in
+[README.md](../README.md) and [site/src/data/site.ts](../site/src/data/site.ts):
+- Windows: `winget install netscli-gui`
+- macOS: `brew install --cask netscli`
+- Linux (Arch): `yay -S netscli-gui-bin`
 
 ## Action pin policy
 
-The two third-party actions used by this workflow are referenced by
+The two third-party actions used by `publish.yml` are referenced by
 version tag, not commit SHA:
 - `vedantmgoyal2009/winget-releaser@v2`
-- `KSXGitHub/github-actions-deploy-aur@v2.7.0`
+- `KSXGitHub/github-actions-deploy-aur@v4.1.3`
 
 These are stable, widely-used actions; pinning to SHA is on the radar
 but not blocking. If you want stricter supply-chain hygiene, swap each

--- a/packaging/aur/netscli-gui-bin/PKGBUILD
+++ b/packaging/aur/netscli-gui-bin/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Felix Stubner <felix.stubner@gmail.com>
+#
+# Sibling package to netscli-bin (the CLI/TUI). Ships the Tauri desktop
+# app as a self-contained .AppImage rather than the .deb, since pacman
+# users typically prefer not to depend on dpkg/Debian conventions for
+# system integration.
+
+pkgname=netscli-gui-bin
+_appname=netscli-gui
+pkgver=0.2.4
+pkgrel=1
+pkgdesc="Network scanner desktop app (Tauri 2 + React) — discover hosts, scan ports, DNS, ARP"
+arch=('x86_64')
+url="https://netscli.com"
+license=('MIT')
+provides=("${_appname}")
+conflicts=("${_appname}")
+# Tauri 2 GTK3 backend — same depends as the upstream Tauri AppImage
+# expects on the host (webkit2gtk-4.1, gtk3, ayatana-appindicator).
+# AppImage is largely self-contained but these are the runtime libs
+# Tauri's window manager needs that aren't always pre-installed.
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator')
+source_x86_64=("${pkgname}-${pkgver}.AppImage::https://github.com/fstubner/netscli/releases/download/v${pkgver}/netscli-gui-linux-x86_64.AppImage")
+sha256sums_x86_64=('f14efe4e93c29d71ff8978f5dd02c619bbee7e7bd75fa75b67be4acedd05ceea')
+
+package() {
+  install -Dm755 "${srcdir}/${pkgname}-${pkgver}.AppImage" \
+    "${pkgdir}/usr/bin/${_appname}"
+}

--- a/packaging/homebrew/Casks/netscli.rb
+++ b/packaging/homebrew/Casks/netscli.rb
@@ -1,0 +1,35 @@
+# Homebrew Cask for the netscli desktop app (Tauri 2 + React).
+#
+# Lives alongside Formula/netscli.rb (the CLI) in fstubner/homebrew-tap.
+# Two architectures because Tauri builds are not universal — Apple
+# Silicon and Intel get distinct .dmg artifacts on every release.
+#
+# After cutting release vX.Y.Z, update `version` and replace each
+# sha256 with the value from the matching `.sha256` asset on the
+# release page (or let publish.yml's homebrew-cask job do it
+# automatically).
+
+cask "netscli" do
+  version "0.2.4"
+
+  on_arm do
+    sha256 "a240ec0ce5a0bbe00226fc078a22a0acede4d320b05fce1d2a80690a136b6bd3"
+    url "https://github.com/fstubner/netscli/releases/download/v#{version}/netscli-gui-macos-aarch64.dmg"
+  end
+  on_intel do
+    sha256 "4dc2c7e76348165624fa4d26f8e78e7892b4f0b8d2762fd9884df524d19a8bdb"
+    url "https://github.com/fstubner/netscli/releases/download/v#{version}/netscli-gui-macos-x86_64.dmg"
+  end
+
+  name "NetsCLI"
+  desc "Network scanner desktop app: discover hosts, scan ports, DNS, ARP"
+  homepage "https://netscli.com"
+
+  app "NetsCLI.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.netscli.app",
+    "~/Library/Caches/com.netscli.app",
+    "~/Library/Preferences/com.netscli.app.plist",
+  ]
+end

--- a/packaging/scoop/netscli-gui.json
+++ b/packaging/scoop/netscli-gui.json
@@ -1,0 +1,34 @@
+{
+  "version": "0.2.4",
+  "description": "Network scanner desktop app (Tauri 2 + React) — discover hosts, scan ports, DNS, ARP. Lives in scoop extras since it's GUI; the CLI ships as `netscli` in this same bucket.",
+  "homepage": "https://netscli.com",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/fstubner/netscli/releases/download/v0.2.4/netscli-gui-windows-x86_64.msi",
+      "hash": "bdef02b05d636627057db8b395f9d38d76d9f884c634310d17f078d1ec86788d"
+    }
+  },
+  "installer": {
+    "type": "msi"
+  },
+  "shortcuts": [
+    [
+      "NetsCLI.exe",
+      "NetsCLI"
+    ]
+  ],
+  "checkver": {
+    "github": "https://github.com/fstubner/netscli"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/fstubner/netscli/releases/download/v$version/netscli-gui-windows-x86_64.msi"
+      }
+    },
+    "hash": {
+      "url": "$url.sha256"
+    }
+  }
+}

--- a/packaging/winget/gui/0.2.4/fstubner.netscli.gui.installer.yaml
+++ b/packaging/winget/gui/0.2.4/fstubner.netscli.gui.installer.yaml
@@ -1,0 +1,19 @@
+# Winget installer manifest for the netscli desktop app.
+#
+# Distinct PackageIdentifier (`fstubner.netscli.gui`) from the CLI
+# (`fstubner.netscli`) so users can install one without the other:
+#   winget install netscli       -> CLI
+#   winget install netscli-gui   -> GUI
+# Moniker resolves to the chosen identifier as long as it's unique in
+# the catalog.
+
+PackageIdentifier: fstubner.netscli.gui
+PackageVersion: 0.2.4
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/fstubner/netscli/releases/download/v0.2.4/netscli-gui-windows-x86_64.msi
+    InstallerSha256: BDEF02B05D636627057DB8B395F9D38D76D9F884C634310D17F078D1EC86788D
+    Scope: user
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/packaging/winget/gui/0.2.4/fstubner.netscli.gui.locale.en-US.yaml
+++ b/packaging/winget/gui/0.2.4/fstubner.netscli.gui.locale.en-US.yaml
@@ -1,0 +1,31 @@
+PackageIdentifier: fstubner.netscli.gui
+PackageVersion: 0.2.4
+PackageLocale: en-US
+Publisher: Felix Stubner
+PublisherUrl: https://github.com/fstubner
+PublisherSupportUrl: https://github.com/fstubner/netscli/issues
+Author: Felix Stubner
+PackageName: NetsCLI Desktop
+PackageUrl: https://netscli.com
+License: MIT
+LicenseUrl: https://github.com/fstubner/netscli/blob/main/LICENSE
+Copyright: Copyright (c) Felix Stubner
+ShortDescription: Network scanner desktop app — discover hosts, scan ports, look up DNS records, inspect ARP table.
+Description: |
+  NetsCLI Desktop is the GUI surface of netscli — a network scanner
+  with CLI, terminal UI, desktop app, and MCP server interfaces all
+  backed by the same Rust core. The desktop app provides a Tauri 2 +
+  React window for visual host discovery, port scanning, DNS lookups,
+  and ARP table inspection without opening a terminal.
+Moniker: netscli-gui
+Tags:
+  - network
+  - scanner
+  - port-scanner
+  - dns
+  - arp
+  - tauri
+  - rust
+  - desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/packaging/winget/gui/0.2.4/fstubner.netscli.gui.yaml
+++ b/packaging/winget/gui/0.2.4/fstubner.netscli.gui.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: fstubner.netscli.gui
+PackageVersion: 0.2.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

v0.2.4 shipped prebuilt GUI installers for the first time — \`.msi\` (Windows), 2×\`.dmg\` (macOS), \`.deb\` and \`.AppImage\` (Linux). Until now those were only available via direct download from the GitHub release page; package managers all shipped the CLI/TUI only.

This PR adds the templates needed to publish the GUI through the same package managers. **Templates only** — actual setup (one-time pushes to each destination) is a follow-up that I can do once this lands; subsequent releases will re-stamp these via \`publish.yml\` (separate PR for that automation).

## What's added

| File | Destination | What users will type |
|------|-------------|---------------------|
| \`packaging/homebrew/Casks/netscli.rb\` | \`fstubner/homebrew-tap\` | \`brew install --cask netscli\` |
| \`packaging/winget/gui/0.2.4/*.yaml\` | \`microsoft/winget-pkgs\` | \`winget install netscli-gui\` |
| \`packaging/scoop/netscli-gui.json\` | \`fstubner/scoop-bucket\` | \`scoop install netscli-gui\` |
| \`packaging/aur/netscli-gui-bin/PKGBUILD\` | AUR | \`yay -S netscli-gui-bin\` |

All five SHA256s are stamped from the live v0.2.4 release assets so the templates are immediately submittable.

## Design notes

- **Distinct PackageIdentifiers** for Winget: \`fstubner.netscli\` (CLI) vs \`fstubner.netscli.gui\` (GUI). Users can install one without the other. Monikers \`netscli\` and \`netscli-gui\` resolve to the right one.
- **Homebrew**: Cask, not Formula. Casks are the right shape for native macOS apps with .dmg/.app shipping; Formulas are for build-from-source or single-binary CLI tools.
- **AUR uses .AppImage** rather than the .deb. pacman users typically prefer self-contained bundles to dpkg-dependent ones.
- **Versioning**: workspace stays in lockstep, GUI installer versions track the release tag exactly. \`0.2.4\` here matches the v0.2.4 release.

## What still needs to happen (after merge)

Documented in [\`docs/RELEASE.md\`](docs/RELEASE.md) — one-time setup table:

1. Copy Cask file into the homebrew-tap repo, push
2. Submit Winget GUI manifests via \`wingetcreate submit\` or PR to microsoft/winget-pkgs
3. Copy Scoop GUI json into the scoop-bucket repo, push
4. Push the AUR PKGBUILD to \`aur@aur.archlinux.org:netscli-gui-bin.git\` with regenerated \`.SRCINFO\`

I'm happy to do all four after merge if you want.

## Test plan

- [x] All SHA256s match v0.2.4 release \`.sha256\` files (verified with curl)
- [x] Winget YAML validates against schema 1.9.0 (matches the existing CLI manifest's structure)
- [ ] CI passes