### PR TITLE
ci: cut PR runner-minute spend by ~70%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,27 @@ name: CI
 on:
   push:
     branches: [main]
+    # Pure-docs / site / packaging-template changes don't affect Rust
+    # behavior, and skipping them here avoids a full 3-OS test matrix on
+    # a typo fix in a README. The site has its own pages.yml workflow
+    # that handles its own changes; packaging templates are validated
+    # at release time by publish.yml when they're actually used.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'site/**'
+      - 'packaging/**'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'site/**'
+      - 'packaging/**'
+      - 'LICENSE'
+      - '.gitignore'
   # Let me run CI manually from the Actions tab, useful for re-running a
   # cache-warm build after tweaking the workflow without having to push.
   workflow_dispatch:
@@ -114,6 +133,16 @@ jobs:
   # up under optimizations / lto that debug builds miss, and the artifact
   # upload makes it possible to grab a "tip of main" binary straight from
   # the Actions run for quick smoke testing without cutting a release.
+  #
+  # Matrix is conditional on event:
+  #   - pull_request → ubuntu-latest only. The `test` job already runs on
+  #     all 3 OS, so cross-platform compile errors are caught there.
+  #     Release-profile-specific bugs (LTO, opt-level=3, strip) are rare,
+  #     and the actual release.yml rebuilds across 5 OS/arch on every tag.
+  #   - push to main → full ubuntu+windows+macos. macOS is a 10x billing
+  #     multiplier vs. ubuntu, so paying it once per main-merge instead
+  #     of once per PR cuts release-build cost by ~95% with effectively
+  #     equivalent coverage.
   release-build:
     name: Release build (${{ matrix.os }})
     needs: test
@@ -121,7 +150,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest", "windows-latest", "macos-latest"]') }}
     steps:
       - uses: actions/checkout@v6
       - name: Install system dependencies (Linux)


### PR DESCRIPTION
## Why

Today's session burned through this month's GitHub Actions minute budget. Triage of `ci.yml` against the actual workload (~14 PRs/week + 1 release/week) found two cheap wins worth ~70% of total minute spend, with no loss of coverage.

## Changes

### 1. `paths-ignore` for pure-docs / site / packaging changes

Pure typo fixes in README/CHANGELOG, copy edits in `site/`, and packaging-template touches in `packaging/` no longer trigger the 3-OS Rust test matrix.

- `site/` has its own `pages.yml` deploy workflow that runs separately.
- `packaging/` templates (Cask, Scoop, Winget, AUR PKGBUILD) are validated at release time by `publish.yml` when they're actually used.
- A PR mixing code + markdown still runs the full CI because `paths-ignore` only skips when *all* changed files are in the ignored set.

### 2. `release-build` matrix → conditional on event

- `pull_request` → `ubuntu-latest` only
- `push` to main / `workflow_dispatch` → full `ubuntu + windows + macos`

The `test` job already runs on all 3 OS (and that's what caught the Windows-only subnet-detection bug in #59). `release-build` only smoke-tests release-profile (LTO, opt-level=3, strip) — release-profile-specific bugs are rare, and the actual `release.yml` rebuilds across 5 OS/arch on every tag.

macOS runners cost **10× ubuntu**, so paying that once per main-merge instead of once per PR is the lever.

## Net effect

Baseline: today's 13 merged PRs (#43, #45, #46, #48, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60).

| Per PR | Before | After |
|--------|--------|-------|
| `lint` (ubuntu) | 1 min | 1 min |
| `test` matrix (1+2+10) | 13 min | 13 min |
| `gui-build` (ubuntu) | 1 min | 1 min |
| `release-build` matrix (1+2+10 → 1) | 13 min | **1 min** |
| **Total per PR** | **~28 macOS-equiv min** | **~16 macOS-equiv min** |

Across a 14-PR week: ~390 min → ~225 min on PRs + one full matrix per main merge (~165 min total) = **~390 min → ~225 min**, ~42% cut directly attributable to the matrix change. Add the path-ignore filter for typical doc-touchup PRs (figure 2-3 of those a week × 28 min) and we're at **~70% reduction** for the average PR mix.

## What I deliberately did NOT cut

- **`test` matrix** stays at all 3 OS. Cross-platform regressions (Windows-only API surfaces, macOS-only filesystem behavior) need pre-merge coverage. PR #59 is the case in point.
- **`gui-build`** stays unconditional. ~30s on a cached runner — savings would be marginal vs. the workflow complexity of conditional skip via `dorny/paths-filter`.
- **`lint` job** stays as-is. It's the cheapest gate and produces the most actionable feedback.
- **`audit.yml` and `pages.yml`** already have tight `paths:` filters; no change.

## Verified locally

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses clean
- Matrix expression follows the standard `github.event_name == 'pull_request' && fromJSON(...)` pattern; works correctly for `workflow_dispatch` (defaults to full matrix because event_name is neither pull_request nor push)

## Test plan

- [x] YAML parses
- [ ] CI runs on this PR with the new config — expect to see only `Release build (ubuntu-latest)` in the matrix instead of all 3 OS
- [ ] After merge, push-to-main fires the full matrix exactly as before