### PR TITLE
release: v0.2.6 fix in-app version display + Tauri capabilities + refactor wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ version and release together.
 
 ## [Unreleased]
 
+## [0.2.6] — 2026-05-06
+
+### Fixed
+
+- **GUI: in-app version display was stuck at `0.1.0`.** A stale
+  `APP_VERSION` constant in `App.tsx` powered both the bottom-bar
+  version readout and the About dialog, but it never got bumped
+  alongside `package.json`, `tauri.conf.json`, or the workspace
+  `Cargo.toml`s. Caught by a Winget moderator on
+  [microsoft/winget-pkgs#368471](https://github.com/microsoft/winget-pkgs/pull/368471):
+  the v0.2.4 build correctly reported `0.2.4` to the Windows registry
+  (Tauri pulls `ProductVersion` from `tauri.conf.json`), but users
+  saw `0.1.0` in the GUI itself. Wired `APP_VERSION` to read
+  `package.json` at build time via Vite's `define` so the in-app
+  display auto-syncs every release going forward.
+- **GUI: title-bar buttons (close, minimize, maximize) didn't work
+  on Windows.** Tauri 2's deny-by-default permission system requires
+  explicit `core:window:allow-close/minimize/maximize/unmaximize/start-dragging`
+  grants; the app was missing its capabilities config entirely.
+  Added `src-tauri/capabilities/main.json`. (#62)
+
+### Changed (internal)
+
+- **Major refactor of TUI / CLI organization** ([#63](https://github.com/fstubner/netscli/pull/63)–[#67](https://github.com/fstubner/netscli/pull/67)):
+  - `apps/netscli-cli/src/main.rs` shrank from 1870 → 527 lines (-72%).
+  - `apps/netscli-cli/src/tui.rs` (2226 lines) decomposed into
+    a `tui/` module with 8 focused files (state, events, widgets,
+    palette, command_catalog, config, history, mod).
+  - `apps/netscli-gui/src/App.tsx` shrank from 1480 → 931 lines (-37%)
+    via per-tab views in `views/*View.tsx`.
+  - `formatter.rs` renamed to `tui_formatter.rs` for naming
+    consistency with `tui_export.rs`, `tui_settings.rs`.
+  - All behavior-preserving; 25 tests pass on every PR's 3-OS matrix.
+- **CI runner-minute spend cut by ~70% per PR** by collapsing the
+  `release-build` matrix to ubuntu-only on PRs (full 3-OS only on
+  push to main) and adding `paths-ignore` for docs/site/packaging
+  changes. ([#61](https://github.com/fstubner/netscli/pull/61))
+
 ## [0.2.5] — 2026-05-05
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "netscli"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-gui"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "ipnet",
  "netscli-core",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-mcp"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "ipnet",

--- a/apps/netscli-cli/Cargo.toml
+++ b/apps/netscli-cli/Cargo.toml
@@ -3,7 +3,7 @@
 # consistency, but the published crate is just `netscli` so users can
 # `cargo install netscli` (matching the produced binary name).
 name = "netscli"
-version = "0.2.5"
+version = "0.2.6"
 description = "Interactive TUI and CLI for network discovery, scanning, and diagnostics"
 authors.workspace = true
 license.workspace = true
@@ -25,8 +25,8 @@ clap_mangen = "0.3"
 ratatui = "0.29.0"
 crossterm = "0.28"
 tui-textarea = "0.7"
-netscli-core = { path = "../../crates/netscli-core", version = "0.2.5", default-features = false, features = ["db", "mdns"] }
-netscli-mcp = { path = "../../crates/netscli-mcp", version = "0.2.5", features = ["mdns"] }
+netscli-core = { path = "../../crates/netscli-core", version = "0.2.6", default-features = false, features = ["db", "mdns"] }
+netscli-mcp = { path = "../../crates/netscli-mcp", version = "0.2.6", features = ["mdns"] }
 serde_yaml_ng = "0.10"
 dirs = "6.0"
 mac_address = "1.1.8"

--- a/apps/netscli-gui/package.json
+++ b/apps/netscli-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netscli-gui",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "NetsCLI GUI - Modern network scanner with beautiful desktop interface",
   "private": true,
   "type": "module",

--- a/apps/netscli-gui/src-tauri/Cargo.toml
+++ b/apps/netscli-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-gui"
-version = "0.2.5"
+version = "0.2.6"
 description = "Tauri 2.0 desktop GUI for network discovery, scanning, and diagnostics"
 authors.workspace = true
 license.workspace = true

--- a/apps/netscli-gui/src-tauri/tauri.conf.json
+++ b/apps/netscli-gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "NetsCLI",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "com.netscli.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/apps/netscli-gui/src/App.tsx
+++ b/apps/netscli-gui/src/App.tsx
@@ -60,7 +60,11 @@ import { ScanToolbar, ScanResults } from './views/ScanView';
 import { SettingsView } from './views/SettingsView';
 import { SweepToolbar, SweepResults } from './views/SweepView';
 
-const APP_VERSION = '0.1.0';
+// Vite injects this at build time from package.json — see vite.config.ts.
+// Keeps the in-app version display (status bar, About dialog) in sync
+// with package.json / tauri.conf.json automatically. Was hardcoded
+// '0.1.0' until v0.2.6, which a Winget moderator caught.
+const APP_VERSION = __APP_VERSION__;
 
 type DnsRecordType = 'A' | 'AAAA';
 

--- a/apps/netscli-gui/src/types/globals.d.ts
+++ b/apps/netscli-gui/src/types/globals.d.ts
@@ -1,0 +1,5 @@
+// Build-time constants injected by Vite's `define` block (see
+// vite.config.ts). The string substitution happens at bundle time so
+// each release carries the package.json version automatically — no
+// hand-editing of an `APP_VERSION` constant in App.tsx required.
+declare const __APP_VERSION__: string

--- a/apps/netscli-gui/vite.config.ts
+++ b/apps/netscli-gui/vite.config.ts
@@ -1,9 +1,22 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { readFileSync } from 'node:fs'
+
+// Read the package version once at config time so we can inject it as
+// a build-time constant. Avoids a stale hardcoded `APP_VERSION` in
+// App.tsx drifting from package.json / tauri.conf.json (the bug a
+// Winget moderator caught on PR microsoft/winget-pkgs#368471 where
+// the v0.2.4 build was still showing 0.1.0 in the UI).
+const pkg = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
+) as { version: string }
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   server: {
     port: 1420,
     strictPort: true,
@@ -16,4 +29,3 @@ export default defineConfig({
     },
   },
 })
-

--- a/crates/netscli-core/Cargo.toml
+++ b/crates/netscli-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-core"
-version = "0.2.5"
+version = "0.2.6"
 description = "Core networking library: discovery, scanning, DNS, ARP, PCAP, and OUI resolution"
 authors.workspace = true
 license.workspace = true

--- a/crates/netscli-mcp/Cargo.toml
+++ b/crates/netscli-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-mcp"
-version = "0.2.5"
+version = "0.2.6"
 description = "Model Context Protocol (MCP) server exposing netscli-core tools to LLM agents"
 authors.workspace = true
 license.workspace = true
@@ -17,7 +17,7 @@ thiserror.workspace = true
 ipnet.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-netscli-core = { path = "../netscli-core", version = "0.2.5", default-features = false }
+netscli-core = { path = "../netscli-core", version = "0.2.6", default-features = false }
 
 [features]
 default = ["mdns"]

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -447,5 +447,5 @@ export const site: SiteData = {
     cloudflareToken: 'c03201f65f6d41aa843c81f259a1ac06',
   },
 
-  version: '0.2.5',
+  version: '0.2.6',
 };


### PR DESCRIPTION
## Summary

Cuts v0.2.6 carrying the post-v0.2.5 work plus the in-app version display bug a Winget moderator caught.

## Headline fix

The GUI's bottom-bar version readout and About dialog were stuck displaying `0.1.0` even after we shipped v0.2.4 / v0.2.5. Caught in [`microsoft/winget-pkgs#368471`](https://github.com/microsoft/winget-pkgs/pull/368471) — the Windows registry correctly showed `0.2.4` (Tauri pulls `ProductVersion` from `tauri.conf.json`), but a stale `const APP_VERSION = '0.1.0'` in `App.tsx` powered the in-app display and never got bumped alongside the rest of the version files.

Fix: wire `APP_VERSION` to `package.json` via Vite's `define` block so the in-app display auto-syncs every release going forward.

```ts
// vite.config.ts
const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'))
export default defineConfig({
  define: { __APP_VERSION__: JSON.stringify(pkg.version) },
  // ...
})
```

```ts
// App.tsx — was: const APP_VERSION = '0.1.0';
const APP_VERSION = __APP_VERSION__;
```

Verified via `npm run build`: bundle now contains the literal `'0.2.6'` substituted in.

## Also carrying (post-v0.2.5)

- **Tauri 2 capabilities for window controls** (#62) — title-bar `close` / `minimize` / `maximize` / `unmaximize` / `start-dragging` now actually work on Windows. Were silently failing because Tauri 2 is deny-by-default per permission and the app had no capabilities config at all.
- **Five refactor PRs** (#63–#67):
  - `main.rs` 1870 → 527 lines (-72%)
  - `App.tsx` 1480 → 931 lines (-37%)
  - `tui.rs` 2226 lines decomposed into 8 focused files in `tui/` module
  - `formatter.rs` renamed to `tui_formatter.rs` for naming consistency
- **CI runner-minute spend cut ~70% per PR** (#61).

## Verified locally

- `cargo clippy -p netscli --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- `cargo test -p netscli` — 25 tests pass
- `npm run build` clean, `0.2.6` substituted into bundle

## Test plan

- [x] Local gates pass
- [ ] CI: ubuntu/macOS/windows test matrix
- [ ] After merge: tag `v0.2.6` and publish the draft release → release.yml builds 64 assets → publish.yml fans out to 8 channels
- [ ] After v0.2.6 release exists: update `microsoft/winget-pkgs#368471` to point at the v0.2.6 .msi