### PR TITLE
release: v0.2.5 windows scan fix + GUI styling fix + 13 dep bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,61 @@ version and release together.
 
 ## [Unreleased]
 
+## [0.2.5] — 2026-05-05
+
+### Security
+
+- **hickory-resolver 0.24 → 0.26** closes
+  [RUSTSEC-2026-0119](https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-q2qq-hmj6-3wpp):
+  CPU exhaustion during message encoding due to O(n²) name compression
+  in `hickory-proto`. The DNS lookup tab and any inspect/discover that
+  resolves hostnames are no longer reachable through the vulnerable
+  encoding path. The 0.26 builder pattern (`TokioResolver::builder_tokio()`)
+  replaces the deprecated `TokioAsyncResolver::tokio` constructor; see
+  PR #55 for the source migration. The `.cargo/audit.toml` ignore added
+  in #52 was removed once the bump landed.
+
+### Fixed
+
+- **GUI: discover/sweep returned only a single host on Windows.**
+  Root cause: `detect_default_ipv4_subnet` iterated
+  `ipconfig::Adapter::prefixes()` and grabbed the first IPv4 entry, but
+  that list contains the host's own /32, broadcast /32, multicast /4,
+  link-local /16, and the network /24. Windows reports the host /32
+  first, so the "subnet" was a single IP. New helper
+  `pick_ipv4_subnet_from_prefixes` filters to network-shaped prefixes
+  (length 1..=30, not multicast, not link-local) and truncates host
+  bits, matching the Linux path. 5 unit tests added that run on every
+  CI platform via `cfg(any(windows, test))`. (#59)
+- **GUI: dashboard "Recent Scans" rendered with wrong colors / not as
+  list rows.** `.history-item` is a `<button>` (for keyboard
+  accessibility) but the CSS didn't reset user-agent button styles.
+  WebView2 on Windows applied Win32 chrome (`color: ButtonText`,
+  centered text, content-fit width, system button font), breaking the
+  inherit chain for child labels. Explicit reset added. (#59)
+
+### Changed
+
+- **Dependencies (all transitive, no API surface impact):**
+  - `crossterm 0.27 → 0.28` + `tui-textarea 0.4 → 0.7` had to land
+    together — tui-textarea 0.7 hardcodes `crossterm = "0.28"`. (#58)
+  - `mdns-sd 0.13 → 0.19` — adapt to the new `ScopedIp::to_ip_addr()`
+    accessor in `netscli-core/src/mdns.rs`. (#58)
+  - `clap 4.5.60 → 4.6.1` (#43), `pcap 1.3 → 2.4` (#45),
+    `clap_mangen 0.2.33 → 0.3.0` (#46),
+    `dialoguer 0.11.0 → 0.12.0` (#48), `dirs 5.0.1 → 6.0.0` (#51),
+    `tokio 1.52.1 → 1.52.2` + `clap_complete 4.6.2 → 4.6.3` (#57).
+- **`ratatui 0.29 → 0.30` deferred:** tui-textarea has no version yet
+  that supports ratatui 0.30 (latest 0.7 still pins ratatui 0.29).
+  Tracked via `@dependabot ignore` on the closed PR #49.
+
+### Added
+
+- **Release pipeline GUI automation.** `publish.yml` extended with 4
+  parallel jobs that publish the GUI bundles to Homebrew Cask, Scoop
+  extras (`netscli-gui.json`), Winget (`fstubner.netscli.gui`), and
+  AUR (`netscli-gui-bin`) on every tagged release. (#54, #53, #56)
+
 ## [0.2.4] — 2026-05-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "netscli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-gui"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "ipnet",
  "netscli-core",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-mcp"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "ipnet",

--- a/apps/netscli-cli/Cargo.toml
+++ b/apps/netscli-cli/Cargo.toml
@@ -3,7 +3,7 @@
 # consistency, but the published crate is just `netscli` so users can
 # `cargo install netscli` (matching the produced binary name).
 name = "netscli"
-version = "0.2.4"
+version = "0.2.5"
 description = "Interactive TUI and CLI for network discovery, scanning, and diagnostics"
 authors.workspace = true
 license.workspace = true
@@ -25,8 +25,8 @@ clap_mangen = "0.3"
 ratatui = "0.29.0"
 crossterm = "0.28"
 tui-textarea = "0.7"
-netscli-core = { path = "../../crates/netscli-core", version = "0.2.4", default-features = false, features = ["db", "mdns"] }
-netscli-mcp = { path = "../../crates/netscli-mcp", version = "0.2.4", features = ["mdns"] }
+netscli-core = { path = "../../crates/netscli-core", version = "0.2.5", default-features = false, features = ["db", "mdns"] }
+netscli-mcp = { path = "../../crates/netscli-mcp", version = "0.2.5", features = ["mdns"] }
 serde_yaml_ng = "0.10"
 dirs = "6.0"
 mac_address = "1.1.8"

--- a/apps/netscli-gui/package.json
+++ b/apps/netscli-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netscli-gui",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "NetsCLI GUI - Modern network scanner with beautiful desktop interface",
   "private": true,
   "type": "module",

--- a/apps/netscli-gui/src-tauri/Cargo.toml
+++ b/apps/netscli-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-gui"
-version = "0.2.4"
+version = "0.2.5"
 description = "Tauri 2.0 desktop GUI for network discovery, scanning, and diagnostics"
 authors.workspace = true
 license.workspace = true

--- a/apps/netscli-gui/src-tauri/tauri.conf.json
+++ b/apps/netscli-gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "NetsCLI",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "com.netscli.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/crates/netscli-core/Cargo.toml
+++ b/crates/netscli-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-core"
-version = "0.2.4"
+version = "0.2.5"
 description = "Core networking library: discovery, scanning, DNS, ARP, PCAP, and OUI resolution"
 authors.workspace = true
 license.workspace = true

--- a/crates/netscli-mcp/Cargo.toml
+++ b/crates/netscli-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-mcp"
-version = "0.2.4"
+version = "0.2.5"
 description = "Model Context Protocol (MCP) server exposing netscli-core tools to LLM agents"
 authors.workspace = true
 license.workspace = true
@@ -17,7 +17,7 @@ thiserror.workspace = true
 ipnet.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-netscli-core = { path = "../netscli-core", version = "0.2.4", default-features = false }
+netscli-core = { path = "../netscli-core", version = "0.2.5", default-features = false }
 
 [features]
 default = ["mdns"]

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -447,5 +447,5 @@ export const site: SiteData = {
     cloudflareToken: 'c03201f65f6d41aa843c81f259a1ac06',
   },
 
-  version: '0.2.4',
+  version: '0.2.5',
 };


### PR DESCRIPTION
## Summary

Cuts v0.2.5. Bundles 13 PRs merged since v0.2.4: 1 security fix, 2 user-visible Windows GUI fixes, 11 transitive dep bumps, plus the GUI release-pipeline automation work.

## Highlights

### Security
- **`hickory-resolver 0.24 → 0.26`** closes [RUSTSEC-2026-0119](https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-q2qq-hmj6-3wpp) — CPU exhaustion via O(n²) name compression in `hickory-proto`. The DNS lookup tab and any inspect/discover that resolves hostnames are no longer reachable through the vulnerable encoding path. Source migration to the new `TokioResolver::builder_tokio()` pattern landed in #55. (#52, #55)

### Fixed (user-visible Windows desktop bugs)
- **Discover/sweep returned only a single host on Windows.** `detect_default_ipv4_subnet` was iterating `ipconfig::Adapter::prefixes()` and grabbing the first IPv4 entry — but Windows reports the host `/32` first, making the "subnet" a single IP. New helper `pick_ipv4_subnet_from_prefixes` filters to network-shaped prefixes and truncates host bits, matching the Linux path. 5 unit tests cover the host-/32-first bug, multicast/link-local skip, host-bit truncation, no-usable-prefix fallthrough, and `/31`/`/0` skip — gated `cfg(any(windows, test))` so they run on every CI platform. (#59)
- **Dashboard "Recent Scans" rendered as Win32-chrome buttons instead of list rows.** `.history-item` is a `<button>` (for keyboard a11y) but the CSS didn't reset UA button styles. WebView2 on Windows applied `color: ButtonText`, centered text, content-fit width, and system button font, breaking the inherit chain. Explicit reset added. (#59)

### Changed
- **Coupled triple bump (#58):** `crossterm 0.27 → 0.28` + `tui-textarea 0.4 → 0.7` + `mdns-sd 0.13 → 0.19`. tui-textarea 0.7 hardcodes `crossterm = "0.28"` so they had to land together; mdns-sd 0.19 needed `ScopedIp::to_ip_addr()` adaptation in `netscli-core/src/mdns.rs`.
- **Routine bumps:** clap 4.5.60→4.6.1 (#43), pcap 1.3→2.4 (#45), clap_mangen 0.2.33→0.3.0 (#46), dialoguer 0.11.0→0.12.0 (#48), dirs 5.0.1→6.0.0 (#51), tokio 1.52.1→1.52.2 + clap_complete 4.6.2→4.6.3 (#57).
- **`ratatui 0.30` deferred:** tui-textarea has no version yet that supports it; tracked via `@dependabot ignore` on PR #49.

### Added
- **Release pipeline GUI automation.** `publish.yml` extended with 4 parallel jobs that publish the GUI bundles to Homebrew Cask, Scoop extras (`netscli-gui.json`), Winget (`fstubner.netscli.gui`), and AUR (`netscli-gui-bin`) on every tagged release. Manifest templates added in #53. Schema-header drive-by fix on Winget templates in #56. (#54)

## Verified locally

- `cargo clippy --all-targets --features mdns -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- `cargo test --workspace --features mdns` — 80 tests pass (5 new for the helper)
- `npm run build` (Vite + tsc in `apps/netscli-gui`) clean

## Files touched

- 5 Cargo.toml version bumps (workspace + 3 published crates + GUI app)
- 2 GUI version bumps (`tauri.conf.json`, `package.json`)
- 1 site version (`site/src/data/site.ts`)
- `Cargo.lock` regenerated cleanly
- `CHANGELOG.md` new `[0.2.5]` section

## Test plan

- [x] All 4 internal crates show `0.2.5` in Cargo.lock
- [x] Internal `version = ` pins (netscli → netscli-core, etc.) bumped together
- [ ] CI: ubuntu/macOS/windows test matrix
- [ ] After merge: `git tag v0.2.5 && git push --tags` → release.yml fires → publish.yml fans out to all 8 channels (crates.io, brew CLI, brew Cask, scoop CLI, scoop GUI, winget CLI, winget GUI, AUR CLI, AUR GUI)