### PR TITLE
packaging(winget): add v0.2.6 GUI manifest templates

### DIFF
--- a/packaging/winget/gui/0.2.6/fstubner.netscli.gui.installer.yaml
+++ b/packaging/winget/gui/0.2.6/fstubner.netscli.gui.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+# Winget installer manifest for the netscli desktop app.
+#
+# Distinct PackageIdentifier (`fstubner.netscli.gui`) from the CLI
+# (`fstubner.netscli`) so users can install one without the other:
+#   winget install netscli       -> CLI
+#   winget install netscli-gui   -> GUI
+# Moniker resolves to the chosen identifier as long as it's unique in
+# the catalog.
+
+PackageIdentifier: fstubner.netscli.gui
+PackageVersion: 0.2.6
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/fstubner/netscli/releases/download/v0.2.6/netscli-gui-windows-x86_64.msi
+    InstallerSha256: 064EF2B5CDA0B70131D07002EA6A51FC0CEBEA863072211E6643A0BB5252FD7E
+    Scope: user
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/packaging/winget/gui/0.2.6/fstubner.netscli.gui.locale.en-US.yaml
+++ b/packaging/winget/gui/0.2.6/fstubner.netscli.gui.locale.en-US.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: fstubner.netscli.gui
+PackageVersion: 0.2.6
+PackageLocale: en-US
+Publisher: Felix Stubner
+PublisherUrl: https://github.com/fstubner
+PublisherSupportUrl: https://github.com/fstubner/netscli/issues
+Author: Felix Stubner
+PackageName: NetsCLI Desktop
+PackageUrl: https://netscli.com
+License: MIT
+LicenseUrl: https://github.com/fstubner/netscli/blob/main/LICENSE
+Copyright: Copyright (c) Felix Stubner
+ShortDescription: Network scanner desktop app — discover hosts, scan ports, look up DNS records, inspect ARP table.
+Description: |
+  NetsCLI Desktop is the GUI surface of netscli — a network scanner
+  with CLI, terminal UI, desktop app, and MCP server interfaces all
+  backed by the same Rust core. The desktop app provides a Tauri 2 +
+  React window for visual host discovery, port scanning, DNS lookups,
+  and ARP table inspection without opening a terminal.
+Moniker: netscli-gui
+Tags:
+  - network
+  - scanner
+  - port-scanner
+  - dns
+  - arp
+  - tauri
+  - rust
+  - desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/packaging/winget/gui/0.2.6/fstubner.netscli.gui.yaml
+++ b/packaging/winget/gui/0.2.6/fstubner.netscli.gui.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: fstubner.netscli.gui
+PackageVersion: 0.2.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Mirrors the v0.2.6 GUI manifests pushed to `microsoft/winget-pkgs#368471` so the local packaging/ tree tracks Winget catalog state. Pure-packaging change — `paths-ignore` skips CI.