### PR TITLE
packaging: add schema header to GUI Winget manifest templates

### DIFF
--- a/packaging/winget/gui/0.2.4/fstubner.netscli.gui.installer.yaml
+++ b/packaging/winget/gui/0.2.4/fstubner.netscli.gui.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
 # Winget installer manifest for the netscli desktop app.
 #
 # Distinct PackageIdentifier (`fstubner.netscli.gui`) from the CLI

--- a/packaging/winget/gui/0.2.4/fstubner.netscli.gui.locale.en-US.yaml
+++ b/packaging/winget/gui/0.2.4/fstubner.netscli.gui.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
 PackageIdentifier: fstubner.netscli.gui
 PackageVersion: 0.2.4
 PackageLocale: en-US

--- a/packaging/winget/gui/0.2.4/fstubner.netscli.gui.yaml
+++ b/packaging/winget/gui/0.2.4/fstubner.netscli.gui.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
 PackageIdentifier: fstubner.netscli.gui
 PackageVersion: 0.2.4
 DefaultLocale: en-US


### PR DESCRIPTION
Drive-by fix to the Winget GUI templates added in #53. The validation pipeline rejects manifests without the `# yaml-language-server: $schema=...` header (we got bitten on #368471 after fixing the path issue). Each manifest type uses a different schema URL.

Future automated submissions via publish.yml's winget-gui job won't hit this — winget-releaser uses komac which adds the header automatically. This just keeps local templates self-consistent for anyone hand-submitting.

3 files, +6 lines, no behavior change.