### PR TITLE
fix(gui): wire up Tauri 2 capabilities so the title-bar buttons work

### DIFF
--- a/apps/netscli-gui/src-tauri/capabilities/main.json
+++ b/apps/netscli-gui/src-tauri/capabilities/main.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main",
+  "description": "Capabilities granted to the main window. Tauri 2 is deny-by-default per permission, and `core:window:default` only includes read-only operations (is-maximized, inner-size, etc.). Without explicit grants for the mutating ops, the close/minimize/maximize buttons in TitleBar.tsx silently fail because the app uses `decorations: false` and a custom React title bar instead of the OS-native window chrome.",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "core:window:allow-close",
+    "core:window:allow-minimize",
+    "core:window:allow-maximize",
+    "core:window:allow-unmaximize",
+    "core:window:allow-start-dragging"
+  ]
+}


### PR DESCRIPTION
## Bug

The close, minimize, and maximize buttons in the custom title bar do nothing on Windows (and likely all platforms — Windows is just where it surfaced). User-reported.

## Root cause

`TitleBar.tsx` calls `getCurrentWindow().close()`, `.minimize()`, `.maximize()`, and `.unmaximize()` from the React frontend. None of those work because **the app had no capabilities files** — only the auto-generated `src-tauri/gen/schemas/capabilities.json` was present, and it was `{}`.

Tauri 2 is **deny-by-default per permission**. The `core:window:default` permission set (which `core:default` pulls in) only includes read-only window operations: `is-maximized`, `inner-size`, `scale-factor`, etc. The mutating operations — `close`, `minimize`, `maximize`, `unmaximize`, `start-dragging` — need explicit grants. Without them, the JS calls reject silently. The handlers in `TitleBar.tsx` catch the rejection and `console.error` it, so the user just sees nothing happen.

This is a **Tauri 1 → Tauri 2 migration trap**. In Tauri 1 you'd have an `allowlist` block in `tauri.conf.json` that defaulted to "all window ops allowed". Tauri 2 inverted the security model to deny-by-default per permission, but the title bar code was ported across without the matching capabilities file.

Custom commands (`discover_network`, `scan_ports`, etc.) work fine because they're exposed via `tauri::generate_handler!`, which is gated by a separate mechanism that doesn't depend on the window capability set. That's why scans worked but window controls didn't.

## Fix

New file `apps/netscli-gui/src-tauri/capabilities/main.json` granting:

| Permission | Why |
|------------|-----|
| `core:default` | Events, app metadata, paths, etc. — the baseline. |
| `core:window:allow-close` | The close button (`X`). |
| `core:window:allow-minimize` | The minimize button. |
| `core:window:allow-maximize` | The maximize button. |
| `core:window:allow-unmaximize` | The "restore" half of the maximize toggle. |
| `core:window:allow-start-dragging` | The `data-tauri-drag-region` attribute on the title bar's drag surface — without this, dragging the title bar to move the window doesn't work either. |

## Verified locally

- `cargo check -p netscli-gui` succeeds (tauri-build's codegen processes the new capability file)
- `apps/netscli-gui/src-tauri/gen/schemas/capabilities.json` went from `{}` (0 bytes meaningful content) → 661 bytes with the `main` capability entry registered
- `cargo clippy -p netscli-gui --all-targets -- -D warnings` clean
- `npm run build` (Vite + tsc) clean
- `cargo fmt --all -- --check` clean

## Test plan

- [x] Build picks up capability file
- [ ] CI: ubuntu/macOS/windows test matrix
- [ ] **Manual smoke on Windows after merge:** click each of the three title-bar buttons (`-`, `□`, `X`) and the title-bar drag surface; all four should now work