### PR TITLE
Update Rust toolchain to 1.96

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,8 @@ cd scripts && cargo run --bin generate-oui
 
 ## Toolchain
 
-- Rust **1.92.0** pinned in `rust-toolchain.toml` (includes rustfmt + clippy)
-- MSRV: 1.92
+- Rust **1.96.0** pinned in `rust-toolchain.toml` (includes rustfmt + clippy)
+- MSRV: 1.96
 - Cargo resolver: v2
 - GUI frontend: Node.js with npm, Vite, TypeScript
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/netscli"
 keywords = ["networking", "scanner", "tui", "cli", "mcp"]
 categories = ["command-line-utilities", "network-programming"]
 edition = "2021"
-rust-version = "1.92.0"
+rust-version = "1.96.0"
 
 [workspace.dependencies]
 # Shared across all workspace members — pinned here to guarantee a single version.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![crates.io](https://img.shields.io/crates/v/netscli.svg)](https://crates.io/crates/netscli)
 [![Release](https://img.shields.io/github/v/release/fstubner/netscli)](https://github.com/fstubner/netscli/releases)
 [![Downloads](https://img.shields.io/github/downloads/fstubner/netscli/total)](https://github.com/fstubner/netscli/releases)
-[![Rust 1.92.0](https://img.shields.io/badge/rust-1.92.0-blue.svg)](https://www.rust-lang.org/)
+[![Rust 1.96.0](https://img.shields.io/badge/rust-1.96.0-blue.svg)](https://www.rust-lang.org/)
 [![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macos%20%7C%20windows-informational)](#installation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -364,7 +364,7 @@ netscli pcap --read capture.pcap --yaml
 
 ### Prerequisites
 
-- Rust 1.92.0 (pinned via `rust-toolchain.toml`) ([install from rustup.rs](https://rustup.rs/))
+- Rust 1.96.0 (pinned via `rust-toolchain.toml`) ([install from rustup.rs](https://rustup.rs/))
 - For GUI: Node.js 18+ and npm
 
 ### CLI Binary

--- a/apps/netscli-cli/src/tui/runtime.rs
+++ b/apps/netscli-cli/src/tui/runtime.rs
@@ -39,20 +39,19 @@ pub async fn run_tui(concurrency: usize) -> Result<()> {
 
         tasks.finish_ready_task(&mut app).await;
 
-        if event::poll(tick_rate)? {
-            match event::read()? {
-                Event::Resize(_, _) => {}
-                Event::Mouse(_) => {}
-                Event::Key(key) => {
-                    if input
-                        .handle_key(key, &mut app, &mut tasks, &ops, &db)
-                        .await?
-                    {
-                        break;
-                    }
-                }
-                _ => {}
-            }
+        if !event::poll(tick_rate)? {
+            continue;
+        }
+
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+
+        if input
+            .handle_key(key, &mut app, &mut tasks, &ops, &db)
+            .await?
+        {
+            break;
         }
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- update the pinned Rust toolchain and workspace rust-version to 1.96.0
- update README and AGENTS toolchain/MSRV notes
- adjust the TUI event loop for a Rust 1.96 Clippy warning

## Checks
- cargo fmt --check
- cargo test -p netscli-core
- cargo test -p netscli
- cargo test -p netscli-mcp
- cargo clippy --all-targets -- -D warnings
- cargo audit