### PR TITLE
Superseded by #107

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,7 +29,7 @@ categories:
       - dependencies
       - refactor
 
-change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-template: "- $TITLE (#$NUMBER) by @$AUTHOR"
 change-title-escapes: '\<*_&'
 
 version-resolver:
@@ -42,9 +42,25 @@ version-resolver:
   default: patch
 
 template: |
+  <!--
+  Before publishing, add a short human-written overview above "What's changed".
+  Good release notes should explain:
+  - what changed for users,
+  - why the change was made,
+  - who benefits,
+  - any upgrade or packaging caveats.
+
+  The changelog page on netscli.com renders this GitHub Markdown directly,
+  so avoid terse PR-title-only releases for visible product milestones.
+  -->
+
   ## What's new in $RESOLVED_VERSION
 
   $CHANGES
+
+  ## Upgrade notes
+
+  No migration is required unless a note above says otherwise.
 
   ---
   **Full changelog:** https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ Prebuilt installers are attached to every [GitHub release](https://github.com/fs
 - **Linux**: `netscli-gui-linux-x86_64.deb` (Debian/Ubuntu) or `netscli-gui-linux-x86_64.AppImage` (any distro; `chmod +x` and run).
 
 The published desktop GUI installers are built without packet capture support
-so they do not depend on or redistribute Npcap/libpcap. Packet Capture appears
-only in local desktop builds compiled with the `pcap` feature and a working
-Npcap/libpcap runtime.
+so they do not depend on or redistribute Npcap/libpcap. The Packet Capture
+tool is visible in the GUI, but it shows setup guidance and cannot run unless
+the desktop backend was built with the `pcap` feature and a working
+Npcap/libpcap runtime is installed.
 
 To build from source instead:
 
@@ -243,7 +244,7 @@ PCAP capture is optional and disabled in the default builds for portability. To 
 - **Via installer (recommended)**: `NETSCLI_PCAP=1` does everything. It picks the pcap-enabled binary variant *and* installs the system library (`libpcap` on Linux/macOS, Npcap on Windows).
   - Add `NETSCLI_SKIP_LIBPCAP=1` (POSIX) or `NETSCLI_SKIP_NPCAP=1` (Windows) if you manage the system library yourself.
 - **From source**: `cargo build --features pcap` (see [Building](#building) for the full command with OS-specific deps).
-- **Desktop GUI**: published GUI installers are intentionally non-PCAP. Use `npm run tauri:dev:pcap` or `npm run tauri build -- --features pcap` for local packet-capture GUI builds.
+- **Desktop GUI**: published GUI installers are intentionally non-PCAP. The Packet Capture tab shows setup guidance in those builds. Use `npm run tauri:dev:pcap` or `npm run tauri build -- --features pcap` for local packet-capture GUI builds.
 - **Capture parsing**: pcap-enabled CLI builds can also summarize existing capture files with `netscli pcap --read <file> --json` or `--yaml`.
 - **On Windows runtime**: ensure `wpcap.dll` is on PATH. Npcap installs it to `C:\Windows\System32\Npcap\` which isn't on PATH by default. Add that directory to your PATH, or the installer does it for you when you set `NETSCLI_PCAP=1`.
 - **On Windows source builds**: install the [Npcap SDK](https://npcap.com/#download) as well as the runtime. MSVC needs the SDK import library (`wpcap.lib`) at link time:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -63,12 +63,13 @@ Before the first automated release runs, add these secrets at
 
    The published desktop GUI installers are intentionally built without
    `--features pcap`. This keeps the GUI install path free of libpcap/Npcap
-   runtime dependencies and avoids redistributing Npcap. Packet Capture is
-   available in local GUI builds only when the Tauri backend is built with
-   `--features pcap` and the user has installed the required system runtime
-   themselves. If a future release adds PCAP-enabled GUI installers, validate
-   launch behavior on Windows with and without Npcap installed before
-   publishing that flavor. For local Windows PCAP GUI experiments, use
+   runtime dependencies and avoids redistributing Npcap. The GUI may still
+   show the Packet Capture tool, but it must present setup guidance and remain
+   non-runnable unless the backend is PCAP-capable and the user has installed
+   the required system runtime themselves. If a future release adds
+   PCAP-enabled GUI installers, validate launch behavior on Windows with and
+   without Npcap installed before publishing that flavor. For local Windows
+   PCAP GUI experiments, use
    `scripts/dev-gui-pcap.ps1` or otherwise set `CARGO_TARGET_DIR=target-pcap`
    so a PCAP-linked debug binary does not replace the normal non-PCAP
    `target/debug/netscli-gui.exe`.
@@ -82,7 +83,19 @@ Before the first automated release runs, add these secrets at
    the full gate before tagging.
 2. **Tag and draft the release.** Either `gh release create vX.Y.Z --draft
    --generate-notes` or use the web UI's "Draft a new release" button.
-3. **Promote the draft to public.** This is the one human action that
+3. **Edit the release notes.** The public changelog page renders the GitHub
+   release body directly, so do not publish PR-title-only notes for a visible
+   product milestone. Add a short human-written overview before the generated
+   change list:
+   - what changed for users,
+   - why it changed,
+   - who benefits,
+   - upgrade, packaging, or runtime caveats.
+
+   For example, the GUI redesign release should explain the move from the
+   simple dashboard-style shell to the tabbed desktop workflow, why richer
+   result details and filters were added, and what stayed compatible.
+4. **Promote the draft to public.** This is the one human action that
    stays in the loop.
    ```bash
    gh release edit vX.Y.Z --draft=false --repo fstubner/netscli
@@ -90,7 +103,7 @@ Before the first automated release runs, add these secrets at
    This single event fires both `release.yml` (builds binaries + GUI
    installers, attaches them to the release) and `publish.yml` (fans out
    to package managers).
-4. **Watch the dashboard.** From the release page or the Actions tab:
+5. **Watch the dashboard.** From the release page or the Actions tab:
    - `Release` workflow: 13 CLI assets + 4 GUI installers attached.
    - `Publish to package managers` workflow: 5 jobs, one per channel.
 
@@ -98,7 +111,7 @@ Before the first automated release runs, add these secrets at
    (up to 15 minutes) so they tolerate the parallel race against
    `release.yml`.
 
-5. **If something fails**, re-run just that job from the Actions tab —
+6. **If something fails**, re-run just that job from the Actions tab —
    `workflow_dispatch` accepts a tag input so you can re-run a specific
    channel without rebuilding binaries or re-running the others.
 

--- a/docs/screenshots/tui-discover.svg
+++ b/docs/screenshots/tui-discover.svg
@@ -27,10 +27,9 @@
     <text x="600" y="216" xml:space="preserve">╚═╝  ╚═══╝╚══════╝   ╚═╝   ╚══════╝ ╚═════╝╚══════╝╚═╝</text>
   </g>
 
-  <!-- Single subtitle line: tagline + version together, centered -->
+  <!-- Evergreen subtitle line: no embedded version, so the asset does not age out. -->
   <text x="600" y="250" class="mono text" font-size="16" text-anchor="middle">
     <tspan>A modern network scanner</tspan>
-    <tspan class="label">  ·  v0.1.0</tspan>
   </text>
 
   <!-- Command output container -->
@@ -38,7 +37,7 @@
   <text x="195" y="334" class="mono" font-size="16">
     <tspan class="label">&gt; </tspan>
     <tspan fill="#1edcff">/discover</tspan>
-    <tspan class="label"> 192.168.1.0/24</tspan>
+    <tspan class="label"> lab-network</tspan>
   </text>
 
   <!--
@@ -48,32 +47,32 @@
   -->
   <g class="mono" font-size="14">
     <text y="372">
-      <tspan x="195" class="label">IP Address</tspan>
-      <tspan x="350" class="label">MAC Address</tspan>
+      <tspan x="195" class="label">Host</tspan>
+      <tspan x="350" class="label">Device ID</tspan>
       <tspan x="535" class="label">Vendor</tspan>
       <tspan x="700" class="label">Hostname</tspan>
     </text>
     <text y="402">
-      <tspan x="195" fill="#0aae7a">192.168.1.10</tspan>
-      <tspan x="350" fill="#f5c84c">00:17:8B:6E:6C:5C</tspan>
+      <tspan x="195" fill="#0aae7a">workstation.local</tspan>
+      <tspan x="350" fill="#f5c84c">lab-node-01</tspan>
       <tspan x="535" class="value">Dell Inc.</tspan>
       <tspan x="700" class="value">workstation</tspan>
     </text>
     <text y="426">
-      <tspan x="195" fill="#0aae7a">192.168.1.21</tspan>
-      <tspan x="350" fill="#f5c84c">7E:6B:4E:32:0D:3E</tspan>
+      <tspan x="195" fill="#0aae7a">phone.local</tspan>
+      <tspan x="350" fill="#f5c84c">lab-node-02</tspan>
       <tspan x="535" class="value">Apple, Inc.</tspan>
       <tspan x="700" class="value">iphone</tspan>
     </text>
     <text y="450">
-      <tspan x="195" fill="#0aae7a">192.168.1.57</tspan>
-      <tspan x="350" fill="#f5c84c">94:C9:8B:92:49:83</tspan>
+      <tspan x="195" fill="#0aae7a">pi.local</tspan>
+      <tspan x="350" fill="#f5c84c">lab-node-03</tspan>
       <tspan x="535" class="value">Raspberry Pi</tspan>
       <tspan x="700" class="value">pi</tspan>
     </text>
     <text y="474">
-      <tspan x="195" fill="#0aae7a">192.168.1.125</tspan>
-      <tspan x="350" fill="#f5c84c">00:17:8B:6E:6C:5C</tspan>
+      <tspan x="195" fill="#0aae7a">nas.local</tspan>
+      <tspan x="350" fill="#f5c84c">lab-node-04</tspan>
       <tspan x="535" class="value">Dell Inc.</tspan>
       <tspan x="700" class="value">nas</tspan>
     </text>
@@ -92,7 +91,7 @@
   <text x="195" y="630" class="mono" font-size="14">
     <tspan class="label">host </tspan><tspan class="value">workstation</tspan>
     <tspan class="label"> · </tspan>
-    <tspan class="label">ip </tspan><tspan class="value">192.168.1.10</tspan>
+    <tspan class="label">target </tspan><tspan class="value">workstation.local</tspan>
   </text>
   <text x="1005" y="630" class="mono" font-size="14" text-anchor="end">
     <tspan fill="#1edcff">↑ </tspan><tspan class="value">0.03</tspan><tspan class="label"> Mbps</tspan>

--- a/docs/screenshots/tui-preview.svg
+++ b/docs/screenshots/tui-preview.svg
@@ -27,10 +27,9 @@
     <text x="600" y="216" xml:space="preserve">╚═╝  ╚═══╝╚══════╝   ╚═╝   ╚══════╝ ╚═════╝╚══════╝╚═╝</text>
   </g>
 
-  <!-- Single subtitle line: tagline + version together, centered -->
+  <!-- Evergreen subtitle line: no embedded version, so the asset does not age out. -->
   <text x="600" y="252" class="mono text" font-size="16" text-anchor="middle">
     <tspan>A modern network scanner</tspan>
-    <tspan class="label">  ·  v0.1.0</tspan>
   </text>
 
   <!-- Tip -->
@@ -55,7 +54,7 @@
   <text x="195" y="590" class="mono" font-size="14">
     <tspan class="label">host </tspan><tspan class="value">workstation</tspan>
     <tspan class="label"> · </tspan>
-    <tspan class="label">ip </tspan><tspan class="value">192.168.1.10</tspan>
+    <tspan class="label">target </tspan><tspan class="value">workstation.local</tspan>
   </text>
   <text x="1005" y="590" class="mono" font-size="14" text-anchor="end">
     <tspan fill="#1edcff">↑ </tspan><tspan class="value">0.07</tspan><tspan class="label"> Mbps</tspan>


### PR DESCRIPTION
Superseded by #107, which uses the clean branch name `release-docs-metadata` instead of the original `codex/` prefixed branch.