### PR TITLE
Update sysinfo to 0.39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3239,6 +3239,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5024,15 +5035,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "windows 0.62.2",
 ]
 

--- a/crates/netscli-core/Cargo.toml
+++ b/crates/netscli-core/Cargo.toml
@@ -28,7 +28,7 @@ pnet_packet = "0.35"
 pnet_transport = "0.35"
 ipnetwork = "0.20"
 hickory-resolver = { version = "0.26", features = ["tokio"] }
-sysinfo = "0.38"
+sysinfo = "0.39"
 mac_address = { version = "1.1", features = ["serde"] }
 futures = "0.3"
 once_cell = "1.21"


### PR DESCRIPTION
Updates sysinfo to the current 0.39 patch release now that the workspace is on Rust 1.96.\n\nLocal checks run:\n- cargo fmt --check\n- cargo test -p netscli-core\n- cargo test -p netscli\n- cargo test -p netscli-mcp\n- cargo clippy --all-targets -- -D warnings\n- cargo audit\n\nThis supersedes the stale Dependabot PR #77, which was blocked by the old Rust 1.92 toolchain.