### PR TITLE
release(publish): wait for Windows release assets in Winget jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,6 +101,35 @@ jobs:
     name: Winget
     runs-on: windows-latest
     steps:
+      # The `winget-releaser` action fetches the release's asset list
+      # via the GitHub API and bails fast if the matching .exe is not
+      # present yet. Both publish.yml and release.yml fire on
+      # `release: published`, so without polling here we race
+      # release.yml's Windows runner: in v0.2.5's run the action ran
+      # at ~1m45s but the .exe didn't land until ~7m later, giving
+      # the empty-`--urls` failure that needed a manual rerun. Poll
+      # the .sha256 sidecar (uploaded last in the matrix; ~600 bytes,
+      # cheap to HEAD) before invoking. Modeled on the AUR job's
+      # equivalent step further down.
+      - name: Wait for Windows CLI release asset
+        shell: bash
+        env:
+          TAG: ${{ env.TAG }}
+        run: |
+          set -euo pipefail
+          url="https://github.com/fstubner/netscli/releases/download/${TAG}/netscli-windows-x86_64.exe.sha256"
+          echo "→ ${url}"
+          for i in {1..30}; do
+            if curl -fsSL --head "$url" >/dev/null 2>&1; then
+              echo "asset present"
+              exit 0
+            fi
+            echo "  not yet; retry in 30s ($i/30)"
+            sleep 30
+          done
+          echo "asset never appeared after 15 minutes" >&2
+          exit 1
+
       - name: Submit netscli to microsoft/winget-pkgs
         uses: vedantmgoyal2009/winget-releaser@v2
         with:
@@ -215,6 +244,32 @@ jobs:
     name: Winget (GUI)
     runs-on: windows-latest
     steps:
+      # Same wait-then-submit pattern as the CLI Winget job above. The
+      # GUI .msi takes longer to build than the CLI .exe (Tauri bundle
+      # + WiX compose), so this poll matters even more here. Note: this
+      # job will still fail until microsoft/winget-pkgs has accepted at
+      # least one version of `fstubner.netscli.gui` — the action checks
+      # for an existing package directory before doing anything else.
+      # PR #368471 is the initial submission gating that.
+      - name: Wait for Windows GUI release asset
+        shell: bash
+        env:
+          TAG: ${{ env.TAG }}
+        run: |
+          set -euo pipefail
+          url="https://github.com/fstubner/netscli/releases/download/${TAG}/netscli-gui-windows-x86_64.msi.sha256"
+          echo "→ ${url}"
+          for i in {1..30}; do
+            if curl -fsSL --head "$url" >/dev/null 2>&1; then
+              echo "asset present"
+              exit 0
+            fi
+            echo "  not yet; retry in 30s ($i/30)"
+            sleep 30
+          done
+          echo "asset never appeared after 15 minutes" >&2
+          exit 1
+
       - name: Submit netscli-gui to microsoft/winget-pkgs
         uses: vedantmgoyal2009/winget-releaser@v2
         with:


### PR DESCRIPTION
## What

Adds a "Wait for Windows release asset" polling step to both Winget jobs in `publish.yml` (CLI + GUI), modeled on the equivalent step the AUR job already has.

## Why

`publish.yml`'s two Winget jobs invoke `vedantmgoyal2009/winget-releaser@v2`, which queries the GitHub API for the release's asset list and bails immediately if the matching `.exe` / `.msi` isn't there yet — there's no built-in polling.

Both `publish.yml` and `release.yml` fire on `release: published`. In v0.2.5's publish run ([run 25348676155](https://github.com/fstubner/netscli/actions/runs/25348676155)):
- The Winget CLI job ran at ~1m45s
- But `release.yml`'s Windows runner didn't upload the `.exe` until ~7m later
- So `winget-releaser` saw an empty asset list and failed with `a value is required for '--urls <URLS>...' but none was supplied`
- Required a manual `gh run rerun --failed` once assets were up

The AUR job further down already polls the `.sha256` sidecar of its Linux artifacts. This PR applies the same pattern to both Winget jobs.

## Approach

Poll the `.sha256` sidecar instead of the `.exe`/`.msi` itself:
- It's the last thing release.yml uploads per artifact (so its presence proves the upload completed)
- ~600 bytes (cheap HEAD)
- Existing pattern matches what AUR already does

15-minute cap (30 retries × 30s) — generous enough for any reasonable matrix delay, fails fast enough that a stuck job doesn't pin a runner indefinitely.

## What this does NOT fix

The Winget GUI job will still fail on the FIRST submission because `winget-releaser` checks for an existing package directory in `microsoft/winget-pkgs` before doing anything else. That's a separate moderator-gated dependency tracked via [`microsoft/winget-pkgs#368471`](https://github.com/microsoft/winget-pkgs/pull/368471) (the initial `fstubner.netscli.gui` submission). This PR only addresses the timing race for jobs whose package already exists in the catalog.

## Verified locally

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` parses cleanly

## Test plan

- [x] YAML parses
- [ ] CI: passes (this PR doesn't touch Rust/TS so only `lint + paths-ignore-eligible` jobs run)
- [ ] **Real test**: next release (v0.2.7+) — Winget CLI job should succeed without the manual rerun this time