### PR TITLE
Expand GUI workspace network tools

### DIFF
--- a/apps/netscli-gui/e2e/tauri-render.mjs
+++ b/apps/netscli-gui/e2e/tauri-render.mjs
@@ -22,6 +22,9 @@ import {
   exerciseSweep,
 } from './tauri-render/scenarios.mjs';
 
+const DESKTOP_WINDOW = { x: 0, y: 0, width: 1000, height: 970 };
+const NARROW_WINDOW = { width: 520, height: 720 };
+
 let tauriDriverProcess;
 let probeServer;
 
@@ -55,7 +58,7 @@ async function main() {
   const driver = await createDriver(webdriverPort, application);
 
   try {
-    await driver.manage().window().setRect({ x: 0, y: 0, width: 774, height: 970 });
+    await driver.manage().window().setRect(DESKTOP_WINDOW);
     await withElement(driver, '[data-testid="app-shell"]', 20_000);
 
     const shell = await withElement(driver, '[data-testid="app-shell"]');
@@ -118,7 +121,7 @@ async function main() {
     await assertTheme(driver, 'light');
     await saveScreenshot(driver, 'tauri-render-light.png');
 
-    await driver.manage().window().setRect({ width: 390, height: 720 });
+    await driver.manage().window().setRect(NARROW_WINDOW);
     await assertNoHorizontalOverflow(driver);
     await withElement(driver, '[data-testid="run-active-tab"]');
     await withElement(driver, '.workspace');

--- a/apps/netscli-gui/e2e/tauri-render/driver.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/driver.mjs
@@ -20,9 +20,10 @@ export function findApplication() {
 
   const appName = process.platform === 'win32' ? 'netscli-gui.exe' : 'netscli-gui';
   const candidates = [
+    process.env.CARGO_TARGET_DIR ? path.join(process.env.CARGO_TARGET_DIR, 'debug', appName) : null,
     path.join(repoRoot, 'target', 'debug', appName),
     path.join(guiRoot, 'src-tauri', 'target', 'debug', appName),
-  ];
+  ].filter(Boolean);
   const application = candidates.find((candidate) => fs.existsSync(candidate));
   if (!application) {
     throw new Error(`Could not find debug Tauri app binary. Checked: ${candidates.join(', ')}`);

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/shell.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/shell.mjs
@@ -77,9 +77,18 @@ export async function exerciseMenusAndToolbar(driver) {
     'Export Selected CSV',
     'Clear Current Results',
   ]);
-  await assertMenuItems(driver, 'Scan', ['Run Active Tab', 'Cancel Active Tab', 'Port Scan', 'Discover', 'Inspect', 'Sweep']);
+  await assertMenuItems(driver, 'Scan', [
+    'Run Active Tab',
+    'Cancel Active Tab',
+    'Port Scan',
+    'Ping',
+    'Trace Route',
+    'Discover',
+    'Inspect',
+    'Sweep',
+  ]);
   await waitForText(driver, '.menu-popover', /Operations/i);
-  await assertMenuIncludes(driver, 'Tools', ['DNS Lookup', 'Interfaces', 'ARP Table']);
+  await assertMenuIncludes(driver, 'Tools', ['DNS Lookup', 'Reverse DNS', 'mDNS Discovery', 'Interfaces', 'ARP Table']);
   await waitForText(driver, '.menu-popover', /Tools and inventory/i);
   await assertMenuItems(driver, 'History', [/netscli scan/i, 'Clear History']);
   await assertSettingsDialog(driver);

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/tools.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/tools.mjs
@@ -97,16 +97,22 @@ export async function exerciseArp(driver) {
 
 export async function exercisePcapValidation(driver) {
   await clickButtonText(driver, '.menu-button', 'Tools');
-  const pcapAvailable = await driver.executeScript(
+  const pcapVisible = await driver.executeScript(
     "return Array.from(document.querySelectorAll('.menu-popover-item')).some((button) => button.textContent.trim() === 'Packet Capture');",
   );
-  if (!pcapAvailable) {
+  if (!pcapVisible) {
     await driver.findElement(By.css('.workspace')).click();
     await waitForNoElement(driver, '.menu-popover');
     return false;
   }
   await clickButtonText(driver, '.menu-popover-item', 'Packet Capture');
   await withElement(driver, '[data-testid="pcap-interface-input"]');
+  const unavailable = await driver.findElements(By.css('[data-testid="pcap-unavailable-state"]'));
+  if (unavailable.length > 0) {
+    await waitForText(driver, '[data-testid="pcap-unavailable-state"]', /Packet Capture/i);
+    await assertNoErrorStrip(driver);
+    return false;
+  }
   const initialCommand = await driver.findElement(By.css('[data-testid="command-strip"]')).getText();
   assert.match(initialCommand, /netscli pcap/);
   if (!/--interface/.test(initialCommand)) {

--- a/apps/netscli-gui/e2e/tauri-render/ui.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/ui.mjs
@@ -76,7 +76,7 @@ export async function clickButtonText(driver, selector, label) {
 
 export async function addToolTab(driver, label) {
   const menuLabel = label === 'PCAP' ? 'Packet Capture' : label;
-  const scanOperations = new Set(['Port Scan', 'Discover', 'Inspect', 'Sweep']);
+  const scanOperations = new Set(['Port Scan', 'Ping', 'Trace Route', 'Discover', 'Inspect', 'Sweep']);
   await clickButtonText(driver, '.menu-button', scanOperations.has(menuLabel) ? 'Scan' : 'Tools');
   await clickButtonText(driver, '.menu-popover-item', menuLabel);
 }

--- a/apps/netscli-gui/src-tauri/Cargo.toml
+++ b/apps/netscli-gui/src-tauri/Cargo.toml
@@ -29,5 +29,7 @@ netscli-core = { path = "../../../crates/netscli-core", default-features = false
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem
 # DO NOT REMOVE!!
+default = ["mdns"]
 custom-protocol = ["tauri/custom-protocol"]
+mdns = ["netscli-core/mdns"]
 pcap = ["netscli-core/pcap"]

--- a/apps/netscli-gui/src-tauri/src/commands/files.rs
+++ b/apps/netscli-gui/src-tauri/src/commands/files.rs
@@ -10,6 +10,7 @@ use crate::state::ArtifactRegistry;
 
 const SAVE_SETTINGS_FILE: &str = "gui-save-settings.json";
 const LEGACY_CAPTURE_SETTINGS_FILE: &str = "gui-capture-settings.json";
+const MAX_RESULT_BUNDLE_BYTES: u64 = 25 * 1024 * 1024;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct FileSavePreferences {
@@ -46,6 +47,59 @@ pub(crate) fn export_text_file(
     std::fs::write(&path, contents).map_err(|e| format!("Failed to write export: {e}"))?;
     artifact_registry.register(&path)?;
     Ok(path.display().to_string())
+}
+
+#[tauri::command]
+pub(crate) fn save_result_bundle(
+    app: tauri::AppHandle,
+    artifact_registry: State<'_, ArtifactRegistry>,
+    contents: String,
+) -> Result<String, String> {
+    if contents.len() as u64 > MAX_RESULT_BUNDLE_BYTES {
+        return Err(format!(
+            "Result bundle is too large (max {})",
+            format_byte_limit(MAX_RESULT_BUNDLE_BYTES)
+        ));
+    }
+    let filename = format!("netscli-result-{}.netscli-result.json", timestamp_millis());
+    export_text_file(app, artifact_registry, filename, contents, None)
+}
+
+#[tauri::command]
+pub(crate) fn open_result_bundle(app: tauri::AppHandle) -> Result<serde_json::Value, String> {
+    let selected = app
+        .dialog()
+        .file()
+        .set_title("Open NetsCLI Result")
+        .add_filter("NetsCLI Result", &["json"])
+        .blocking_pick_file()
+        .ok_or_else(|| "Open result cancelled".to_string())?;
+    let path = selected
+        .into_path()
+        .map_err(|_| "Selected result is not a local filesystem path".to_string())?;
+    if !path.is_file() {
+        return Err("Result path must be a file".to_string());
+    }
+    ensure_file_size_limit(&path, MAX_RESULT_BUNDLE_BYTES, "Result bundle")?;
+    let text =
+        std::fs::read_to_string(&path).map_err(|e| format!("Failed to read result bundle: {e}"))?;
+    serde_json::from_str(&text).map_err(|e| format!("Failed to parse result bundle: {e}"))
+}
+
+pub(super) fn ensure_file_size_limit(
+    path: &Path,
+    max_bytes: u64,
+    label: &str,
+) -> Result<(), String> {
+    let metadata =
+        std::fs::metadata(path).map_err(|e| format!("Failed to inspect {label}: {e}"))?;
+    if metadata.len() > max_bytes {
+        return Err(format!(
+            "{label} is too large (max {})",
+            format_byte_limit(max_bytes)
+        ));
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -466,4 +520,13 @@ fn timestamp_millis() -> u128 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis())
         .unwrap_or_default()
+}
+
+fn format_byte_limit(bytes: u64) -> String {
+    const MIB: u64 = 1024 * 1024;
+    if bytes >= MIB && bytes.is_multiple_of(MIB) {
+        format!("{} MiB", bytes / MIB)
+    } else {
+        format!("{bytes} bytes")
+    }
 }

--- a/apps/netscli-gui/src-tauri/src/commands/mod.rs
+++ b/apps/netscli-gui/src-tauri/src/commands/mod.rs
@@ -4,11 +4,12 @@ mod operations;
 
 pub(crate) use files::{
     choose_file_save_default_directory, clear_file_save_default_directory, export_text_file,
-    get_file_save_preferences, open_saved_artifact, reveal_saved_artifact,
-    set_file_save_ask_each_time,
+    get_file_save_preferences, open_result_bundle, open_saved_artifact, reveal_saved_artifact,
+    save_result_bundle, set_file_save_ask_each_time,
 };
 pub(crate) use monitor::{get_default_interface, get_network_stats};
 pub(crate) use operations::{
-    cancel_operation, capture_pcap, discover_network, dns_lookup, get_arp_table, inspect_host_cmd,
-    list_interfaces, pcap_capability, scan_ports, sweep_network,
+    cancel_operation, capture_pcap, discover_mdns, discover_network, dns_lookup, get_arp_table,
+    inspect_host_cmd, list_interfaces, mdns_capability, open_pcap_file, pcap_capability, ping_host,
+    reverse_dns_lookup, scan_ports, sweep_network, trace_route_cmd,
 };

--- a/apps/netscli-gui/src-tauri/src/commands/operations.rs
+++ b/apps/netscli-gui/src-tauri/src/commands/operations.rs
@@ -1,12 +1,14 @@
-use std::{future::Future, sync::Arc};
+use std::{future::Future, sync::Arc, time::Duration};
 
 use netscli_core::{parse_ports_checked, Ops, PcapCancelToken};
 use tauri::{Emitter, Manager};
+use tauri_plugin_dialog::DialogExt;
 
-use super::files::resolve_gui_pcap_output_path;
+use super::files::{ensure_file_size_limit, resolve_gui_pcap_output_path};
 use crate::state::{ArtifactRegistry, OperationManager};
 
 type JsonResult = Result<serde_json::Value, String>;
+const MAX_GUI_PCAP_IMPORT_BYTES: u64 = 512 * 1024 * 1024;
 
 const OPERATION_PROGRESS_EVENT: &str = "netscli://operation-progress";
 
@@ -28,9 +30,23 @@ fn emit_operation_progress(app: &tauri::AppHandle, payload: OperationProgressPay
 
 #[derive(serde::Serialize)]
 pub(crate) struct PcapCapability {
+    compiled: bool,
     available: bool,
     interfaces: Vec<String>,
     message: Option<String>,
+}
+
+#[derive(Clone, serde::Serialize)]
+pub(crate) struct OptionalCapability {
+    compiled: bool,
+    available: bool,
+    message: Option<String>,
+}
+
+#[derive(Clone, serde::Serialize)]
+struct ReverseDnsResult {
+    ip: String,
+    hostname: Option<String>,
 }
 
 async fn run_json_operation<F, Fut>(
@@ -63,14 +79,29 @@ pub(crate) async fn pcap_capability() -> Result<PcapCapability, String> {
     let ops = Ops::default();
     Ok(match ops.pcap_check_support() {
         Ok(interfaces) => PcapCapability {
+            compiled: true,
             available: true,
             interfaces,
             message: None,
         },
         Err(error) => PcapCapability {
+            compiled: cfg!(feature = "pcap"),
             available: false,
             interfaces: Vec::new(),
             message: Some(error.to_string()),
+        },
+    })
+}
+
+#[tauri::command]
+pub(crate) async fn mdns_capability() -> Result<OptionalCapability, String> {
+    Ok(OptionalCapability {
+        compiled: cfg!(feature = "mdns"),
+        available: cfg!(feature = "mdns"),
+        message: if cfg!(feature = "mdns") {
+            None
+        } else {
+            Some("mDNS discovery is not included in this build.".to_string())
         },
     })
 }
@@ -83,6 +114,129 @@ pub(crate) async fn cancel_operation(
     // Treat missing ids as a no-op so cancellation is idempotent.
     let _ = manager.cancel(&op_id).await;
     Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn ping_host(
+    op_id: Option<String>,
+    host: String,
+    count: Option<u32>,
+    manager: tauri::State<'_, OperationManager>,
+) -> JsonResult {
+    run_json_operation(op_id, manager, None, move || async move {
+        let ops = Ops::default();
+        let count = count.unwrap_or(4).clamp(1, 64);
+        let res = ops
+            .ping_host_summary(host.trim(), count)
+            .await
+            .map_err(|e| e.to_string())?;
+        serde_json::to_value(res).map_err(|e| e.to_string())
+    })
+    .await
+}
+
+#[tauri::command]
+pub(crate) async fn trace_route_cmd(
+    app: tauri::AppHandle,
+    op_id: Option<String>,
+    host: String,
+    max_hops: Option<u32>,
+    resolve: Option<bool>,
+    manager: tauri::State<'_, OperationManager>,
+) -> JsonResult {
+    let progress = op_id.clone().map(|op_id| {
+        let app = app.clone();
+        let max_hops = max_hops.unwrap_or(30).clamp(1, 255);
+        let (tx, mut rx) = tokio::sync::watch::channel(String::new());
+        tauri::async_runtime::spawn(async move {
+            while rx.changed().await.is_ok() {
+                let detail = rx.borrow().clone();
+                if detail.trim().is_empty() {
+                    continue;
+                }
+                let completed = trace_progress_hop(&detail).unwrap_or(0) as usize;
+                emit_operation_progress(
+                    &app,
+                    OperationProgressPayload {
+                        op_id: op_id.clone(),
+                        kind: "trace",
+                        phase: Some("tracing"),
+                        completed,
+                        total: max_hops as usize,
+                        found: 0,
+                        target: None,
+                        detail: Some(detail),
+                    },
+                );
+            }
+        });
+        tx
+    });
+
+    run_json_operation(op_id, manager, None, move || async move {
+        let ops = Ops::default();
+        let res = ops
+            .trace_route_with_progress(
+                host.trim(),
+                max_hops.unwrap_or(30),
+                resolve.unwrap_or(false),
+                progress,
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+        serde_json::to_value(res).map_err(|e| e.to_string())
+    })
+    .await
+}
+
+fn trace_progress_hop(detail: &str) -> Option<u32> {
+    let rest = detail.strip_prefix("hop ")?;
+    rest.split('/').next()?.parse().ok()
+}
+
+#[tauri::command]
+pub(crate) async fn reverse_dns_lookup(
+    op_id: Option<String>,
+    ip: String,
+    manager: tauri::State<'_, OperationManager>,
+) -> JsonResult {
+    run_json_operation(op_id, manager, None, move || async move {
+        let ops = Ops::default();
+        let ip = ip.trim().to_string();
+        let hostname = ops.reverse_lookup(&ip).await.map_err(|e| e.to_string())?;
+        serde_json::to_value(ReverseDnsResult { ip, hostname }).map_err(|e| e.to_string())
+    })
+    .await
+}
+
+#[tauri::command]
+pub(crate) async fn discover_mdns(
+    op_id: Option<String>,
+    timeout_ms: Option<u64>,
+    service_types: Option<Vec<String>>,
+    manager: tauri::State<'_, OperationManager>,
+) -> JsonResult {
+    run_json_operation(op_id, manager, None, move || async move {
+        #[cfg(feature = "mdns")]
+        {
+            let ops = Ops::default();
+            let timeout_ms = timeout_ms.unwrap_or(3000).clamp(250, 30_000);
+            let service_types = service_types.unwrap_or_default();
+            let services = ops
+                .discover_mdns(&service_types, Duration::from_millis(timeout_ms))
+                .await
+                .map_err(|e| e.to_string())?;
+            serde_json::to_value(services).map_err(|e| e.to_string())
+        }
+
+        #[cfg(not(feature = "mdns"))]
+        {
+            let _ = timeout_ms;
+            let _ = service_types;
+            Err("mDNS discovery is not included in this build.".to_string())
+        }
+    })
+    .await
 }
 
 #[tauri::command]
@@ -319,4 +473,30 @@ pub(crate) async fn capture_pcap(
         serde_json::to_value(res).map_err(|e| e.to_string())
     })
     .await
+}
+
+#[tauri::command]
+pub(crate) async fn open_pcap_file(
+    app: tauri::AppHandle,
+    artifact_registry: tauri::State<'_, ArtifactRegistry>,
+    max_packets: Option<usize>,
+) -> JsonResult {
+    let path = app
+        .dialog()
+        .file()
+        .set_title("Open Packet Capture")
+        .add_filter("Packet Capture", &["pcap"])
+        .blocking_pick_file()
+        .ok_or_else(|| "Open capture cancelled".to_string())?;
+    let path = path
+        .into_path()
+        .map_err(|_| "Selected packet capture is not a local filesystem path".to_string())?;
+    ensure_file_size_limit(&path, MAX_GUI_PCAP_IMPORT_BYTES, "Packet capture")?;
+
+    let ops = Ops::default();
+    let parsed = ops
+        .parse_pcap_file(path.display().to_string(), max_packets)
+        .map_err(|e| e.to_string())?;
+    artifact_registry.register(&path)?;
+    serde_json::to_value(parsed).map_err(|e| e.to_string())
 }

--- a/apps/netscli-gui/src-tauri/src/main.rs
+++ b/apps/netscli-gui/src-tauri/src/main.rs
@@ -8,10 +8,12 @@ use std::sync::Mutex;
 
 use commands::{
     cancel_operation, capture_pcap, choose_file_save_default_directory,
-    clear_file_save_default_directory, discover_network, dns_lookup, export_text_file,
-    get_arp_table, get_default_interface, get_file_save_preferences, get_network_stats,
-    inspect_host_cmd, list_interfaces, open_saved_artifact, pcap_capability, reveal_saved_artifact,
-    scan_ports, set_file_save_ask_each_time, sweep_network,
+    clear_file_save_default_directory, discover_mdns, discover_network, dns_lookup,
+    export_text_file, get_arp_table, get_default_interface, get_file_save_preferences,
+    get_network_stats, inspect_host_cmd, list_interfaces, mdns_capability, open_pcap_file,
+    open_result_bundle, open_saved_artifact, pcap_capability, ping_host, reveal_saved_artifact,
+    reverse_dns_lookup, save_result_bundle, scan_ports, set_file_save_ask_each_time, sweep_network,
+    trace_route_cmd,
 };
 use netscli_core::NetworkMonitor;
 use state::{ArtifactRegistry, OperationManager};
@@ -50,6 +52,10 @@ fn main() {
         .manage(ArtifactRegistry::default())
         .invoke_handler(tauri::generate_handler![
             cancel_operation,
+            ping_host,
+            trace_route_cmd,
+            reverse_dns_lookup,
+            discover_mdns,
             discover_network,
             scan_ports,
             inspect_host_cmd,
@@ -57,9 +63,13 @@ fn main() {
             dns_lookup,
             list_interfaces,
             get_arp_table,
+            mdns_capability,
             pcap_capability,
             capture_pcap,
+            open_pcap_file,
             export_text_file,
+            save_result_bundle,
+            open_result_bundle,
             open_saved_artifact,
             reveal_saved_artifact,
             get_file_save_preferences,

--- a/apps/netscli-gui/src/App.css
+++ b/apps/netscli-gui/src/App.css
@@ -2,5 +2,6 @@
 @import './styles/shell.css';
 @import './styles/forms.css';
 @import './styles/results.css';
+@import './styles/pcap.css';
 @import './styles/details.css';
 @import './styles/responsive.css';

--- a/apps/netscli-gui/src/App.tsx
+++ b/apps/netscli-gui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, type MouseEvent } from 'react';
+import { useRef, useState, type MouseEvent } from 'react';
 
 import './App.css';
 
@@ -13,6 +13,7 @@ import { SettingsDialog } from './components/shell/SettingsDialog';
 import { StatusBar } from './components/shell/StatusBar';
 import { TabStrip } from './components/shell/TabStrip';
 import { Toolbar } from './components/shell/Toolbar';
+import { WorkspaceSearchDialog } from './components/shell/WorkspaceSearchDialog';
 import { DetailPane } from './components/results/DetailPane';
 import { EmptyWorkspace } from './components/results/EmptyWorkspace';
 import { OperationProgress } from './components/results/OperationProgress';
@@ -46,8 +47,12 @@ function App() {
     setOperationToasts,
     setPersistentHistory,
     setReleaseNotifications,
+    setTrafficDisplayUnit,
     setTrafficIndicators,
+    setTrafficPrecision,
+    trafficDisplayUnit,
     trafficIndicators,
+    trafficPrecision,
   } = usePreferences();
   const workspace = useWorkspace({ interactionToasts, operationToasts, persistentHistory });
   const activeTab = workspace.activeTab;
@@ -61,13 +66,16 @@ function App() {
     chooseSaveFolder,
     clearSaveFolder,
     fileSavePreferences,
-    pcapAvailable,
+    pcapCapability,
+    toolCapabilities,
     toggleFileSaveAskEachTime,
   } = useTauriRuntimeState();
   const [dismissedWarningKeys, setDismissedWarningKeys] = useState<Record<string, true>>({});
   const [aboutOpen, setAboutOpen] = useState(false);
   const [pendingRun, setPendingRun] = useState<{ tabId: string; guard: OperationGuard } | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [workspaceSearchOpen, setWorkspaceSearchOpen] = useState(false);
+  const filterInputRef = useRef<HTMLInputElement | null>(null);
 
   useReleaseNotifications({
     appVersion: APP_VERSION,
@@ -78,10 +86,23 @@ function App() {
   });
 
   usePopoverDismissal({ contentContextMenu, openMenu, setContentContextMenu, setOpenMenu });
-  useKeyboardShortcuts({ openMenu, setOpenMenu, setSettingsOpen, settingsOpen, workspace });
+  useKeyboardShortcuts({
+    focusResultFilter: () => {
+      filterInputRef.current?.focus({ preventScroll: true });
+      filterInputRef.current?.select();
+    },
+    openMenu,
+    setOpenMenu,
+    setSettingsOpen,
+    settingsOpen,
+    setWorkspaceSearchOpen,
+    workspace,
+    workspaceSearchOpen,
+  });
 
   function requestRun(tabId: string) {
     const tab = workspace.tabs.find((item) => item.id === tabId);
+    if (tab?.kind === 'pcap' && !pcapCapability.available) return;
     const guard = guardForOperation(tab);
     if (guard) {
       setPendingRun({ tabId, guard });
@@ -124,6 +145,10 @@ function App() {
   const warningMessage = !activeTab?.error ? warningMessageFor(activeTab?.result?.warnings) : null;
   const warningKey = activeTab && warningMessage ? `${activeTab.id}:${workspace.commandPreview}:${warningMessage}` : null;
   const showWarning = Boolean(warningKey && !dismissedWarningKeys[warningKey]);
+  const pcapUnavailableReason =
+    activeTab?.kind === 'pcap' && !pcapCapability.available
+      ? packetCaptureUnavailableMessage(pcapCapability.message)
+      : null;
 
   return (
     <div className={`container ${darkMode ? 'theme-dark' : 'theme-light'}`} data-testid="app-shell">
@@ -132,9 +157,9 @@ function App() {
           activeTab={activeTab}
           history={workspace.history}
           openMenu={openMenu}
-          pcapAvailable={pcapAvailable}
           setOpenMenu={setOpenMenu}
           tabCount={workspace.tabs.length}
+          toolCapabilities={toolCapabilities}
           onAddTab={workspace.addTab}
           onAbout={() => setAboutOpen(true)}
           onOpenSettings={() => setSettingsOpen(true)}
@@ -153,6 +178,8 @@ function App() {
           onExport={workspace.exportCurrent}
           onExportSelectedJson={workspace.exportSelectedJson}
           onExportSelectedCsv={workspace.exportSelectedCsv}
+          onOpenResultBundle={() => void workspace.openResultBundle()}
+          onSaveResultBundle={() => void workspace.saveResultBundle()}
           onOpenHistoryEntry={workspace.openHistoryEntry}
           onRunActive={runActive}
         />
@@ -160,6 +187,7 @@ function App() {
 
       <Toolbar
         activeTab={activeTab}
+        filterInputRef={filterInputRef}
         filterText={workspace.filterText}
         openMenu={openMenu}
         setOpenMenu={setOpenMenu}
@@ -168,13 +196,14 @@ function App() {
         onExportCsv={() => workspace.exportCurrent('csv')}
         onExportJson={() => workspace.exportCurrent('json')}
         onRunActive={runActive}
+        runDisabledReason={pcapUnavailableReason ?? undefined}
       />
 
       <TabStrip
         activeTabId={workspace.activeTabId}
         openMenu={openMenu}
-        pcapAvailable={pcapAvailable}
         tabs={workspace.tabs}
+        toolCapabilities={toolCapabilities}
         onAddScanTab={() => workspace.addTab('scan')}
         onAddToolTab={workspace.addTab}
         onCloseTab={workspace.closeTab}
@@ -201,12 +230,12 @@ function App() {
                 onDismiss={() => setDismissedWarningKeys((prev) => ({ ...prev, [warningKey]: true }))}
               />
             ) : null}
-            {activeTab.busy && <OperationProgress tab={activeTab} />}
-
             <section className="result-region">
+              {activeTab.busy && <OperationProgress tab={activeTab} />}
               <ResultTable
                 activeTab={activeTab}
                 columns={workspace.columns}
+                pcapCapability={pcapCapability}
                 rows={workspace.rows}
                 onContentContextMenu={openContentContextMenu}
                 onSelectAllRows={workspace.selectAllRows}
@@ -230,7 +259,7 @@ function App() {
           </>
         ) : (
           <EmptyWorkspace
-            pcapAvailable={pcapAvailable}
+            toolCapabilities={toolCapabilities}
             onAddToolTab={workspace.addTab}
           />
         )}
@@ -243,6 +272,8 @@ function App() {
         networkStats={workspace.networkStats}
         rowCount={workspace.rows.length}
         selectedCount={workspace.selectedRows.length}
+        trafficDisplayUnit={trafficDisplayUnit}
+        trafficPrecision={trafficPrecision}
       />
 
       <ToastHost
@@ -282,13 +313,17 @@ function App() {
           operationToasts={operationToasts}
           persistentHistory={persistentHistory}
           releaseNotifications={releaseNotifications}
+          trafficDisplayUnit={trafficDisplayUnit}
           fileSavePreferences={fileSavePreferences}
+          trafficPrecision={trafficPrecision}
           trafficInterfaceName={workspace.trafficInterfaceName}
           onClose={() => setSettingsOpen(false)}
           onChooseSaveFolder={() => void chooseSaveFolder()}
           onClearSaveFolder={() => void clearSaveFolder()}
           onSelectTrafficInterface={workspace.setTrafficInterfaceName}
           onSetDarkMode={setDarkMode}
+          onSetTrafficDisplayUnit={setTrafficDisplayUnit}
+          onSetTrafficPrecision={setTrafficPrecision}
           onToggleFileSaveAskEachTime={() => void toggleFileSaveAskEachTime()}
           onToggleInteractionToasts={() => setInteractionToasts((prev) => !prev)}
           onToggleOperationToasts={() => setOperationToasts((prev) => !prev)}
@@ -296,6 +331,19 @@ function App() {
           onToggleReleaseNotifications={() => setReleaseNotifications((prev) => !prev)}
           onToggleCommandBar={() => setCommandBarVisible((prev) => !prev)}
           onToggleTrafficArrowAnimation={() => setTrafficIndicators((prev) => !prev)}
+        />
+      )}
+      {workspaceSearchOpen && (
+        <WorkspaceSearchDialog
+          history={workspace.history}
+          tabs={workspace.tabs}
+          onClose={() => setWorkspaceSearchOpen(false)}
+          onOpenHistoryEntry={workspace.openHistoryEntry}
+          onSelectTab={workspace.setActiveTabId}
+          onSelectRow={(tabId, rowIndex) => {
+            workspace.setActiveTabId(tabId);
+            window.setTimeout(() => workspace.selectRow(rowIndex), 0);
+          }}
         />
       )}
       {aboutOpen && <AboutDialog appVersion={APP_VERSION} onClose={() => setAboutOpen(false)} />}
@@ -315,6 +363,13 @@ function App() {
       <AppTooltip />
     </div>
   );
+}
+
+function packetCaptureUnavailableMessage(message?: string | null): string {
+  if (message?.includes("built without feature 'pcap'")) {
+    return 'Packet Capture is not included in this build.';
+  }
+  return 'Packet Capture needs Npcap/libpcap before it can run.';
 }
 
 export default App;

--- a/apps/netscli-gui/src/components/results/DetailPane.tsx
+++ b/apps/netscli-gui/src/components/results/DetailPane.tsx
@@ -1,5 +1,7 @@
 import { ChevronDown, ChevronUp, Square } from 'lucide-react';
 import {
+  useEffect,
+  useRef,
   useState,
   type KeyboardEvent,
   type MouseEvent as ReactMouseEvent,
@@ -92,7 +94,20 @@ export function DetailPane({
   const activeDetail = tabSet.includes(activeTab.detailTab) ? activeTab.detailTab : tabSet[0];
   const [height, setHeight] = useState(184);
   const [mode, setMode] = useState<'normal' | 'collapsed' | 'expanded'>('normal');
+  const detailBodyRef = useRef<HTMLDivElement | null>(null);
+  const [overflow, setOverflow] = useState({
+    top: false,
+    right: false,
+    bottom: false,
+    left: false,
+    vertical: false,
+    horizontal: false,
+  });
   const flexBasis = mode === 'collapsed' ? 35 : mode === 'expanded' ? 'min(62vh, 560px)' : height;
+
+  useEffect(() => {
+    updateDetailOverflowState(detailBodyRef.current, setOverflow);
+  }, [activeDetail, activeTab.result, mode, selectedCount, selectedRow?.id]);
 
   return (
     <div
@@ -134,7 +149,7 @@ export function DetailPane({
             data-tooltip={mode === 'expanded' ? 'Restore Details Size' : 'Maximize Details Pane'}
             onClick={() => setMode(mode === 'expanded' ? 'normal' : 'expanded')}
           >
-            <Square size={12} />
+            <Square size={mode === 'expanded' ? 10 : 12} />
           </button>
           <button
             aria-label={mode === 'collapsed' ? 'Open Details Pane' : 'Collapse Details Pane'}
@@ -147,10 +162,20 @@ export function DetailPane({
       </div>
       {mode !== 'collapsed' && (
         <div
-          className="detail-body"
+          className={[
+            'detail-body',
+            overflow.vertical ? 'has-vertical-overflow' : '',
+            overflow.horizontal ? 'has-horizontal-overflow' : '',
+            overflow.top ? 'has-top-overflow' : '',
+            overflow.right ? 'has-right-overflow' : '',
+            overflow.bottom ? 'has-bottom-overflow' : '',
+            overflow.left ? 'has-left-overflow' : '',
+          ].filter(Boolean).join(' ')}
+          ref={detailBodyRef}
           tabIndex={0}
           onContextMenu={onContentContextMenu}
           onKeyDown={selectDetailBodyOnShortcut}
+          onScroll={() => updateDetailOverflowState(detailBodyRef.current, setOverflow)}
           onMouseDown={(event) => {
             event.currentTarget.focus({ preventScroll: true });
           }}
@@ -183,6 +208,27 @@ export function DetailPane({
       )}
     </div>
   );
+}
+
+function updateDetailOverflowState(
+  element: HTMLDivElement | null,
+  setOverflow: (state: {
+    top: boolean;
+    right: boolean;
+    bottom: boolean;
+    left: boolean;
+    vertical: boolean;
+    horizontal: boolean;
+  }) => void,
+) {
+  if (!element) return;
+  const vertical = element.scrollHeight > element.clientHeight + 1;
+  const horizontal = element.scrollWidth > element.clientWidth + 1;
+  const top = element.scrollTop > 1;
+  const left = element.scrollLeft > 1;
+  const bottom = element.scrollTop + element.clientHeight < element.scrollHeight - 1;
+  const right = element.scrollLeft + element.clientWidth < element.scrollWidth - 1;
+  setOverflow({ top, right, bottom, left, vertical, horizontal });
 }
 
 function selectionBreakdownLines(rows: ResultRow[], columns: ResultColumn[]): Array<{ label: string; value: string; muted?: boolean }> {

--- a/apps/netscli-gui/src/components/results/EmptyWorkspace.tsx
+++ b/apps/netscli-gui/src/components/results/EmptyWorkspace.tsx
@@ -2,18 +2,18 @@ import { Search, Terminal, Wrench } from 'lucide-react';
 import { useRef, useState } from 'react';
 
 import { availableToolKinds, LOOKUP_TOOL_KINDS, SCAN_TOOL_KINDS, TOOL_CONFIG } from '../../tools/registry';
-import type { ToolKind } from '../../tools/types';
+import type { ToolCapabilityMap, ToolKind } from '../../tools/types';
 import { useRovingFocus } from '../primitives/focus';
 import { useOverlayDismiss } from '../primitives/overlay';
 
 interface EmptyWorkspaceProps {
-  pcapAvailable: boolean;
+  toolCapabilities: ToolCapabilityMap;
   onAddToolTab: (kind: ToolKind) => void;
 }
 
 type PickerKind = 'scan' | 'tool';
 
-export function EmptyWorkspace({ onAddToolTab, pcapAvailable }: EmptyWorkspaceProps) {
+export function EmptyWorkspace({ onAddToolTab, toolCapabilities }: EmptyWorkspaceProps) {
   const [pickerKind, setPickerKind] = useState<PickerKind | null>(null);
   const pickerRef = useRef<HTMLDivElement | null>(null);
   const pickerPanelRef = useRef<HTMLDivElement | null>(null);
@@ -34,7 +34,7 @@ export function EmptyWorkspace({ onAddToolTab, pcapAvailable }: EmptyWorkspacePr
   const pickerConfig =
     pickerKind === 'scan'
       ? { kinds: SCAN_TOOL_KINDS, label: 'Scan Operations' }
-      : { kinds: availableToolKinds(LOOKUP_TOOL_KINDS, pcapAvailable), label: 'Lookups and Inventory' };
+      : { kinds: availableToolKinds(LOOKUP_TOOL_KINDS, toolCapabilities), label: 'Lookups and Inventory' };
 
   function togglePicker(kind: PickerKind) {
     setPickerKind((current) => (current === kind ? null : kind));

--- a/apps/netscli-gui/src/components/results/OperationProgress.tsx
+++ b/apps/netscli-gui/src/components/results/OperationProgress.tsx
@@ -35,20 +35,28 @@ function operationTitle(tab: WorkspaceTab): string {
   switch (tab.kind) {
     case 'scan':
       return 'Scanning ports';
+    case 'ping':
+      return 'Pinging host';
+    case 'trace':
+      return 'Tracing route';
     case 'discover':
       return 'Discovering hosts';
     case 'dns':
       return 'Resolving DNS records';
+    case 'reverse':
+      return 'Resolving reverse DNS';
     case 'inspect':
       return 'Inspecting host';
     case 'sweep':
       return 'Sweeping network';
+    case 'mdns':
+      return 'Discovering mDNS services';
     case 'interfaces':
       return 'Refreshing interfaces';
     case 'arp':
       return 'Reading ARP table';
     case 'pcap':
-      return 'Capturing packets';
+      return tab.form.mode === 'Open File' ? 'Opening packet capture' : 'Capturing packets';
   }
 }
 
@@ -56,20 +64,32 @@ function operationDetail(tab: WorkspaceTab): string {
   switch (tab.kind) {
     case 'scan':
       return `${tab.form.host || 'host'} across ${countList(tab.form.ports)} ports`;
+    case 'ping':
+      return `${tab.form.host || 'host'} with ${tab.form.count || '4'} probes`;
+    case 'trace':
+      return `${tab.form.host || 'host'} up to ${tab.form.max_hops || '30'} hops`;
     case 'discover':
       return `${tab.form.subnet || 'selected subnet'} with host discovery probes`;
     case 'dns':
       return `${tab.form.record || 'ALL'} records for ${tab.form.host || 'host'}`;
+    case 'reverse':
+      return `Reverse lookup for ${tab.form.ip || 'IP address'}`;
     case 'inspect':
       return `${tab.form.host || 'host'} with ${countList(tab.form.ports)} port probes`;
     case 'sweep':
       return `${tab.form.subnet || 'selected subnet'} across ${countList(tab.form.ports)} ports per host`;
+    case 'mdns':
+      return tab.form.service_types?.trim()
+        ? `Listening for ${tab.form.service_types}`
+        : 'Listening for local service announcements';
     case 'interfaces':
       return 'Collecting local interface state and addresses';
     case 'arp':
       return 'Collecting local neighbor entries and vendor names';
     case 'pcap':
-      return `${tab.form.interface || 'selected interface'}, up to ${tab.form.max_packets || '1000'} packets`;
+      return tab.form.mode === 'Open File'
+        ? `Parsing up to ${tab.form.max_packets || '1000'} packets`
+        : `${tab.form.interface || 'selected interface'}, up to ${tab.form.max_packets || '1000'} packets`;
   }
 }
 

--- a/apps/netscli-gui/src/components/results/PcapUnavailableState.tsx
+++ b/apps/netscli-gui/src/components/results/PcapUnavailableState.tsx
@@ -1,0 +1,30 @@
+import { AlertTriangle, ExternalLink } from 'lucide-react';
+
+import { openAllowedExternalUrl } from '../../services/externalLinks';
+import type { PcapCapability } from '../../types/netscli';
+
+export function PcapUnavailableState({ capability }: { capability: PcapCapability }) {
+  const buildWithoutPcap = !capability.compiled || capability.message?.includes("built without feature 'pcap'");
+  const title = buildWithoutPcap ? 'Packet Capture is not included in this build' : 'Packet Capture needs a capture driver';
+  const body = buildWithoutPcap
+    ? 'Use a PCAP-enabled NetsCLI Desktop build. On Windows, Npcap is also required before captures can run.'
+    : 'Install Npcap on Windows, or libpcap on Linux/macOS, then restart NetsCLI and open Packet Capture again.';
+
+  return (
+    <div className="pcap-unavailable" data-testid="pcap-unavailable-state">
+      <AlertTriangle size={24} />
+      <div className="pcap-unavailable-copy">
+        <h2>{title}</h2>
+        <p>{body}</p>
+        {capability.message ? <code>{capability.message}</code> : null}
+      </div>
+      <button
+        type="button"
+        onClick={() => void openAllowedExternalUrl('https://github.com/fstubner/netscli#packet-capture')}
+      >
+        <ExternalLink size={14} />
+        <span>Open setup docs</span>
+      </button>
+    </div>
+  );
+}

--- a/apps/netscli-gui/src/components/results/ResultTable.tsx
+++ b/apps/netscli-gui/src/components/results/ResultTable.tsx
@@ -13,11 +13,14 @@ import {
 
 import { copyContextForCell, renderValue } from '../../tools/presentation';
 import type { ResultCellContext, ResultColumn, ResultRow, RowSelectionMode, WorkspaceTab } from '../../tools/types';
+import type { PcapCapability } from '../../types/netscli';
+import { PcapUnavailableState } from './PcapUnavailableState';
 import { StatusPill } from './StatusPill';
 
 interface ResultTableProps {
   activeTab: WorkspaceTab;
   columns: ResultColumn[];
+  pcapCapability?: PcapCapability;
   rows: ResultRow[];
   onContentContextMenu: (event: MouseEvent<HTMLElement>, cell?: ResultCellContext) => void;
   onSelectAllRows: () => void;
@@ -28,6 +31,7 @@ interface ResultTableProps {
 export function ResultTable({
   activeTab,
   columns,
+  pcapCapability,
   rows,
   onContentContextMenu,
   onSelectAllRows,
@@ -36,7 +40,14 @@ export function ResultTable({
 }: ResultTableProps) {
   const tableShellRef = useRef<HTMLDivElement | null>(null);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
-  const [overflow, setOverflow] = useState({ top: false, bottom: false, vertical: false });
+  const [overflow, setOverflow] = useState({
+    top: false,
+    right: false,
+    bottom: false,
+    left: false,
+    vertical: false,
+    horizontal: false,
+  });
   const effectiveColumns = useMemo(
     () => columns.map((column) => ({ ...column, width: columnWidths[column.key] ?? column.width })),
     [columns, columnWidths],
@@ -57,6 +68,10 @@ export function ResultTable({
   }, [rows.length, activeTab.result]);
 
   if (!activeTab.result) {
+    if (activeTab.kind === 'pcap' && !activeTab.result && pcapCapability && !pcapCapability.available) {
+      return <PcapUnavailableState capability={pcapCapability} />;
+    }
+
     return (
       <div className="empty-workspace" tabIndex={0} onContextMenu={onContentContextMenu}>
         <Terminal size={28} />
@@ -71,8 +86,11 @@ export function ResultTable({
       className={[
         'table-shell',
         overflow.vertical ? 'has-vertical-overflow' : '',
+        overflow.horizontal ? 'has-horizontal-overflow' : '',
         overflow.top ? 'has-top-overflow' : '',
+        overflow.right ? 'has-right-overflow' : '',
         overflow.bottom ? 'has-bottom-overflow' : '',
+        overflow.left ? 'has-left-overflow' : '',
       ].filter(Boolean).join(' ')}
       data-testid="result-table"
       ref={tableShellRef}
@@ -83,6 +101,10 @@ export function ResultTable({
       onContextMenu={onContentContextMenu}
       onKeyDown={(event) => handleTableKeyDown(event, activeTab.selectedIndex, rows.length, onSelectAllRows, onSelectRow)}
     >
+      <span className="table-overflow-shadow top" aria-hidden="true" />
+      <span className="table-overflow-shadow right" aria-hidden="true" />
+      <span className="table-overflow-shadow bottom" aria-hidden="true" />
+      <span className="table-overflow-shadow left" aria-hidden="true" />
       <table className="result-table">
         <colgroup>
           {effectiveColumns.map((column) => (
@@ -189,13 +211,23 @@ function openCellContextMenu(
 
 function updateOverflowState(
   element: HTMLDivElement | null,
-  setOverflow: (state: { top: boolean; bottom: boolean; vertical: boolean }) => void,
+  setOverflow: (state: {
+    top: boolean;
+    right: boolean;
+    bottom: boolean;
+    left: boolean;
+    vertical: boolean;
+    horizontal: boolean;
+  }) => void,
 ) {
   if (!element) return;
   const vertical = element.scrollHeight > element.clientHeight + 1;
+  const horizontal = element.scrollWidth > element.clientWidth + 1;
   const top = element.scrollTop > 1;
+  const left = element.scrollLeft > 1;
   const bottom = element.scrollTop + element.clientHeight < element.scrollHeight - 1;
-  setOverflow({ top, bottom, vertical });
+  const right = element.scrollLeft + element.clientWidth < element.scrollWidth - 1;
+  setOverflow({ top, right, bottom, left, vertical, horizontal });
 }
 
 function handleColumnResizeKeyDown(

--- a/apps/netscli-gui/src/components/results/StatusPill.tsx
+++ b/apps/netscli-gui/src/components/results/StatusPill.tsx
@@ -31,6 +31,12 @@ function statusExplanation(value: unknown): string {
       return 'Interface or host is reachable/up.';
     case 'down':
       return 'Interface or host is unavailable/down.';
+    case 'reply':
+      return 'Reply: this hop responded to the trace probe.';
+    case 'timeout':
+      return 'Timeout: this hop did not respond before the trace timeout.';
+    case 'note':
+      return 'Trace output note from the system trace tool.';
     default:
       return renderValue(value);
   }

--- a/apps/netscli-gui/src/components/shell/MenuBar.tsx
+++ b/apps/netscli-gui/src/components/shell/MenuBar.tsx
@@ -6,11 +6,13 @@ import {
   Download,
   FileSpreadsheet,
   FilePlus,
+  FolderOpen,
   PanelTopClose,
   History as HistoryIcon,
   Info,
   LogOut,
   Play,
+  Save,
   Square,
   SquareX,
   Trash2,
@@ -20,7 +22,7 @@ import {
 import { useEffect, useRef } from 'react';
 
 import { availableToolKinds, LOOKUP_TOOL_KINDS, SCAN_TOOL_KINDS, TOOL_CONFIG } from '../../tools/registry';
-import type { HistoryEntry, ToolKind, WorkspaceTab } from '../../tools/types';
+import type { HistoryEntry, ToolCapabilityMap, ToolKind, WorkspaceTab } from '../../tools/types';
 import { useRovingFocus } from '../primitives/focus';
 import { useAnchoredPopoverPosition, useOverlayDismiss } from '../primitives/overlay';
 import { NetsCliMenuMark } from './NetsCliMenuMark';
@@ -45,9 +47,9 @@ interface MenuBarProps {
   activeTab: WorkspaceTab | undefined;
   history: HistoryEntry[];
   openMenu: string | null;
-  pcapAvailable: boolean;
   setOpenMenu: (menu: string | null) => void;
   tabCount: number;
+  toolCapabilities: ToolCapabilityMap;
   onAddTab: (kind: ToolKind) => void;
   onAbout: () => void;
   onOpenSettings: () => void;
@@ -64,6 +66,8 @@ interface MenuBarProps {
   onExport: (format: 'json' | 'csv') => void;
   onExportSelectedJson: () => void;
   onExportSelectedCsv: () => void;
+  onOpenResultBundle: () => void;
+  onSaveResultBundle: () => void;
   onOpenHistoryEntry: (entry: HistoryEntry) => void;
   onRunActive: () => void;
 }
@@ -72,9 +76,9 @@ export function MenuBar({
   activeTab,
   history,
   openMenu,
-  pcapAvailable,
   setOpenMenu,
   tabCount,
+  toolCapabilities,
   onAddTab,
   onAbout,
   onOpenSettings,
@@ -91,6 +95,8 @@ export function MenuBar({
   onExport,
   onExportSelectedJson,
   onExportSelectedCsv,
+  onOpenResultBundle,
+  onSaveResultBundle,
   onOpenHistoryEntry,
   onRunActive,
 }: MenuBarProps) {
@@ -160,6 +166,8 @@ export function MenuBar({
               disabled: !activeTab || tabCount <= 1,
             },
             { label: 'Close All Tabs', Icon: SquareX, action: onCloseAllTabs, disabled: tabCount === 0 },
+            { label: 'Open Result Bundle', Icon: FolderOpen, action: onOpenResultBundle },
+            { label: 'Save Result Bundle', Icon: Save, action: onSaveResultBundle, disabled: !activeTab?.result },
             { label: 'Export JSON', Icon: Download, action: () => onExport('json'), disabled: !activeTab?.result },
             { label: 'Export CSV', Icon: Download, action: () => onExport('csv'), disabled: !activeTab?.result },
           ],
@@ -229,7 +237,7 @@ export function MenuBar({
       sections: [
         {
           label: 'Tools and Inventory',
-          items: availableToolKinds(LOOKUP_TOOL_KINDS, pcapAvailable).map(makeToolItem),
+          items: availableToolKinds(LOOKUP_TOOL_KINDS, toolCapabilities).map(makeToolItem),
         },
       ],
     },
@@ -350,7 +358,7 @@ export function MenuBar({
                       }}
                     >
                       <item.Icon size={14} />
-                      {item.label}
+                      <span className="menu-popover-item-label">{item.label}</span>
                     </button>
                   ))}
                 </div>

--- a/apps/netscli-gui/src/components/shell/SettingsControls.tsx
+++ b/apps/netscli-gui/src/components/shell/SettingsControls.tsx
@@ -41,29 +41,42 @@ interface NetworkInterfacePickerProps {
   defaultInterface: DefaultInterfaceInfo | null;
   interfaces: InterfaceInfo[];
   selectedName: string | null;
+  compact?: boolean;
   onSelect: (name: string) => void;
 }
 
-export function NetworkInterfacePicker({
-  defaultInterface,
-  interfaces,
-  selectedName,
+interface SettingsSelectOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+interface SettingsSelectProps {
+  label: string;
+  options: SettingsSelectOption[];
+  testId: string;
+  value: string;
+  onSelect: (value: string) => void;
+}
+
+export function SettingsSelect({
+  label,
+  options,
+  testId,
+  value,
   onSelect,
-}: NetworkInterfacePickerProps) {
+}: SettingsSelectProps) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
-  const selectedInterface = interfaces.find((iface) => iface.name === selectedName);
-  const selectedInterfaceName = selectedInterface?.name ?? selectedName ?? '';
-  const selectedInterfaceDetail = selectedInterface
-    ? formatInterfaceDetail(selectedInterface)
-    : 'Detecting...';
+  const selectedOption = options.find((option) => option.value === value) ?? options[0];
   const position = useAnchoredPopoverPosition({
+    align: 'end',
     anchorRef: triggerRef,
-    estimatedHeight: 280,
+    estimatedHeight: 180,
     open,
     panelRef: listRef,
-    width: 620,
+    width: 190,
   });
 
   useOverlayDismiss({
@@ -81,7 +94,90 @@ export function NetworkInterfacePicker({
   });
 
   return (
-    <div className="settings-interface-field">
+    <div className="settings-select-field">
+      <button
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label={label}
+        className={`settings-select-trigger ${open ? 'active' : ''}`}
+        data-testid={testId}
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            setOpen(true);
+          }
+        }}
+      >
+        <span>{selectedOption?.label ?? value}</span>
+        <ChevronDown size={13} />
+      </button>
+      {open && (
+        <div
+          aria-label={label}
+          className="settings-select-list"
+          ref={listRef}
+          role="listbox"
+          style={position}
+          tabIndex={-1}
+          onKeyDown={onListKeyDown}
+        >
+          {options.map((option) => (
+            <button
+              aria-selected={option.value === value}
+              className={option.value === value ? 'selected' : ''}
+              key={option.value}
+              role="option"
+              type="button"
+              onClick={() => {
+                onSelect(option.value);
+                setOpen(false);
+              }}
+            >
+              <span className="settings-select-option-label">{option.label}</span>
+              {option.description ? <small>{option.description}</small> : null}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function NetworkInterfacePicker({
+  defaultInterface,
+  interfaces,
+  selectedName,
+  compact = false,
+  onSelect,
+}: NetworkInterfacePickerProps) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const selectedInterface = interfaces.find((iface) => iface.name === selectedName);
+  const selectedInterfaceName = selectedInterface?.name ?? selectedName ?? '';
+  const selectedInterfaceDetail = selectedInterface
+    ? compact ? formatInterfaceMeta(selectedInterface, selectedInterface.name === defaultInterface?.name, true) : formatInterfaceDetail(selectedInterface)
+    : 'Detecting...';
+
+  useOverlayDismiss({
+    enabled: open,
+    onClose: () => setOpen(false),
+    refs: [triggerRef, listRef],
+    restoreFocusRef: triggerRef,
+  });
+
+  const onListKeyDown = useRovingFocus({
+    containerRef: listRef,
+    enabled: open,
+    itemSelector: 'button[role="option"]',
+    onClose: () => setOpen(false),
+  });
+
+  return (
+    <div className={`settings-interface-field ${compact ? 'compact' : ''}`}>
       <button
         aria-expanded={open}
         aria-haspopup="listbox"
@@ -96,14 +192,16 @@ export function NetworkInterfacePicker({
           if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
             event.preventDefault();
             setOpen(true);
+          } else if (event.key === 'Escape') {
+            setOpen(false);
           }
         }}
       >
         <span>
-          <span>Network Interface</span>
+          <span>{compact ? selectedInterfaceName || 'Detecting...' : 'Network Interface'}</span>
           <small>
             {selectedInterfaceName
-              ? `${selectedInterfaceName} - ${selectedInterfaceDetail}`
+              ? compact ? selectedInterfaceDetail : `${selectedInterfaceName} - ${selectedInterfaceDetail}`
               : 'Detecting...'}
           </small>
         </span>
@@ -115,7 +213,6 @@ export function NetworkInterfacePicker({
           className="settings-interface-list"
           ref={listRef}
           role="listbox"
-          style={position}
           tabIndex={-1}
           onKeyDown={onListKeyDown}
         >
@@ -141,10 +238,14 @@ export function NetworkInterfacePicker({
               >
                 <span className="settings-interface-main">
                   <span>{iface.name}</span>
-                  <small>{formatInterfaceDetail(iface)}</small>
+                  <small>{compact ? formatInterfaceMeta(iface, isDefault, selected) : formatInterfaceDetail(iface)}</small>
                 </span>
                 <span className="settings-interface-badges">
-                  {isDefault && <span className="settings-interface-badge">Default</span>}
+                  <span className={`settings-interface-status ${iface.is_up ? 'up' : 'down'}`}>
+                    <span aria-hidden="true" />
+                    {iface.is_up ? 'Up' : 'Down'}
+                  </span>
+                  {isDefault && <span className="settings-interface-badge">Primary</span>}
                   {selected && (
                     <span className="settings-interface-badge selected">
                       <Check size={11} />
@@ -165,4 +266,12 @@ function formatInterfaceDetail(iface: InterfaceInfo): string {
   const status = iface.is_up ? 'Up' : 'Down';
   const addresses = iface.ips.length > 0 ? iface.ips.slice(0, 2).join(', ') : 'No address';
   return `${addresses} - ${status}`;
+}
+
+function formatInterfaceMeta(iface: InterfaceInfo, isDefault: boolean, selected: boolean): string {
+  return [
+    selected ? 'Selected' : '',
+    isDefault ? 'Primary' : '',
+    iface.is_up ? 'Up' : 'Down',
+  ].filter(Boolean).join(' - ');
 }

--- a/apps/netscli-gui/src/components/shell/SettingsDialog.tsx
+++ b/apps/netscli-gui/src/components/shell/SettingsDialog.tsx
@@ -11,8 +11,9 @@ import {
 } from 'lucide-react';
 
 import type { DefaultInterfaceInfo, FileSavePreferences, InterfaceInfo } from '../../types/netscli';
+import type { TrafficDisplayUnit, TrafficPrecision } from '../../hooks/usePreferences';
 import { useModalFocus } from '../primitives/focus';
-import { NetworkInterfacePicker, SettingsSwitch } from './SettingsControls';
+import { NetworkInterfacePicker, SettingsSelect, SettingsSwitch } from './SettingsControls';
 
 interface SettingsDialogProps {
   animateTrafficArrows: boolean;
@@ -25,12 +26,16 @@ interface SettingsDialogProps {
   operationToasts: boolean;
   persistentHistory: boolean;
   releaseNotifications: boolean;
+  trafficDisplayUnit: TrafficDisplayUnit;
   trafficInterfaceName: string | null;
+  trafficPrecision: TrafficPrecision;
   onClose: () => void;
   onChooseSaveFolder: () => void;
   onClearSaveFolder: () => void;
   onSelectTrafficInterface: (name: string) => void;
   onSetDarkMode: (enabled: boolean) => void;
+  onSetTrafficDisplayUnit: (unit: TrafficDisplayUnit) => void;
+  onSetTrafficPrecision: (precision: TrafficPrecision) => void;
   onToggleFileSaveAskEachTime: () => void;
   onToggleInteractionToasts: () => void;
   onToggleOperationToasts: () => void;
@@ -51,12 +56,16 @@ export function SettingsDialog({
   operationToasts,
   persistentHistory,
   releaseNotifications,
+  trafficDisplayUnit,
   trafficInterfaceName,
+  trafficPrecision,
   onClose,
   onChooseSaveFolder,
   onClearSaveFolder,
   onSelectTrafficInterface,
   onSetDarkMode,
+  onSetTrafficDisplayUnit,
+  onSetTrafficPrecision,
   onToggleFileSaveAskEachTime,
   onToggleInteractionToasts,
   onToggleOperationToasts,
@@ -216,12 +225,53 @@ export function SettingsDialog({
               testId="settings-activity-animation-toggle"
               onClick={onToggleTrafficArrowAnimation}
             />
-            <NetworkInterfacePicker
-              defaultInterface={defaultInterface}
-              interfaces={interfaces}
-              selectedName={trafficInterfaceName}
-              onSelect={onSelectTrafficInterface}
-            />
+            <div className="settings-row">
+              <div className="settings-row-copy">
+                <span>Traffic Units</span>
+                <small>Unit shown beside status-bar upload and download rates.</small>
+              </div>
+              <SettingsSelect
+                label="Traffic Units"
+                testId="settings-traffic-unit"
+                value={trafficDisplayUnit}
+                options={[
+                  { value: 'Gbps', label: 'Gbps' },
+                  { value: 'Mbps', label: 'Mbps' },
+                  { value: 'Kbps', label: 'Kbps' },
+                ]}
+                onSelect={(value) => onSetTrafficDisplayUnit(value as TrafficDisplayUnit)}
+              />
+            </div>
+            <div className="settings-row">
+              <div className="settings-row-copy">
+                <span>Traffic Precision</span>
+                <small>Decimal places for status-bar traffic rates.</small>
+              </div>
+              <SettingsSelect
+                label="Traffic Precision"
+                testId="settings-traffic-precision"
+                value={String(trafficPrecision)}
+                options={[
+                  { value: '0', label: '0 decimals' },
+                  { value: '1', label: '1 decimal' },
+                  { value: '2', label: '2 decimals' },
+                ]}
+                onSelect={(value) => onSetTrafficPrecision(Number(value) as TrafficPrecision)}
+              />
+            </div>
+            <div className="settings-row">
+              <div className="settings-row-copy">
+                <span>Network Interface</span>
+                <small>Interface used for status-bar traffic rates.</small>
+              </div>
+              <NetworkInterfacePicker
+                compact
+                defaultInterface={defaultInterface}
+                interfaces={interfaces}
+                selectedName={trafficInterfaceName}
+                onSelect={onSelectTrafficInterface}
+              />
+            </div>
           </section>
         </div>
       </section>

--- a/apps/netscli-gui/src/components/shell/StatusBar.tsx
+++ b/apps/netscli-gui/src/components/shell/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { ArrowDown, ArrowUp } from 'lucide-react';
 
 import type { DefaultInterfaceInfo, NetworkStats } from '../../types/netscli';
+import type { TrafficDisplayUnit, TrafficPrecision } from '../../hooks/usePreferences';
 import { resultSummary } from '../../tools/presentation';
 import { TOOL_CONFIG } from '../../tools/registry';
 import type { WorkspaceTab } from '../../tools/types';
@@ -12,6 +13,8 @@ interface StatusBarProps {
   networkStats: NetworkStats | null;
   rowCount: number;
   selectedCount: number;
+  trafficDisplayUnit: TrafficDisplayUnit;
+  trafficPrecision: TrafficPrecision;
 }
 
 export function StatusBar({
@@ -21,6 +24,8 @@ export function StatusBar({
   networkStats,
   rowCount,
   selectedCount,
+  trafficDisplayUnit,
+  trafficPrecision,
 }: StatusBarProps) {
   const interfaceDown = Boolean(interfaceInfo && !interfaceInfo.is_up);
   const statusText = interfaceInfo ? (interfaceDown ? 'Interface down' : 'Interface up') : 'No interface';
@@ -30,19 +35,29 @@ export function StatusBar({
   return (
     <footer className="statusbar" data-testid="statusbar">
       <div className="status-left">
-        <span className={`run-dot ${interfaceDown ? 'down' : ''}`} />
-        <span>{statusText}</span>
+        <span
+          aria-label={statusText}
+          className={`run-dot ${interfaceDown ? 'down' : ''}`}
+          data-tooltip={statusText}
+          role="img"
+        />
+        <span className="status-text">{statusText}</span>
         {interfaceInfo && (
           <>
             <span className="divider" />
-            <span>{interfaceInfo.name}</span>
-            <code>{interfaceInfo.ips[0] ?? 'no address'}</code>
+            <span className="status-interface-name">{interfaceInfo.name}</span>
+            <code className="status-interface-address">{interfaceInfo.ips[0] ?? 'no address'}</code>
           </>
         )}
         {networkStats && (
           <>
             <span className="divider" />
-            <TrafficStats animateArrows={animateTrafficArrows} stats={networkStats} />
+            <TrafficStats
+              animateArrows={animateTrafficArrows}
+              precision={trafficPrecision}
+              stats={networkStats}
+              unit={trafficDisplayUnit}
+            />
           </>
         )}
         {operationText && (
@@ -52,7 +67,12 @@ export function StatusBar({
           </>
         )}
       </div>
-      {resultText && <div className="status-right">{resultText}</div>}
+      {resultText && (
+        <>
+          <span className="divider status-result-divider" />
+          <div className="status-right">{resultText}</div>
+        </>
+      )}
     </footer>
   );
 }
@@ -62,10 +82,22 @@ function footerResultText(tab: WorkspaceTab, rowCount: number, selectedCount: nu
   return resultSummary(tab.result ?? null);
 }
 
-function TrafficStats({ animateArrows, stats }: { animateArrows: boolean; stats: NetworkStats }) {
+function TrafficStats({
+  animateArrows,
+  precision,
+  stats,
+  unit,
+}: {
+  animateArrows: boolean;
+  precision: TrafficPrecision;
+  stats: NetworkStats;
+  unit: TrafficDisplayUnit;
+}) {
   const downloadActive = animateArrows && stats.download_active;
   const uploadActive = animateArrows && stats.upload_active;
   const title = stats.available ? 'Network activity on selected interface' : 'No traffic data for selected interface';
+  const download = formatTrafficRate(stats.download_mbps, unit, precision);
+  const upload = formatTrafficRate(stats.upload_mbps, unit, precision);
 
   return (
     <span className="traffic-stats" data-testid="traffic-stats" aria-label={title} data-tooltip={title}>
@@ -78,7 +110,7 @@ function TrafficStats({ animateArrows, stats }: { animateArrows: boolean; stats:
         <span className="traffic-arrow">
           <ArrowDown size={12} />
         </span>
-        <span>{stats.download_mbps.toFixed(2)}</span>
+        <span>{download}</span>
       </span>
       <span
         className={`traffic-rate ${uploadActive ? 'active' : ''}`}
@@ -89,9 +121,14 @@ function TrafficStats({ animateArrows, stats }: { animateArrows: boolean; stats:
         <span className="traffic-arrow">
           <ArrowUp size={12} />
         </span>
-        <span>{stats.upload_mbps.toFixed(2)}</span>
+        <span>{upload}</span>
       </span>
-      <span className="traffic-unit">Mbps</span>
+      <span className="traffic-unit">{unit}</span>
     </span>
   );
+}
+
+function formatTrafficRate(valueMbps: number, unit: TrafficDisplayUnit, precision: TrafficPrecision): string {
+  const value = unit === 'Gbps' ? valueMbps / 1000 : unit === 'Kbps' ? valueMbps * 1000 : valueMbps;
+  return value.toFixed(precision);
 }

--- a/apps/netscli-gui/src/components/shell/TabStrip.tsx
+++ b/apps/netscli-gui/src/components/shell/TabStrip.tsx
@@ -3,7 +3,7 @@ import { ChevronDown, Plus, X } from 'lucide-react';
 
 import { TOOL_CONFIG } from '../../tools/registry';
 import { tabIdentity } from '../../tools/presentation';
-import type { ToolKind, WorkspaceTab } from '../../tools/types';
+import type { ToolCapabilityMap, ToolKind, WorkspaceTab } from '../../tools/types';
 import { computePopoverPosition } from '../primitives/overlay';
 import { tabDisplayFor } from './tabDisplay';
 import { TabToolMenu } from './TabToolMenu';
@@ -12,7 +12,7 @@ interface TabStripProps {
   tabs: WorkspaceTab[];
   activeTabId: string;
   openMenu: string | null;
-  pcapAvailable: boolean;
+  toolCapabilities: ToolCapabilityMap;
   onAddScanTab: () => void;
   onAddToolTab: (kind: ToolKind) => void;
   onCloseTab: (tabId: string) => void;
@@ -24,7 +24,7 @@ export function TabStrip({
   tabs,
   activeTabId,
   openMenu,
-  pcapAvailable,
+  toolCapabilities,
   onAddScanTab,
   onAddToolTab,
   onCloseTab,
@@ -283,9 +283,9 @@ export function TabStrip({
       {toolMenuOpen && (
         <TabToolMenu
           onAddToolTab={onAddToolTab}
-          pcapAvailable={pcapAvailable}
           position={toolMenuPosition}
           setOpenMenu={setOpenMenu}
+          toolCapabilities={toolCapabilities}
           triggerRef={chevronRef}
         />
       )}

--- a/apps/netscli-gui/src/components/shell/TabToolMenu.tsx
+++ b/apps/netscli-gui/src/components/shell/TabToolMenu.tsx
@@ -1,19 +1,19 @@
 import { useRef, type RefObject } from 'react';
 
 import { availableToolKinds, LOOKUP_TOOL_KINDS, SCAN_TOOL_KINDS, TOOL_CONFIG } from '../../tools/registry';
-import type { ToolKind } from '../../tools/types';
+import type { ToolCapabilityMap, ToolKind } from '../../tools/types';
 import { useRovingFocus } from '../primitives/focus';
 import { useOverlayDismiss, type PopoverPosition } from '../primitives/overlay';
 
 interface TabToolMenuProps {
   onAddToolTab: (kind: ToolKind) => void;
-  pcapAvailable: boolean;
   position: PopoverPosition;
   setOpenMenu: (menu: string | null) => void;
+  toolCapabilities: ToolCapabilityMap;
   triggerRef: RefObject<HTMLButtonElement | null>;
 }
 
-export function TabToolMenu({ onAddToolTab, pcapAvailable, position, setOpenMenu, triggerRef }: TabToolMenuProps) {
+export function TabToolMenu({ onAddToolTab, position, setOpenMenu, toolCapabilities, triggerRef }: TabToolMenuProps) {
   const menuRef = useRef<HTMLDivElement | null>(null);
   const closeMenu = () => setOpenMenu(null);
   const onKeyDown = useRovingFocus({
@@ -45,7 +45,7 @@ export function TabToolMenu({ onAddToolTab, pcapAvailable, position, setOpenMenu
         setOpenMenu={setOpenMenu}
       />
       <ToolMenuSection
-        kinds={availableToolKinds(LOOKUP_TOOL_KINDS, pcapAvailable)}
+        kinds={availableToolKinds(LOOKUP_TOOL_KINDS, toolCapabilities)}
         label="Lookups and inventory"
         onAddToolTab={onAddToolTab}
         setOpenMenu={setOpenMenu}

--- a/apps/netscli-gui/src/components/shell/Toolbar.tsx
+++ b/apps/netscli-gui/src/components/shell/Toolbar.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, Download, FileSpreadsheet, Filter, Play, Square, X } from 'lucide-react';
-import { useRef } from 'react';
+import { useRef, type RefObject } from 'react';
 
 import { TOOL_CONFIG } from '../../tools/registry';
 import { filterHintsFor } from '../../tools/presentation';
@@ -9,6 +9,7 @@ import { useAnchoredPopoverPosition, useOverlayDismiss } from '../primitives/ove
 
 interface ToolbarProps {
   activeTab: WorkspaceTab | undefined;
+  filterInputRef?: RefObject<HTMLInputElement | null>;
   filterText: string;
   openMenu: string | null;
   setOpenMenu: (menu: string | null) => void;
@@ -17,10 +18,12 @@ interface ToolbarProps {
   onExportJson: () => void;
   onExportCsv: () => void;
   onRunActive: () => void;
+  runDisabledReason?: string;
 }
 
 export function Toolbar({
   activeTab,
+  filterInputRef,
   filterText,
   openMenu,
   setOpenMenu,
@@ -29,6 +32,7 @@ export function Toolbar({
   onExportCsv,
   onExportJson,
   onRunActive,
+  runDisabledReason,
 }: ToolbarProps) {
   const filterMenuOpen = openMenu === 'advanced-filter';
   const kind = activeTab?.kind ?? 'scan';
@@ -67,9 +71,9 @@ export function Toolbar({
       <button
         className="icon-button strong toolbar-run"
         data-testid="run-active-tab"
-        disabled={!activeTab || activeTab.busy}
+        disabled={!activeTab || activeTab.busy || Boolean(runDisabledReason)}
         aria-label={runLabel}
-        data-tooltip={runLabel}
+        data-tooltip={runDisabledReason ?? runLabel}
         data-tooltip-placement="bottom"
         onClick={onRunActive}
       >
@@ -117,6 +121,7 @@ export function Toolbar({
             autoCapitalize="off"
             autoCorrect="off"
             data-testid="result-filter"
+            ref={filterInputRef}
             spellCheck={false}
             disabled={!activeTab}
             value={filterText}

--- a/apps/netscli-gui/src/components/shell/WorkspaceSearchDialog.tsx
+++ b/apps/netscli-gui/src/components/shell/WorkspaceSearchDialog.tsx
@@ -1,0 +1,241 @@
+import { Search, X } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+
+import { buildRows } from '../../tools/presentation';
+import { TOOL_CONFIG } from '../../tools/registry';
+import type { HistoryEntry, ResultRow, WorkspaceTab } from '../../tools/types';
+import { useModalFocus } from '../primitives/focus';
+
+interface WorkspaceSearchDialogProps {
+  history: HistoryEntry[];
+  tabs: WorkspaceTab[];
+  onClose: () => void;
+  onOpenHistoryEntry: (entry: HistoryEntry) => void;
+  onSelectRow: (tabId: string, rowIndex: number) => void;
+  onSelectTab: (tabId: string) => void;
+}
+
+type SearchItem =
+  | {
+      id: string;
+      kind: 'tab';
+      primary: string;
+      secondary: string;
+      searchText: string;
+      tabId: string;
+    }
+  | {
+      id: string;
+      kind: 'row';
+      primary: string;
+      secondary: string;
+      searchText: string;
+      rowIndex: number;
+      tabId: string;
+    }
+  | {
+      id: string;
+      kind: 'history';
+      primary: string;
+      secondary: string;
+      searchText: string;
+      entry: HistoryEntry;
+    };
+
+export function WorkspaceSearchDialog({
+  history,
+  tabs,
+  onClose,
+  onOpenHistoryEntry,
+  onSelectRow,
+  onSelectTab,
+}: WorkspaceSearchDialogProps) {
+  const dialogRef = useRef<HTMLElement | null>(null);
+  const resultsRef = useRef<HTMLDivElement | null>(null);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const items = useMemo(() => searchItemsFor(tabs, history), [history, tabs]);
+  const matches = useMemo(() => filterItems(items, query).slice(0, 40), [items, query]);
+  const activeItem = matches[Math.min(activeIndex, Math.max(0, matches.length - 1))];
+
+  useModalFocus({ dialogRef, onClose });
+
+  useEffect(() => {
+    resultsRef.current
+      ?.querySelector('button.active')
+      ?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }, [activeIndex, matches.length]);
+
+  function activate(item: SearchItem | undefined) {
+    if (!item) return;
+    if (item.kind === 'tab') {
+      onSelectTab(item.tabId);
+    } else if (item.kind === 'row') {
+      onSelectRow(item.tabId, item.rowIndex);
+    } else {
+      onOpenHistoryEntry(item.entry);
+    }
+    onClose();
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLElement>) {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        setActiveIndex((index) => Math.min(index + 1, Math.max(0, matches.length - 1)));
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        setActiveIndex((index) => Math.max(0, index - 1));
+        break;
+      case 'PageDown':
+        event.preventDefault();
+        setActiveIndex((index) => Math.min(index + 6, Math.max(0, matches.length - 1)));
+        break;
+      case 'PageUp':
+        event.preventDefault();
+        setActiveIndex((index) => Math.max(0, index - 6));
+        break;
+      case 'Home':
+        event.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        setActiveIndex(Math.max(0, matches.length - 1));
+        break;
+      case 'Enter':
+        event.preventDefault();
+        activate(activeItem);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return (
+    <div className="search-overlay" role="presentation" onMouseDown={onClose}>
+      <section
+        aria-label="Workspace search"
+        aria-modal="true"
+        className="workspace-search"
+        data-testid="workspace-search"
+        ref={dialogRef}
+        role="dialog"
+        tabIndex={-1}
+        onKeyDown={onKeyDown}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="workspace-search-input">
+          <Search size={15} />
+          <input
+            aria-label="Search workspace"
+            autoCapitalize="off"
+            autoCorrect="off"
+            autoFocus
+            data-testid="workspace-search-input"
+            placeholder="Search tabs, results, and history"
+            spellCheck={false}
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setActiveIndex(0);
+            }}
+          />
+          <button aria-label="Close search" data-tooltip="Close search" type="button" onClick={onClose}>
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="workspace-search-results" ref={resultsRef} role="listbox">
+          {matches.length === 0 ? (
+            <span className="workspace-search-empty">No workspace matches.</span>
+          ) : (
+            matches.map((item, index) => (
+              <button
+                aria-selected={item === activeItem}
+                className={item === activeItem ? 'active' : ''}
+                key={item.id}
+                role="option"
+                type="button"
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => activate(item)}
+              >
+                <span className="workspace-search-kind">{labelForKind(item.kind)}</span>
+                <span className="workspace-search-main">
+                  <strong>{item.primary}</strong>
+                  <small>{item.secondary}</small>
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function searchItemsFor(tabs: WorkspaceTab[], history: HistoryEntry[]): SearchItem[] {
+  return [
+    ...tabs.flatMap((tab) => tabItems(tab)),
+    ...history.slice(0, 20).map((entry) => ({
+      id: `history-${entry.id}`,
+      kind: 'history' as const,
+      primary: entry.command,
+      secondary: `History - ${entry.tabTitle}`,
+      searchText: `${entry.command} ${entry.tabTitle} ${JSON.stringify(entry.form)}`.toLowerCase(),
+      entry,
+    })),
+  ];
+}
+
+function tabItems(tab: WorkspaceTab): SearchItem[] {
+  const config = TOOL_CONFIG[tab.kind];
+  const tabText = `${config.label} ${tab.title} ${Object.values(tab.form).join(' ')}`;
+  const tabItem: SearchItem = {
+    id: `tab-${tab.id}`,
+    kind: 'tab',
+    primary: `${config.label} tab`,
+    secondary: tabTitle(tab),
+    searchText: tabText.toLowerCase(),
+    tabId: tab.id,
+  };
+  const rowItems = buildRows(tab.result).map((row, rowIndex) => rowItem(tab, row, rowIndex));
+  return [tabItem, ...rowItems];
+}
+
+function rowItem(tab: WorkspaceTab, row: ResultRow, rowIndex: number): SearchItem {
+  const config = TOOL_CONFIG[tab.kind];
+  return {
+    id: `row-${tab.id}-${row.id}`,
+    kind: 'row',
+    primary: rowTitle(row),
+    secondary: `${config.label} - ${tabTitle(tab)}`,
+    searchText: `${row.searchText} ${config.label} ${tab.title} ${Object.values(tab.form).join(' ')}`.toLowerCase(),
+    rowIndex,
+    tabId: tab.id,
+  };
+}
+
+function filterItems(items: SearchItem[], query: string): SearchItem[] {
+  const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return items.slice(0, 20);
+  return items.filter((item) => tokens.every((token) => item.searchText.includes(token)));
+}
+
+function tabTitle(tab: WorkspaceTab): string {
+  return Object.values(tab.form).filter(Boolean).join(' - ') || tab.title;
+}
+
+function rowTitle(row: ResultRow): string {
+  const values = ['ip', 'host', 'hostname', 'port', 'service', 'vendor', 'record_type', 'value', 'protocol', 'destination']
+    .map((key) => row.data[key])
+    .filter((value) => value !== null && value !== undefined && value !== '');
+  return values.length > 0 ? values.map(String).join(' - ') : row.searchText.slice(0, 80);
+}
+
+function labelForKind(kind: SearchItem['kind']): string {
+  if (kind === 'tab') return 'Tab';
+  if (kind === 'history') return 'History';
+  return 'Result';
+}

--- a/apps/netscli-gui/src/components/tools/ToolForm.tsx
+++ b/apps/netscli-gui/src/components/tools/ToolForm.tsx
@@ -1,10 +1,10 @@
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { useRovingFocus } from '../primitives/focus';
 import { useAnchoredPopoverPosition, useOverlayDismiss } from '../primitives/overlay';
 import { TOOL_CONFIG } from '../../tools/registry';
-import type { WorkspaceTab } from '../../tools/types';
+import type { ToolField, WorkspaceTab } from '../../tools/types';
 import type { InterfaceInfo } from '../../types/netscli';
 
 interface SelectOption {
@@ -52,7 +52,7 @@ export function ToolForm({ tab, interfaces = [], onPatchForm, onRun }: ToolFormP
 
   return (
     <div className="form-row" ref={formRef}>
-      {config.fields.map((field) => {
+      {fieldsForTab(tab, config.fields).map((field) => {
         const options = selectOptionsForField(tab, field.key, field.options, interfaces);
         const selectedValue = tab.form[field.key] || field.placeholder || options[0]?.value || '';
         const selectedLabel = options.find((option) => option.value === tab.form[field.key])?.label ?? selectedValue;
@@ -60,8 +60,15 @@ export function ToolForm({ tab, interfaces = [], onPatchForm, onRun }: ToolFormP
         return (
           <div className={`form-field ${field.compact ? 'compact' : ''}`} key={field.key}>
             <span>{field.label}</span>
-            {field.type === 'select' ? (
-            <div className="field-select">
+            {field.type === 'number' ? (
+              <NumberField
+                field={field}
+                tab={tab}
+                onPatchForm={onPatchForm}
+                onRun={onRun}
+              />
+            ) : field.type === 'select' ? (
+              <div className="field-select">
               <button
                 aria-expanded={openField === field.key}
                 aria-haspopup="listbox"
@@ -119,7 +126,7 @@ export function ToolForm({ tab, interfaces = [], onPatchForm, onRun }: ToolFormP
                   ))}
                 </div>
               )}
-            </div>
+              </div>
           ) : (
             <input
               aria-label={field.label}
@@ -141,6 +148,115 @@ export function ToolForm({ tab, interfaces = [], onPatchForm, onRun }: ToolFormP
       })}
     </div>
   );
+}
+
+function NumberField({
+  field,
+  tab,
+  onPatchForm,
+  onRun,
+}: {
+  field: ToolField;
+  tab: WorkspaceTab;
+  onPatchForm: (tabId: string, key: string, value: string) => void;
+  onRun: (tabId: string) => void;
+}) {
+  const value = tab.form[field.key] ?? '';
+  const numericValue = numberFromFieldValue(value, field);
+  const min = field.min;
+  const max = field.max;
+  const step = field.step ?? 1;
+
+  function commit(raw: string) {
+    onPatchForm(tab.id, field.key, normalizeNumberFieldValue(raw, field));
+  }
+
+  function stepBy(delta: number) {
+    const next = clampNumber((numericValue ?? numberFromFieldValue(field.placeholder, field) ?? min ?? 0) + delta * step, field);
+    onPatchForm(tab.id, field.key, formatNumberFieldValue(next, field));
+  }
+
+  return (
+    <div className="number-field-control">
+      <input
+        aria-label={field.label}
+        autoCapitalize="off"
+        autoCorrect="off"
+        data-testid={`${tab.kind}-${field.key}-input`}
+        inputMode="numeric"
+        max={max}
+        min={min}
+        spellCheck={false}
+        step={step}
+        type="number"
+        value={value}
+        placeholder={field.placeholder}
+        onBlur={(event) => commit(event.currentTarget.value)}
+        onChange={(event) => commit(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            commit(event.currentTarget.value);
+            window.setTimeout(() => onRun(tab.id), 0);
+          }
+        }}
+      />
+      <span className="number-field-steppers">
+        <button
+          aria-label={`Increase ${field.label}`}
+          data-tooltip={`Increase ${field.label}`}
+          disabled={max !== undefined && numericValue !== null && numericValue >= max}
+          tabIndex={-1}
+          type="button"
+          onClick={() => stepBy(1)}
+        >
+          <ChevronUp size={10} />
+        </button>
+        <button
+          aria-label={`Decrease ${field.label}`}
+          data-tooltip={`Decrease ${field.label}`}
+          disabled={min !== undefined && numericValue !== null && numericValue <= min}
+          tabIndex={-1}
+          type="button"
+          onClick={() => stepBy(-1)}
+        >
+          <ChevronDown size={10} />
+        </button>
+      </span>
+    </div>
+  );
+}
+
+function normalizeNumberFieldValue(raw: string, field: ToolField): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) return '';
+  return formatNumberFieldValue(clampNumber(parsed, field), field);
+}
+
+function numberFromFieldValue(value: string | undefined, field: ToolField): number | null {
+  const normalized = normalizeNumberFieldValue(value ?? '', field);
+  return normalized ? Number(normalized) : null;
+}
+
+function clampNumber(value: number, field: ToolField): number {
+  const step = field.step ?? 1;
+  const stepped = Number.isInteger(step) ? Math.trunc(value) : value;
+  const lowerBounded = field.min === undefined ? stepped : Math.max(field.min, stepped);
+  return field.max === undefined ? lowerBounded : Math.min(field.max, lowerBounded);
+}
+
+function formatNumberFieldValue(value: number, field: ToolField): string {
+  return Number.isInteger(field.step ?? 1) ? String(Math.trunc(value)) : String(value);
+}
+
+function fieldsForTab(tab: WorkspaceTab, fields: ToolField[]): ToolField[] {
+  if (tab.kind !== 'pcap') return fields;
+  const mode = tab.form.mode || 'Capture';
+  if (mode === 'Open File') {
+    return fields.filter((field) => field.key === 'mode' || field.key === 'max_packets');
+  }
+  return fields;
 }
 
 function selectOptionsForField(

--- a/apps/netscli-gui/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/netscli-gui/src/hooks/useKeyboardShortcuts.ts
@@ -3,17 +3,23 @@ import { useEffect } from 'react';
 import type { WorkspaceModel } from '../workspace/types';
 
 export function useKeyboardShortcuts({
+  focusResultFilter,
   openMenu,
   setOpenMenu,
   setSettingsOpen,
   settingsOpen,
+  setWorkspaceSearchOpen,
   workspace,
+  workspaceSearchOpen,
 }: {
+  focusResultFilter: () => void;
   openMenu: string | null;
   setOpenMenu: (menu: string | null) => void;
   setSettingsOpen: (open: boolean) => void;
   settingsOpen: boolean;
+  setWorkspaceSearchOpen: (open: boolean) => void;
   workspace: WorkspaceModel;
+  workspaceSearchOpen: boolean;
 }) {
   const activeTab = workspace.activeTab;
 
@@ -28,6 +34,31 @@ export function useKeyboardShortcuts({
 
     function handleKeyboardShortcuts(event: KeyboardEvent) {
       if (event.defaultPrevented) return;
+      const ctrlOrMeta = event.ctrlKey || event.metaKey;
+
+      if (ctrlOrMeta && !event.shiftKey && event.key.toLowerCase() === 'f') {
+        event.preventDefault();
+        if (activeTab && !settingsOpen && !workspaceSearchOpen) {
+          setOpenMenu(null);
+          focusResultFilter();
+        }
+        return;
+      }
+
+      if (ctrlOrMeta && !event.shiftKey && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        if (!settingsOpen) {
+          setOpenMenu(null);
+          setWorkspaceSearchOpen(true);
+        }
+        return;
+      }
+
+      if (event.key === 'Escape' && workspaceSearchOpen) {
+        event.preventDefault();
+        setWorkspaceSearchOpen(false);
+        return;
+      }
 
       if (event.key === 'Escape' && openMenu) {
         event.preventDefault();
@@ -42,7 +73,6 @@ export function useKeyboardShortcuts({
       }
 
       if (!activeTab || isEditableTarget(event.target)) return;
-      const ctrlOrMeta = event.ctrlKey || event.metaKey;
 
       if (ctrlOrMeta && event.key.toLowerCase() === 'a' && !isScopedSelectTarget(event.target)) {
         event.preventDefault();
@@ -80,6 +110,16 @@ export function useKeyboardShortcuts({
 
     document.addEventListener('keydown', handleKeyboardShortcuts);
     return () => document.removeEventListener('keydown', handleKeyboardShortcuts);
-  }, [activeTab, openMenu, setOpenMenu, setSettingsOpen, settingsOpen, workspace]);
+  }, [
+    activeTab,
+    focusResultFilter,
+    openMenu,
+    setOpenMenu,
+    setSettingsOpen,
+    settingsOpen,
+    setWorkspaceSearchOpen,
+    workspace,
+    workspaceSearchOpen,
+  ]);
 }
 

--- a/apps/netscli-gui/src/hooks/usePreferences.ts
+++ b/apps/netscli-gui/src/hooks/usePreferences.ts
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react';
 
+export type TrafficDisplayUnit = 'Gbps' | 'Mbps' | 'Kbps';
+export type TrafficPrecision = 0 | 1 | 2;
+
 function initialDarkMode(): boolean {
   if (typeof window === 'undefined') return true;
   const themeParam = new URLSearchParams(window.location.search).get('theme');
@@ -11,6 +14,18 @@ function initialDarkMode(): boolean {
 function initialTrafficIndicators(): boolean {
   if (typeof window === 'undefined') return true;
   return window.localStorage.getItem('netscli-traffic-indicators') !== 'off';
+}
+
+function initialTrafficDisplayUnit(): TrafficDisplayUnit {
+  if (typeof window === 'undefined') return 'Mbps';
+  const value = window.localStorage.getItem('netscli-traffic-display-unit');
+  return value === 'Gbps' || value === 'Mbps' || value === 'Kbps' ? value : 'Mbps';
+}
+
+function initialTrafficPrecision(): TrafficPrecision {
+  if (typeof window === 'undefined') return 2;
+  const value = Number(window.localStorage.getItem('netscli-traffic-precision'));
+  return value === 0 || value === 1 || value === 2 ? value : 2;
 }
 
 function initialCommandBarVisible(): boolean {
@@ -41,6 +56,8 @@ function initialPersistentHistory(): boolean {
 export function usePreferences() {
   const [darkMode, setDarkMode] = useState(initialDarkMode);
   const [trafficIndicators, setTrafficIndicators] = useState(initialTrafficIndicators);
+  const [trafficDisplayUnit, setTrafficDisplayUnit] = useState<TrafficDisplayUnit>(initialTrafficDisplayUnit);
+  const [trafficPrecision, setTrafficPrecision] = useState<TrafficPrecision>(initialTrafficPrecision);
   const [commandBarVisible, setCommandBarVisible] = useState(initialCommandBarVisible);
   const [interactionToasts, setInteractionToasts] = useState(initialInteractionToasts);
   const [operationToasts, setOperationToasts] = useState(initialOperationToasts);
@@ -54,6 +71,14 @@ export function usePreferences() {
   useEffect(() => {
     window.localStorage.setItem('netscli-traffic-indicators', trafficIndicators ? 'on' : 'off');
   }, [trafficIndicators]);
+
+  useEffect(() => {
+    window.localStorage.setItem('netscli-traffic-display-unit', trafficDisplayUnit);
+  }, [trafficDisplayUnit]);
+
+  useEffect(() => {
+    window.localStorage.setItem('netscli-traffic-precision', String(trafficPrecision));
+  }, [trafficPrecision]);
 
   useEffect(() => {
     window.localStorage.setItem('netscli-command-bar', commandBarVisible ? 'on' : 'off');
@@ -88,7 +113,11 @@ export function usePreferences() {
     setOperationToasts,
     setPersistentHistory,
     setReleaseNotifications,
+    setTrafficDisplayUnit,
     setTrafficIndicators,
+    setTrafficPrecision,
+    trafficDisplayUnit,
     trafficIndicators,
+    trafficPrecision,
   };
 }

--- a/apps/netscli-gui/src/hooks/useTauriRuntimeState.ts
+++ b/apps/netscli-gui/src/hooks/useTauriRuntimeState.ts
@@ -5,25 +5,56 @@ import {
   chooseFileSaveDefaultDirectory,
   clearFileSaveDefaultDirectory,
   getFileSavePreferences,
+  getMdnsCapability,
   getPcapCapability,
   setFileSaveAskEachTime,
 } from '../services/netscli';
-import type { FileSavePreferences } from '../types/netscli';
+import type { FileSavePreferences, OptionalCapability } from '../types/netscli';
+import type { PcapCapability } from '../types/netscli';
+import type { ToolCapabilityMap } from '../tools/types';
 
 export function useTauriRuntimeState() {
   const [fileSavePreferences, setFileSavePreferences] = useState<FileSavePreferences>({
     ask_each_time: false,
     default_directory: null,
   });
-  const [pcapAvailable, setPcapAvailable] = useState(false);
+  const [pcapCapability, setPcapCapability] = useState<PcapCapability>({
+    compiled: false,
+    available: false,
+    interfaces: [],
+    message: 'Checking Packet Capture support.',
+  });
+  const [mdnsCapability, setMdnsCapability] = useState<OptionalCapability>({
+    compiled: true,
+    available: true,
+    message: null,
+  });
 
   useEffect(() => {
     if (!isTauri()) return;
     let cancelled = false;
-    void Promise.allSettled([getPcapCapability(), getFileSavePreferences()]).then((results) => {
+    void Promise.allSettled([getPcapCapability(), getMdnsCapability(), getFileSavePreferences()]).then((results) => {
       if (cancelled) return;
-      const [pcapCapability, savePreferences] = results;
-      setPcapAvailable(pcapCapability.status === 'fulfilled' ? pcapCapability.value.available : false);
+      const [pcapCapability, mdnsCapability, savePreferences] = results;
+      setPcapCapability(
+        pcapCapability.status === 'fulfilled'
+          ? pcapCapability.value
+          : {
+              compiled: false,
+              available: false,
+              interfaces: [],
+              message: 'Packet Capture support could not be checked.',
+            },
+      );
+      setMdnsCapability(
+        mdnsCapability.status === 'fulfilled'
+          ? mdnsCapability.value
+          : {
+              compiled: false,
+              available: false,
+              message: 'mDNS discovery support could not be checked.',
+            },
+      );
       if (savePreferences.status === 'fulfilled') {
         setFileSavePreferences(savePreferences.value);
       }
@@ -63,11 +94,18 @@ export function useTauriRuntimeState() {
     }
   }
 
+  const toolCapabilities: ToolCapabilityMap = {
+    mdns: mdnsCapability.compiled,
+    pcap: pcapCapability.compiled,
+  };
+
   return {
     chooseSaveFolder,
     clearSaveFolder,
     fileSavePreferences,
-    pcapAvailable,
+    mdnsCapability,
+    pcapCapability,
+    toolCapabilities,
     toggleFileSaveAskEachTime,
   };
 }

--- a/apps/netscli-gui/src/services/appWindow.ts
+++ b/apps/netscli-gui/src/services/appWindow.ts
@@ -9,7 +9,13 @@ export async function appWindowAction(action: AppWindowAction) {
     const win = getCurrentWindow();
     if (action === 'close') await win.close();
     if (action === 'minimize') await win.minimize();
-    if (action === 'maximize') await win.toggleMaximize();
+    if (action === 'maximize') {
+      if (await win.isMaximized()) {
+        await win.unmaximize();
+      } else {
+        await win.maximize();
+      }
+    }
     if (action === 'drag') await win.startDragging();
   } catch {
     return;

--- a/apps/netscli-gui/src/services/netscli.ts
+++ b/apps/netscli-gui/src/services/netscli.ts
@@ -9,11 +9,17 @@ import type {
   Host,
   InspectResult,
   InterfaceInfo,
+  MdnsService,
   NetworkStats,
+  OptionalCapability,
   PcapCapability,
+  PcapParseResult,
   PcapResult,
+  PingSummary,
   PortResult,
+  ReverseDnsResult,
   SweepEntry,
+  TraceResult,
 } from '../types/netscli';
 import type { OperationProgressState } from '../tools/types';
 
@@ -41,6 +47,30 @@ export async function scanPorts(
   return invoke<PortResult[]>('scan_ports', { op_id, host, ports });
 }
 
+export async function pingHost(
+  host: string,
+  count?: number,
+  op_id?: string,
+): Promise<PingSummary> {
+  return invoke<PingSummary>('ping_host', { op_id, host, count });
+}
+
+export async function traceRoute(
+  host: string,
+  max_hops?: number,
+  resolve?: boolean,
+  op_id?: string,
+): Promise<TraceResult> {
+  return invoke<TraceResult>('trace_route_cmd', { op_id, host, max_hops, resolve });
+}
+
+export async function reverseDnsLookup(
+  ip: string,
+  op_id?: string,
+): Promise<ReverseDnsResult> {
+  return invoke<ReverseDnsResult>('reverse_dns_lookup', { op_id, ip });
+}
+
 export async function inspectHost(
   host: string,
   ports?: string,
@@ -64,6 +94,14 @@ export async function dnsLookup(
   op_id?: string,
 ): Promise<DnsRecord[]> {
   return invoke<DnsRecord[]>('dns_lookup', { op_id, host, record });
+}
+
+export async function discoverMdns(
+  timeout_ms?: number,
+  service_types?: string[],
+  op_id?: string,
+): Promise<MdnsService[]> {
+  return invoke<MdnsService[]>('discover_mdns', { op_id, timeout_ms, service_types });
 }
 
 export async function listInterfaces(op_id?: string): Promise<InterfaceInfo[]> {
@@ -92,8 +130,16 @@ export async function capturePcap(
   });
 }
 
+export async function openPcapFile(max_packets?: number): Promise<PcapParseResult> {
+  return invoke<PcapParseResult>('open_pcap_file', { max_packets });
+}
+
 export async function getPcapCapability(): Promise<PcapCapability> {
   return invoke<PcapCapability>('pcap_capability');
+}
+
+export async function getMdnsCapability(): Promise<OptionalCapability> {
+  return invoke<OptionalCapability>('mdns_capability');
 }
 
 export async function getFileSavePreferences(): Promise<FileSavePreferences> {
@@ -129,6 +175,14 @@ export async function exportTextFile(
   contents: string,
 ): Promise<string> {
   return invoke<string>('export_text_file', { filename, contents, target_path: null });
+}
+
+export async function saveResultBundle(contents: string): Promise<string> {
+  return invoke<string>('save_result_bundle', { contents });
+}
+
+export async function openResultBundle(): Promise<unknown> {
+  return invoke<unknown>('open_result_bundle');
 }
 
 export async function openFilesystemPath(path: string): Promise<void> {

--- a/apps/netscli-gui/src/styles/details.css
+++ b/apps/netscli-gui/src/styles/details.css
@@ -110,11 +110,20 @@
 }
 
 .detail-body {
+  --detail-shadow-top: 0 0 transparent;
+  --detail-shadow-right: 0 0 transparent;
+  --detail-shadow-bottom: 0 0 transparent;
+  --detail-shadow-left: 0 0 transparent;
   flex: 1;
   min-height: 0;
   overflow: auto;
   padding: 10px 14px;
   user-select: text;
+  box-shadow:
+    var(--detail-shadow-top),
+    var(--detail-shadow-right),
+    var(--detail-shadow-bottom),
+    var(--detail-shadow-left);
 }
 
 .detail-body:focus {
@@ -122,7 +131,24 @@
 }
 
 .detail-body:focus-visible {
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--mint), transparent 50%);
+  outline: 1px solid color-mix(in srgb, var(--mint), transparent 50%);
+  outline-offset: -1px;
+}
+
+.detail-body.has-top-overflow {
+  --detail-shadow-top: inset 0 18px 16px -16px color-mix(in srgb, var(--shadow), black 25%);
+}
+
+.detail-body.has-right-overflow {
+  --detail-shadow-right: inset -18px 0 16px -16px color-mix(in srgb, var(--shadow), black 25%);
+}
+
+.detail-body.has-bottom-overflow {
+  --detail-shadow-bottom: inset 0 -18px 16px -16px color-mix(in srgb, var(--shadow), black 25%);
+}
+
+.detail-body.has-left-overflow {
+  --detail-shadow-left: inset 18px 0 16px -16px color-mix(in srgb, var(--shadow), black 25%);
 }
 
 .detail-body pre {

--- a/apps/netscli-gui/src/styles/forms.css
+++ b/apps/netscli-gui/src/styles/forms.css
@@ -83,6 +83,63 @@
   appearance: none;
 }
 
+.number-field-control {
+  width: 100%;
+  height: 30px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 20px;
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--bg-input);
+}
+
+.number-field-control:focus-within {
+  border-color: var(--mint);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--mint), transparent 78%);
+}
+
+.number-field-control input,
+.number-field-control input:focus {
+  height: 100%;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0 8px 0 10px;
+}
+
+.number-field-steppers {
+  display: grid;
+  grid-template-rows: 1fr 1fr;
+  border-left: 1px solid var(--border-subtle);
+}
+
+.number-field-steppers button {
+  width: 20px;
+  height: 14px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  padding: 0;
+  cursor: default;
+}
+
+.number-field-steppers button:first-child {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.number-field-steppers button:hover:not(:disabled) {
+  background: var(--bg-selected);
+  color: var(--mint);
+}
+
+.number-field-steppers button:disabled {
+  opacity: 0.35;
+}
+
 .field-select {
   position: relative;
   min-width: 0;

--- a/apps/netscli-gui/src/styles/pcap.css
+++ b/apps/netscli-gui/src/styles/pcap.css
@@ -1,0 +1,59 @@
+.pcap-unavailable {
+  width: min(560px, calc(100% - 40px));
+  margin: auto;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  align-items: start;
+  gap: 12px 14px;
+  padding: 18px;
+  color: var(--text-secondary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 12px 24px var(--shadow);
+}
+
+.pcap-unavailable > svg {
+  color: var(--amber);
+}
+
+.pcap-unavailable-copy {
+  min-width: 0;
+}
+
+.pcap-unavailable h2 {
+  margin: 0 0 6px;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.pcap-unavailable p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.pcap-unavailable code {
+  display: block;
+  margin-top: 10px;
+  color: var(--text-muted);
+  white-space: normal;
+}
+
+.pcap-unavailable button {
+  grid-column: 2;
+  justify-self: start;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+}
+
+.pcap-unavailable button:hover {
+  border-color: color-mix(in srgb, var(--mint), transparent 35%);
+  color: var(--mint);
+}

--- a/apps/netscli-gui/src/styles/responsive.css
+++ b/apps/netscli-gui/src/styles/responsive.css
@@ -13,6 +13,10 @@
   border: 2px solid var(--bg-base);
 }
 
+::-webkit-scrollbar-corner {
+  background: var(--bg-base);
+}
+
 @media (max-width: 760px) {
   .app-frame {
     flex-basis: 32px;
@@ -23,16 +27,19 @@
   }
 
   .toolbar {
-    flex-wrap: wrap;
-    min-height: 78px;
-    padding: 7px 10px;
+    flex-wrap: nowrap;
+    flex-basis: 45px;
+    min-height: 45px;
+    padding: 0 10px;
   }
 
   .filter-control {
-    order: 2;
-    width: 100%;
+    flex: 1 1 180px;
+    order: 0;
+    width: auto;
     max-width: none;
     min-width: 0;
+    margin-top: 0;
   }
 
   .filter-advanced-popover {
@@ -71,15 +78,54 @@
   }
 
   .statusbar {
-    align-items: flex-start;
-    flex-direction: column;
-    height: auto;
-    padding: 6px 10px;
+    align-items: center;
+    flex-direction: row;
+    height: 27px;
+    min-height: 27px;
+    gap: 8px;
+    padding: 0 10px;
+  }
+
+  .status-left {
+    flex: 1 1 auto;
+    width: auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .status-text {
+    display: none;
+  }
+
+  .status-text,
+  .status-interface-name,
+  .traffic-stats,
+  .status-right {
+    white-space: nowrap;
+  }
+
+  .status-interface-address {
+    min-width: 0;
+    max-width: min(34vw, 300px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .status-right {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: none;
+    min-width: max-content;
+    justify-content: flex-end;
     margin-left: 0;
-    flex-wrap: wrap;
+    overflow: visible;
+    text-overflow: clip;
+    flex-wrap: nowrap;
+    white-space: nowrap;
   }
 }
 
@@ -97,5 +143,51 @@
 
   .filter-section code {
     justify-self: start;
+  }
+
+  .statusbar {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    height: 27px;
+    min-height: 27px;
+    padding: 0 8px;
+  }
+
+  .status-left {
+    flex: 1 1 auto;
+    flex-wrap: nowrap;
+    gap: 6px;
+  }
+
+  .status-interface-name {
+    flex: 0 1 auto;
+    max-width: 86px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .status-interface-address {
+    flex: 1 1 auto;
+    min-width: 42px;
+    max-width: 30vw;
+    margin-left: 0;
+  }
+
+  .traffic-stats {
+    flex: 0 0 auto;
+  }
+
+  .status-right {
+    flex: 0 0 auto;
+    max-width: none;
+    min-width: max-content;
+    overflow: visible;
+    text-overflow: clip;
+  }
+
+  .operation-status {
+    display: none;
   }
 }

--- a/apps/netscli-gui/src/styles/results.css
+++ b/apps/netscli-gui/src/styles/results.css
@@ -57,10 +57,10 @@
   flex: 0 0 auto;
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 170px;
+  grid-template-columns: minmax(0, 1fr);
   align-items: center;
-  gap: 14px;
-  padding: 8px 14px;
+  gap: 5px;
+  padding: 10px 14px 7px;
   border-bottom: 1px solid var(--border-subtle);
   background: color-mix(in srgb, var(--mint), transparent 94%);
 }
@@ -87,10 +87,12 @@
 }
 
 .operation-progress-bar {
-  height: 3px;
+  position: absolute;
+  inset: 0 0 auto;
+  height: 2px;
   overflow: hidden;
-  background: var(--bg-input);
-  border: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--mint), transparent 88%);
+  border: 0;
 }
 
 .operation-progress-bar span {
@@ -145,6 +147,10 @@
 }
 
 .table-shell {
+  --table-shadow-top: 0 0 transparent;
+  --table-shadow-right: 0 0 transparent;
+  --table-shadow-bottom: 0 0 transparent;
+  --table-shadow-left: 0 0 transparent;
   flex: 1;
   width: 100%;
   height: 100%;
@@ -152,6 +158,11 @@
   overflow: auto;
   outline: 0;
   user-select: none;
+  box-shadow:
+    var(--table-shadow-top),
+    var(--table-shadow-right),
+    var(--table-shadow-bottom),
+    var(--table-shadow-left);
 }
 
 .table-shell.has-vertical-overflow {
@@ -159,7 +170,61 @@
 }
 
 .table-shell:focus-visible {
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--mint), transparent 35%);
+  outline: 1px solid color-mix(in srgb, var(--mint), transparent 35%);
+  outline-offset: -1px;
+}
+
+.table-overflow-shadow {
+  position: sticky;
+  z-index: 7;
+  display: block;
+  pointer-events: none;
+  opacity: 0;
+}
+
+.table-overflow-shadow.top {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 14px;
+  margin-bottom: -14px;
+  background: linear-gradient(to bottom, color-mix(in srgb, var(--shadow), transparent 58%), transparent);
+}
+
+.table-overflow-shadow.bottom {
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 14px;
+  margin-top: -14px;
+  background: linear-gradient(to top, color-mix(in srgb, var(--shadow), transparent 58%), transparent);
+}
+
+.table-overflow-shadow.left {
+  top: 0;
+  left: 0;
+  width: 14px;
+  height: 100%;
+  margin-right: -14px;
+  float: left;
+  background: linear-gradient(to right, color-mix(in srgb, var(--shadow), transparent 58%), transparent);
+}
+
+.table-overflow-shadow.right {
+  top: 0;
+  right: 0;
+  width: 14px;
+  height: 100%;
+  margin-left: -14px;
+  float: right;
+  background: linear-gradient(to left, color-mix(in srgb, var(--shadow), transparent 58%), transparent);
+}
+
+.table-shell.has-top-overflow .table-overflow-shadow.top,
+.table-shell.has-right-overflow .table-overflow-shadow.right,
+.table-shell.has-bottom-overflow .table-overflow-shadow.bottom,
+.table-shell.has-left-overflow .table-overflow-shadow.left {
+  opacity: 1;
 }
 
 .result-table {
@@ -221,34 +286,20 @@
   background: color-mix(in srgb, var(--mint), transparent 72%);
 }
 
-.table-shell::before,
-.table-shell::after {
-  content: "";
-  position: sticky;
-  left: 0;
-  display: block;
-  width: 100%;
-  height: 14px;
-  z-index: 4;
-  pointer-events: none;
-  opacity: 0;
+.table-shell.has-top-overflow {
+  --table-shadow-top: inset 0 18px 16px -16px color-mix(in srgb, var(--shadow), black 25%);
 }
 
-.table-shell::before {
-  top: 30px;
-  margin-bottom: -14px;
-  background: linear-gradient(to bottom, var(--shadow), transparent);
+.table-shell.has-right-overflow {
+  --table-shadow-right: inset -18px 0 16px -16px color-mix(in srgb, var(--shadow), black 25%);
 }
 
-.table-shell::after {
-  bottom: 0;
-  margin-top: -14px;
-  background: linear-gradient(to top, var(--shadow), transparent);
+.table-shell.has-bottom-overflow {
+  --table-shadow-bottom: inset 0 -18px 16px -16px color-mix(in srgb, var(--shadow), black 25%);
 }
 
-.table-shell.has-top-overflow::before,
-.table-shell.has-bottom-overflow::after {
-  opacity: 0.42;
+.table-shell.has-left-overflow {
+  --table-shadow-left: inset 18px 0 16px -16px color-mix(in srgb, var(--shadow), black 25%);
 }
 
 .result-table tbody tr {
@@ -296,6 +347,7 @@
 }
 
 .status-open .status-dot,
+.status-reply .status-dot,
 .status-up .status-dot,
 .run-dot {
   background: var(--mint);
@@ -306,7 +358,8 @@
   background: var(--red);
 }
 
-.status-filtered .status-dot {
+.status-filtered .status-dot,
+.status-timeout .status-dot {
   background: var(--amber);
 }
 

--- a/apps/netscli-gui/src/styles/shell/command-status.css
+++ b/apps/netscli-gui/src/styles/shell/command-status.css
@@ -52,6 +52,10 @@
   white-space: nowrap;
 }
 
+.status-result-divider {
+  flex: 0 0 auto;
+}
+
 .traffic-stats {
   display: inline-flex;
   align-items: center;
@@ -83,6 +87,7 @@
 }
 
 .traffic-rate.active .traffic-arrow {
+  color: var(--mint);
   opacity: 1;
 }
 

--- a/apps/netscli-gui/src/styles/shell/dialogs.css
+++ b/apps/netscli-gui/src/styles/shell/dialogs.css
@@ -217,3 +217,133 @@
   border-color: color-mix(in srgb, var(--mint), transparent 35%);
   color: var(--mint);
 }
+
+.search-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal);
+  display: grid;
+  justify-items: center;
+  align-items: start;
+  padding: 82px 18px 18px;
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.workspace-search {
+  width: min(680px, calc(100vw - 36px));
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  box-shadow: 0 24px 70px var(--shadow);
+}
+
+.workspace-search-input {
+  height: 44px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 0 10px 0 14px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+}
+
+.workspace-search-input input {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.workspace-search-input input::placeholder {
+  color: var(--text-muted);
+}
+
+.workspace-search-input button {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  padding: 0;
+}
+
+.workspace-search-input button:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-selected);
+  color: var(--text-primary);
+}
+
+.workspace-search-results {
+  max-height: min(420px, calc(100vh - 180px));
+  overflow: auto;
+  padding: 6px;
+  background:
+    linear-gradient(var(--bg-elevated), var(--bg-elevated)) top / 100% 16px no-repeat local,
+    linear-gradient(var(--bg-elevated), var(--bg-elevated)) bottom / 100% 16px no-repeat local,
+    linear-gradient(to bottom, color-mix(in srgb, var(--shadow), transparent 55%), transparent) top / 100% 12px no-repeat scroll,
+    linear-gradient(to top, color-mix(in srgb, var(--shadow), transparent 55%), transparent) bottom / 100% 12px no-repeat scroll;
+}
+
+.workspace-search-results button {
+  width: 100%;
+  min-height: 46px;
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  padding: 7px 10px;
+  text-align: left;
+}
+
+.workspace-search-results button:hover,
+.workspace-search-results button.active {
+  background: var(--bg-selected);
+}
+
+.workspace-search-kind {
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.workspace-search-main {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.workspace-search-main strong,
+.workspace-search-main small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-search-main strong {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.workspace-search-main small {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.workspace-search-empty {
+  display: block;
+  padding: 18px;
+  color: var(--text-muted);
+  text-align: center;
+}

--- a/apps/netscli-gui/src/styles/shell/menu.css
+++ b/apps/netscli-gui/src/styles/shell/menu.css
@@ -67,6 +67,10 @@
   box-shadow: 0 12px 30px var(--shadow);
 }
 
+.history-popover {
+  width: 320px;
+}
+
 .menu-popover-section + .menu-popover-section {
   margin-top: 5px;
   padding-top: 5px;
@@ -117,6 +121,13 @@
 
 .menu-popover-item svg {
   color: var(--text-muted);
+}
+
+.menu-popover-item-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .menu-popover-item:hover:not(:disabled) svg {

--- a/apps/netscli-gui/src/styles/shell/settings.css
+++ b/apps/netscli-gui/src/styles/shell/settings.css
@@ -4,6 +4,12 @@
   gap: 6px;
 }
 
+.settings-interface-field.compact {
+  width: 174px;
+  min-width: 174px;
+  justify-self: end;
+}
+
 .settings-interface-trigger {
   width: 100%;
   min-height: 48px;
@@ -38,13 +44,14 @@
 
 .settings-interface-trigger svg {
   flex: 0 0 auto;
+  align-self: center;
   color: var(--text-muted);
+  justify-self: end;
 }
 
-.settings-interface-list {
+.settings-select-list {
   position: fixed;
   z-index: var(--z-dropdown);
-  width: min(620px, calc(100vw - 16px));
   display: flex;
   flex-direction: column;
   align-content: start;
@@ -53,6 +60,23 @@
   border: 1px solid var(--border-subtle);
   background: var(--bg-input);
   box-shadow: 0 18px 46px var(--shadow);
+}
+
+.settings-interface-list {
+  display: flex;
+  flex-direction: column;
+  align-content: start;
+  width: 100%;
+  max-height: 280px;
+  overflow: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-input);
+}
+
+.settings-select-list {
+  min-width: 150px;
+  padding: 5px;
 }
 
 .settings-interface-option {
@@ -90,6 +114,31 @@
   gap: 5px;
 }
 
+.settings-interface-field.compact .settings-interface-badges {
+  min-width: 0;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.settings-interface-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.settings-interface-status > span {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--red);
+}
+
+.settings-interface-status.up > span {
+  background: var(--mint);
+}
+
 .settings-interface-badge {
   display: inline-flex;
   align-items: center;
@@ -109,6 +158,86 @@
 .settings-interface-option.selected {
   color: var(--mint);
   background: color-mix(in srgb, var(--mint), transparent 90%);
+}
+
+.settings-select-field {
+  width: 174px;
+  min-width: 174px;
+}
+
+.settings-select-trigger {
+  width: 100%;
+  height: 30px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  padding: 0 9px 0 10px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.settings-interface-field.compact .settings-interface-option {
+  min-height: 40px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 5px;
+  padding: 7px 9px;
+}
+
+.settings-interface-field.compact .settings-interface-trigger {
+  min-height: 30px;
+  padding: 4px 9px 4px 10px;
+}
+
+.settings-select-trigger:hover,
+.settings-select-trigger:focus-visible,
+.settings-select-trigger.active {
+  border-color: var(--border-strong);
+}
+
+.settings-select-trigger span,
+.settings-select-option-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-select-trigger svg {
+  align-self: center;
+  color: var(--text-muted);
+  justify-self: end;
+}
+
+.settings-select-list button {
+  width: 100%;
+  min-height: 30px;
+  display: grid;
+  gap: 2px;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  padding: 6px 9px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.settings-select-list button:hover,
+.settings-select-list button.selected {
+  background: var(--bg-selected);
+  color: var(--mint);
+}
+
+.settings-select-list small {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .settings-empty {

--- a/apps/netscli-gui/src/tools/presentation/columns.ts
+++ b/apps/netscli-gui/src/tools/presentation/columns.ts
@@ -39,6 +39,26 @@ export function columnsFor(
           ? { key: 'banner', label: 'Banner', grow: true }
           : { key: 'banner', label: 'Banner', width: 160 },
       ];
+    case 'ping':
+      return [
+        { key: 'metric', label: 'Metric', width: 120 },
+        { key: 'host', label: 'Host', mono: true, width: 220 },
+        { key: 'ip', label: 'Resolved IP', mono: true, width: 220 },
+        { key: 'sent', label: 'Sent', mono: true, width: 90 },
+        { key: 'received', label: 'Received', mono: true, width: 110 },
+        { key: 'loss', label: 'Loss', mono: true, width: 100 },
+        { key: 'avg', label: 'Avg RTT', mono: true, width: 120 },
+        { key: 'range', label: 'RTT Range', mono: true, grow: true },
+      ];
+    case 'trace':
+      return [
+        { key: 'hop', label: 'Hop', mono: true, width: 90 },
+        { key: 'status', label: 'Status', width: 120 },
+        { key: 'best', label: 'Best', mono: true, width: 120 },
+        { key: 'avg', label: 'Avg', mono: true, width: 120 },
+        { key: 'worst', label: 'Worst', mono: true, width: 120 },
+        { key: 'address', label: 'Address / Host', mono: true, grow: true },
+      ];
     case 'discover':
       return [
         { key: 'ip', label: 'IP', mono: true, width: 170 },
@@ -57,6 +77,11 @@ export function columnsFor(
         { key: 'value', label: 'Value', mono: true, grow: true },
         { key: 'ttl', label: 'TTL', mono: true, width: 90 },
         { key: 'resolver', label: 'Resolver', width: 130 },
+      ];
+    case 'reverse':
+      return [
+        { key: 'ip', label: 'IP', mono: true, width: 220 },
+        { key: 'hostname', label: 'Reverse Name', mono: true, grow: true },
       ];
     case 'sweep':
       return [
@@ -89,6 +114,14 @@ export function columnsFor(
         { key: 'mac', label: 'MAC', mono: true, width: 190 },
         { key: 'interface', label: 'Interface', width: 160 },
         { key: 'vendor', label: 'Vendor', grow: true },
+      ];
+    case 'mdns':
+      return [
+        { key: 'service_type', label: 'Service Type', mono: true, width: 210 },
+        { key: 'hostname', label: 'Hostname', width: 220 },
+        { key: 'addresses', label: 'Addresses', mono: true, grow: true },
+        { key: 'port', label: 'Port', mono: true, width: 90 },
+        { key: 'name', label: 'Name', mono: true, grow: true },
       ];
     case 'pcap':
       return [

--- a/apps/netscli-gui/src/tools/presentation/commands.ts
+++ b/apps/netscli-gui/src/tools/presentation/commands.ts
@@ -6,21 +6,42 @@ export function buildCommand(tab: WorkspaceTab): string {
   switch (tab.kind) {
     case 'scan':
       return `netscli scan ${form.host || '<host>'} -p ${form.ports || DEFAULT_PORTS} --json`;
+    case 'ping':
+      return `netscli ping ${form.host || '<host>'}${form.count ? ` --count ${form.count}` : ''} --json`;
+    case 'trace': {
+      const resolve = form.resolve === 'On' ? ' --resolve' : '';
+      return `netscli trace ${form.host || '<host>'}${form.max_hops ? ` --max-hops ${form.max_hops}` : ''}${resolve} --json`;
+    }
     case 'discover':
       return `netscli discover${form.subnet ? ` ${form.subnet}` : ''} --resolve --json`;
     case 'dns': {
       const record = form.record && form.record !== 'ALL' ? ` --record ${form.record}` : '';
       return `netscli dns ${form.host || '<host>'}${record} --json`;
     }
+    case 'reverse':
+      return `netscli reverse ${form.ip || '<ip>'} --json`;
     case 'inspect':
       return `netscli inspect ${form.host || '<host>'}${form.ports ? ` -p ${form.ports}` : ''} --json`;
     case 'sweep':
       return `netscli sweep${form.subnet ? ` ${form.subnet}` : ''}${form.ports ? ` -p ${form.ports}` : ''} --resolve --json`;
+    case 'mdns': {
+      const types = form.service_types
+        ?.split(',')
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .map((item) => ` --type ${item}`)
+        .join('') ?? '';
+      const timeout = form.timeout_ms && form.timeout_ms !== '3000' ? ` --timeout-ms ${form.timeout_ms}` : '';
+      return `netscli mdns${timeout}${types} --json`;
+    }
     case 'interfaces':
       return 'netscli interfaces --json';
     case 'arp':
       return 'netscli arp --json';
     case 'pcap': {
+      if (form.mode === 'Open File') {
+        return `netscli pcap --read <file>${form.max_packets ? ` --max-packets ${form.max_packets}` : ''} --json`;
+      }
       const parts = ['netscli pcap'];
       if (form.interface) parts.push(`--interface ${form.interface}`);
       if (form.duration) parts.push(`--duration ${form.duration}`);

--- a/apps/netscli-gui/src/tools/presentation/details.ts
+++ b/apps/netscli-gui/src/tools/presentation/details.ts
@@ -187,6 +187,19 @@ export function detailLinesForRow(row: ResultRow): DetailLine[] {
   }));
 
   switch (row.kind) {
+    case 'ping':
+      return pingDetailLines(row.raw);
+    case 'trace':
+      return traceDetailLines(row.raw);
+    case 'reverse':
+      return [
+        ...lines,
+        {
+          label: 'Summary',
+          value: row.data.hostname ? 'Reverse DNS name found for this IP.' : 'No reverse DNS name returned.',
+          muted: !row.data.hostname,
+        },
+      ];
     case 'discover':
       return [
         ...lines,
@@ -220,9 +233,68 @@ export function detailLinesForRow(row: ResultRow): DetailLine[] {
       ];
     case 'dns':
       return lines.filter((line) => line.value !== '-');
+    case 'mdns':
+      return mdnsDetailLines(row.raw);
     default:
       return lines;
   }
+}
+
+function pingDetailLines(raw: unknown): DetailLine[] {
+  const summary = raw as Record<string, unknown>;
+  const sent = Number(summary.sent ?? 0);
+  const received = Number(summary.received ?? 0);
+  const loss = Number(summary.loss_pct ?? 0);
+  return [
+    { label: 'Host', value: valueOrDash(summary.host) },
+    { label: 'Resolved IP', value: valueOrDash(summary.ip) },
+    { label: 'Sent', value: valueOrDash(summary.sent) },
+    { label: 'Received', value: valueOrDash(summary.received) },
+    { label: 'Packet Loss', value: `${formatNumeric(loss)}%`, muted: loss > 0 },
+    { label: 'RTT Average', value: optionalMs(summary.rtt_ms_avg) },
+    { label: 'RTT Min', value: optionalMs(summary.rtt_ms_min) },
+    { label: 'RTT Max', value: optionalMs(summary.rtt_ms_max) },
+    {
+      label: 'Summary',
+      value:
+        received > 0
+          ? `${received} of ${sent} probes replied.`
+          : 'No replies were received before timeout.',
+      muted: received === 0,
+    },
+  ];
+}
+
+function traceDetailLines(raw: unknown): DetailLine[] {
+  const hop = raw as Record<string, unknown>;
+  return [
+    { label: 'Hop', value: valueOrDash(hop.hop) },
+    { label: 'Status', value: valueOrDash(hop.status) },
+    { label: 'Best RTT', value: valueOrDash(hop.best) },
+    { label: 'Average RTT', value: valueOrDash(hop.avg) },
+    { label: 'Worst RTT', value: valueOrDash(hop.worst) },
+    { label: 'Address / Host', value: valueOrDash(hop.address) },
+    { label: 'Tool', value: valueOrDash(hop.tool) },
+    { label: 'Exit Code', value: valueOrDash(hop.exit_code) },
+    { label: 'Output', value: valueOrDash(hop.line) },
+  ];
+}
+
+function mdnsDetailLines(raw: unknown): DetailLine[] {
+  const service = raw as Record<string, unknown>;
+  const properties = service.properties && typeof service.properties === 'object'
+    ? Object.entries(service.properties as Record<string, unknown>)
+        .map(([key, value]) => `${key}=${String(value)}`)
+        .join(', ')
+    : '';
+  return [
+    { label: 'Service Type', value: valueOrDash(service.service_type) },
+    { label: 'Hostname', value: valueOrDash(service.hostname) },
+    { label: 'Addresses', value: Array.isArray(service.addresses) ? service.addresses.join(', ') : '-' },
+    { label: 'Port', value: valueOrDash(service.port) },
+    { label: 'Full Name', value: valueOrDash(service.full_name) },
+    { label: 'TXT Properties', value: properties || '-', muted: !properties },
+  ];
 }
 
 function pcapDetailLines(raw: unknown): DetailLine[] {
@@ -258,6 +330,14 @@ function addOptionalLine(lines: DetailLine[], label: string, value: unknown) {
 
 function valueOrDash(value: unknown): string {
   return value == null || value === '' ? '-' : String(value);
+}
+
+function optionalMs(value: unknown): string {
+  return typeof value === 'number' && Number.isFinite(value) ? `${formatNumeric(value)} ms` : '-';
+}
+
+function formatNumeric(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }
 
 function bannerReason(port: PortResult): string {
@@ -363,14 +443,22 @@ function labelForKind(kind: string): string {
   switch (kind) {
     case 'scan':
       return 'Port scan';
+    case 'ping':
+      return 'Ping';
+    case 'trace':
+      return 'Trace route';
     case 'discover':
       return 'Discovery';
     case 'dns':
       return 'DNS lookup';
+    case 'reverse':
+      return 'Reverse DNS';
     case 'inspect':
       return 'Inspect';
     case 'sweep':
       return 'Sweep';
+    case 'mdns':
+      return 'mDNS discovery';
     case 'interfaces':
       return 'Interfaces';
     case 'arp':

--- a/apps/netscli-gui/src/tools/presentation/filterHints.ts
+++ b/apps/netscli-gui/src/tools/presentation/filterHints.ts
@@ -15,17 +15,27 @@ export interface FilterHints {
 
 const FIELD_KEY_LABELS: Record<string, string> = {
   ip: 'IP address',
+  addresses: 'Addresses',
+  avg: 'Avg RTT',
+  hop: 'Hop',
   record_type: 'Record type',
   ips: 'Address',
+  loss: 'Packet loss',
+  metric: 'Metric',
   name: 'Interface',
   open_ports: 'Open ports',
   resolver: 'Resolver',
+  service_type: 'Service type',
   ttl: 'TTL',
   app: 'App marker',
+  address: 'Address / host',
+  best: 'Best RTT',
+  worst: 'Worst RTT',
 };
 
 const FIELD_KEY_ALIASES: Record<string, string> = {
   banner: 'banner',
+  addresses: 'addresses',
   app: 'app',
   duration: 'duration',
   file: 'file',
@@ -52,7 +62,18 @@ const FIELD_KEY_ALIASES: Record<string, string> = {
   info: 'info',
   kind: 'kind',
   length: 'length',
+  loss: 'loss',
   time: 'time',
+  hop: 'hop',
+  host: 'host',
+  address: 'address',
+  received: 'received',
+  sent: 'sent',
+  avg: 'avg',
+  best: 'best',
+  worst: 'worst',
+  range: 'range',
+  service_type: 'service_type',
   ttl: 'ttl',
   value: 'value',
   resolver: 'resolver',
@@ -61,10 +82,14 @@ const FIELD_KEY_ALIASES: Record<string, string> = {
 
 const SAMPLE_FIELDS: Record<ToolKind, string[]> = {
   scan: ['status', 'port', 'service', 'banner'],
+  ping: ['host', 'ip', 'loss', 'avg'],
+  trace: ['hop', 'status', 'address', 'avg'],
   discover: ['ip', 'hostname', 'vendor', 'mac'],
   dns: ['record_type', 'value', 'resolver', 'ttl'],
+  reverse: ['ip', 'hostname'],
   inspect: ['status', 'port', 'service', 'hostname'],
   sweep: ['ip', 'hostname', 'vendor', 'ports', 'mac'],
+  mdns: ['service_type', 'hostname', 'addresses', 'port'],
   interfaces: ['state', 'name', 'ips', 'kind'],
   arp: ['ip', 'interface', 'vendor', 'mac'],
   pcap: ['protocol', 'source', 'destination', 'info'],
@@ -99,11 +124,19 @@ function placeholderFor(kind: ToolKind): string {
     case 'scan':
     case 'inspect':
       return 'filter results: status:open port:<number>';
+    case 'ping':
+      return 'filter results: host:<name> loss:<percent>';
+    case 'trace':
+      return 'filter results: hop:<number> address:<host>';
     case 'dns':
       return 'filter results: type:A value:<text>';
+    case 'reverse':
+      return 'filter results: ip:<address> hostname:<name>';
     case 'discover':
     case 'sweep':
       return 'filter results: ip:<address> vendor:<name>';
+    case 'mdns':
+      return 'filter results: service_type:<type> hostname:<name>';
     case 'interfaces':
       return 'filter results: state:up interface:<name>';
     case 'arp':
@@ -118,11 +151,19 @@ function exampleFor(kind: ToolKind): string {
     case 'scan':
     case 'inspect':
       return 'status:open';
+    case 'ping':
+      return 'loss:0';
+    case 'trace':
+      return 'hop:1';
     case 'dns':
       return 'type:A';
+    case 'reverse':
+      return 'hostname:router';
     case 'discover':
     case 'sweep':
       return 'ip:192.168';
+    case 'mdns':
+      return 'service_type:_http';
     case 'interfaces':
       return 'state:up';
     case 'arp':

--- a/apps/netscli-gui/src/tools/presentation/rows.ts
+++ b/apps/netscli-gui/src/tools/presentation/rows.ts
@@ -29,6 +29,54 @@ export function buildRows(result: ToolResult | null): ResultRow[] {
   switch (result.kind) {
     case 'scan':
       return result.data.map((port, index) => portRow(port, index, 'scan'));
+    case 'ping': {
+      const loss = Number.isFinite(result.data.loss_pct) ? `${formatNumber(result.data.loss_pct)}%` : '';
+      const data = {
+        metric: 'summary',
+        host: result.data.host,
+        ip: result.data.ip,
+        sent: result.data.sent,
+        received: result.data.received,
+        loss,
+        avg: result.data.rtt_ms_avg == null ? '' : `${formatNumber(result.data.rtt_ms_avg)} ms`,
+        range:
+          result.data.rtt_ms_min == null || result.data.rtt_ms_max == null
+            ? ''
+            : `${result.data.rtt_ms_min}-${result.data.rtt_ms_max} ms`,
+      };
+      return [
+        {
+          id: `ping-${result.data.host}`,
+          kind: 'ping',
+          data,
+          raw: result.data,
+          searchText: Object.values(data).join(' ').toLowerCase(),
+        },
+      ];
+    }
+    case 'trace':
+      return result.data.lines
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => parseTraceLine(line))
+        .filter((hop): hop is TraceHopRow => hop !== null)
+        .map((hop, index) => {
+          const data = {
+            hop: hop.hop,
+            status: hop.status,
+            best: hop.best,
+            avg: hop.avg,
+            worst: hop.worst,
+            address: hop.address,
+          };
+          return {
+            id: `trace-${hop.hop}-${index}`,
+            kind: 'trace' as const,
+            data,
+            raw: { ...hop, tool: result.data.tool, exit_code: result.data.exit_code },
+            searchText: Object.values(data).join(' ').toLowerCase(),
+          };
+        });
     case 'discover':
       return result.data.map((host, index) => {
         const data = {
@@ -63,6 +111,21 @@ export function buildRows(result: ToolResult | null): ResultRow[] {
           searchText: Object.values(data).join(' ').toLowerCase(),
         };
       });
+    case 'reverse': {
+      const data = {
+        ip: result.data.ip,
+        hostname: result.data.hostname ?? '',
+      };
+      return [
+        {
+          id: `reverse-${result.data.ip}`,
+          kind: 'reverse',
+          data,
+          raw: result.data,
+          searchText: Object.values(data).join(' ').toLowerCase(),
+        },
+      ];
+    }
     case 'inspect': {
       const ports = result.data.ports?.length ? result.data.ports : result.data.open_ports;
       const rows = ports.map((port, index) => portRow(port, index, 'inspect'));
@@ -102,6 +165,23 @@ export function buildRows(result: ToolResult | null): ResultRow[] {
           kind: 'sweep',
           data,
           raw: entry,
+          searchText: Object.values(data).join(' ').toLowerCase(),
+        };
+      });
+    case 'mdns':
+      return result.data.map((service, index) => {
+        const data = {
+          service_type: service.service_type,
+          hostname: service.hostname,
+          addresses: service.addresses.join(', '),
+          port: service.port,
+          name: service.full_name,
+        };
+        return {
+          id: `mdns-${service.full_name}-${index}`,
+          kind: 'mdns',
+          data,
+          raw: service,
           searchText: Object.values(data).join(' ').toLowerCase(),
         };
       });
@@ -164,6 +244,94 @@ export function buildRows(result: ToolResult | null): ResultRow[] {
       });
     }
   }
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+interface TraceHopRow {
+  hop: number;
+  status: string;
+  best: string;
+  avg: string;
+  worst: string;
+  address: string;
+  line: string;
+}
+
+function parseTraceLine(line: string): TraceHopRow | null {
+  const windows = line.match(
+    /^\s*(\d+)\s+((?:<\d+|\d+)\s*ms|\*)\s+((?:<\d+|\d+)\s*ms|\*)\s+((?:<\d+|\d+)\s*ms|\*)\s+(.+)$/i,
+  );
+  if (windows) {
+    const samples = [windows[2], windows[3], windows[4]].map(formatTraceSample);
+    const address = windows[5].trim();
+    const timeout = samples.every((sample) => sample === '*');
+    return {
+      hop: Number(windows[1]),
+      status: timeout ? 'timeout' : 'reply',
+      best: timeout ? '-' : traceBest(samples),
+      avg: timeout ? '-' : traceAverage(samples),
+      worst: timeout ? '-' : traceWorst(samples),
+      address: timeout ? 'Request timed out' : address,
+      line,
+    };
+  }
+
+  const unix = line.match(/^\s*(\d+)\s+(.+)$/);
+  if (!unix) return null;
+  const rest = unix[2].trim();
+  if (/^(tracing route|trace complete|over a maximum)/i.test(rest)) return null;
+  const timeout = /^\*([\s*]+)?$/.test(rest);
+  if (timeout) {
+    return {
+      hop: Number(unix[1]),
+      status: 'timeout',
+      best: '-',
+      avg: '-',
+      worst: '-',
+      address: 'Request timed out',
+      line,
+    };
+  }
+  const samples = Array.from(rest.matchAll(/(<\d+|\d+(?:\.\d+)?)\s*ms/gi)).map((match) => formatTraceSample(match[0]));
+  const address = rest.replace(/\s+(?:<\d+|\d+(?:\.\d+)?)\s*ms/gi, '').trim();
+  return {
+    hop: Number(unix[1]),
+    status: samples.length > 0 ? 'reply' : 'note',
+    best: samples.length > 0 ? traceBest(samples) : '-',
+    avg: samples.length > 0 ? traceAverage(samples) : '-',
+    worst: samples.length > 0 ? traceWorst(samples) : '-',
+    address: address || rest,
+    line,
+  };
+}
+
+function formatTraceSample(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function traceSampleNumber(value: string): number | null {
+  const match = value.match(/<?(\d+(?:\.\d+)?)/);
+  return match ? Number(match[1]) : null;
+}
+
+function traceBest(samples: string[]): string {
+  const numbers = samples.map(traceSampleNumber).filter((value): value is number => value != null);
+  return numbers.length > 0 ? `${Math.min(...numbers)} ms` : '-';
+}
+
+function traceWorst(samples: string[]): string {
+  const numbers = samples.map(traceSampleNumber).filter((value): value is number => value != null);
+  return numbers.length > 0 ? `${Math.max(...numbers)} ms` : '-';
+}
+
+function traceAverage(samples: string[]): string {
+  const numbers = samples.map(traceSampleNumber).filter((value): value is number => value != null);
+  if (numbers.length === 0) return '-';
+  const avg = numbers.reduce((sum, value) => sum + value, 0) / numbers.length;
+  return `${formatNumber(avg)} ms`;
 }
 
 function interfaceKind(name: string, isLoopback: boolean): string {

--- a/apps/netscli-gui/src/tools/presentation/summaries.ts
+++ b/apps/netscli-gui/src/tools/presentation/summaries.ts
@@ -7,10 +7,16 @@ export function resultSummary(result: ToolResult | null): string {
       const open = result.data.filter((port) => port.open).length;
       return `${result.data.length} results - ${open} open`;
     }
+    case 'ping':
+      return `${result.data.received}/${result.data.sent} replies - ${formatNumber(result.data.loss_pct)}% loss`;
+    case 'trace':
+      return `${traceHopCount(result.data.lines)} hops - ${result.data.tool}`;
     case 'discover':
       return `${result.data.length} hosts`;
     case 'dns':
       return `${result.data.length} records`;
+    case 'reverse':
+      return result.data.hostname ? 'reverse name found' : 'no reverse name';
     case 'inspect': {
       const ports = result.data.ports ?? result.data.open_ports;
       if (ports.length > 0) {
@@ -25,11 +31,21 @@ export function resultSummary(result: ToolResult | null): string {
       const open = result.data.filter((host) => host.open_ports.length > 0).length;
       return `${hosts} hosts - ${open} with open ports`;
     }
+    case 'mdns':
+      return `${result.data.length} services`;
     case 'interfaces':
       return `${result.data.length} interfaces`;
     case 'arp':
       return `${result.data.length} ARP entries`;
     case 'pcap':
-      return `${result.data.packets_captured} packets`;
+      return `${'packets_captured' in result.data ? result.data.packets_captured : result.data.total_packets} packets`;
   }
+}
+
+function traceHopCount(lines: string[]): number {
+  return lines.filter((line) => /^\s*\d+\s+/.test(line)).length;
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }

--- a/apps/netscli-gui/src/tools/presentation/table.ts
+++ b/apps/netscli-gui/src/tools/presentation/table.ts
@@ -33,10 +33,10 @@ interface FilterToken {
 }
 
 const FIELD_ALIASES: Record<string, string[]> = {
-  address: ['ips'],
-  addresses: ['ips'],
+  address: ['ips', 'addresses'],
+  addresses: ['ips', 'addresses'],
   dns: ['record_type'],
-  host: ['ip'],
+  host: ['host', 'ip', 'hostname'],
   interface: ['interface', 'name'],
   record: ['record_type'],
   type: ['record_type'],

--- a/apps/netscli-gui/src/tools/presentation/tabs.ts
+++ b/apps/netscli-gui/src/tools/presentation/tabs.ts
@@ -8,10 +8,14 @@ export interface TabIdentity {
 
 const TAB_LABELS: Record<WorkspaceTab['kind'], string> = {
   scan: 'Scan',
+  ping: 'Ping',
+  trace: 'Trace',
   discover: 'Discover',
   dns: 'DNS',
+  reverse: 'Reverse DNS',
   inspect: 'Inspect',
   sweep: 'Sweep',
+  mdns: 'mDNS',
   interfaces: 'Interfaces',
   arp: 'ARP',
   pcap: 'Packet Capture',
@@ -27,6 +31,10 @@ export function tabIdentity(tab: WorkspaceTab): TabIdentity {
         label,
         identifier: joinParts(clean(form.host), customPorts(form.ports)),
       };
+    case 'ping':
+      return { label, identifier: clean(form.host) || 'New' };
+    case 'trace':
+      return { label, identifier: clean(form.host) || 'New' };
     case 'discover':
       return { label, identifier: clean(form.subnet) || 'Default subnet' };
     case 'dns':
@@ -34,6 +42,8 @@ export function tabIdentity(tab: WorkspaceTab): TabIdentity {
         label,
         identifier: clean(form.host) ? joinParts(clean(form.host), dnsRecordLabel(form.record)) : 'New',
       };
+    case 'reverse':
+      return { label, identifier: clean(form.ip) || 'New' };
     case 'inspect':
       return {
         label,
@@ -44,6 +54,11 @@ export function tabIdentity(tab: WorkspaceTab): TabIdentity {
         label,
         identifier: joinParts(clean(form.subnet), customPorts(form.ports)),
       };
+    case 'mdns':
+      return {
+        label,
+        identifier: clean(form.service_types) || '',
+      };
     case 'interfaces':
       return { label, identifier: '' };
     case 'arp':
@@ -51,7 +66,12 @@ export function tabIdentity(tab: WorkspaceTab): TabIdentity {
     case 'pcap':
       return {
         label,
-        identifier: clean(form.interface) ? joinParts(clean(form.interface), clean(form.filter)) : 'New',
+        identifier:
+          form.mode === 'Open File'
+            ? 'Open File'
+            : clean(form.interface)
+              ? joinParts(clean(form.interface), clean(form.filter))
+              : 'New',
       };
   }
 }

--- a/apps/netscli-gui/src/tools/registry.ts
+++ b/apps/netscli-gui/src/tools/registry.ts
@@ -3,32 +3,42 @@ import {
   Database,
   Globe2,
   HardDrive,
+  Map,
   Network,
   Radio,
+  Radar,
+  Route,
   Search,
 } from 'lucide-react';
 
-import type { ToolConfig, ToolKind, WorkspaceTab } from './types';
+import type { ToolCapabilityMap, ToolConfig, ToolKind, WorkspaceTab } from './types';
 
 export const DEFAULT_PORTS = '22,80,443,8080,8443';
 
 export const TOOL_KINDS: ToolKind[] = [
   'scan',
+  'ping',
+  'trace',
   'discover',
   'dns',
+  'reverse',
   'inspect',
   'sweep',
+  'mdns',
   'interfaces',
   'arp',
   'pcap',
 ];
 
-export const SCAN_TOOL_KINDS: ToolKind[] = ['scan', 'discover', 'inspect', 'sweep'];
+export const SCAN_TOOL_KINDS: ToolKind[] = ['scan', 'ping', 'trace', 'discover', 'inspect', 'sweep'];
 
-export const LOOKUP_TOOL_KINDS: ToolKind[] = ['dns', 'interfaces', 'arp', 'pcap'];
+export const LOOKUP_TOOL_KINDS: ToolKind[] = ['dns', 'reverse', 'mdns', 'interfaces', 'arp', 'pcap'];
 
-export function availableToolKinds(kinds: ToolKind[], pcapAvailable: boolean): ToolKind[] {
-  return pcapAvailable ? kinds : kinds.filter((kind) => kind !== 'pcap');
+export function availableToolKinds(
+  kinds: ToolKind[],
+  capabilities: ToolCapabilityMap,
+): ToolKind[] {
+  return kinds.filter((kind) => capabilities[kind] ?? true);
 }
 
 export const TOOL_CONFIG: Record<ToolKind, ToolConfig> = {
@@ -40,6 +50,33 @@ export const TOOL_CONFIG: Record<ToolKind, ToolConfig> = {
     fields: [
       { key: 'host', label: 'Host', placeholder: '127.0.0.1', required: true },
       { key: 'ports', label: 'Ports', placeholder: DEFAULT_PORTS },
+    ],
+  },
+  ping: {
+    label: 'Ping',
+    shortLabel: 'ping',
+    Icon: Radar,
+    action: 'Ping',
+    fields: [
+      { key: 'host', label: 'Host', placeholder: '127.0.0.1', required: true },
+      { key: 'count', label: 'Count', type: 'number', compact: true, placeholder: '4', min: 1, max: 50, step: 1 },
+    ],
+  },
+  trace: {
+    label: 'Trace Route',
+    shortLabel: 'trace',
+    Icon: Route,
+    action: 'Trace',
+    fields: [
+      { key: 'host', label: 'Host', placeholder: '1.1.1.1', required: true },
+      { key: 'max_hops', label: 'Hops', type: 'number', compact: true, placeholder: '30', min: 1, max: 255, step: 1 },
+      {
+        key: 'resolve',
+        label: 'Names',
+        type: 'select',
+        compact: true,
+        options: ['Off', 'On'],
+      },
     ],
   },
   discover: {
@@ -65,6 +102,13 @@ export const TOOL_CONFIG: Record<ToolKind, ToolConfig> = {
       },
     ],
   },
+  reverse: {
+    label: 'Reverse DNS',
+    shortLabel: 'reverse',
+    Icon: Globe2,
+    action: 'Lookup',
+    fields: [{ key: 'ip', label: 'IP', placeholder: '192.168.1.1', required: true }],
+  },
   inspect: {
     label: 'Inspect',
     shortLabel: 'inspect',
@@ -85,6 +129,15 @@ export const TOOL_CONFIG: Record<ToolKind, ToolConfig> = {
       { key: 'ports', label: 'Ports', placeholder: '22,80,443' },
     ],
   },
+  mdns: {
+    label: 'mDNS Discovery',
+    shortLabel: 'mdns',
+    Icon: Radio,
+    action: 'Discover',
+    fields: [
+      { key: 'service_types', label: 'Service Types', placeholder: '_http._tcp.local., _ssh._tcp.local.' },
+    ],
+  },
   interfaces: {
     label: 'Interfaces',
     shortLabel: 'interfaces',
@@ -102,34 +155,43 @@ export const TOOL_CONFIG: Record<ToolKind, ToolConfig> = {
   pcap: {
     label: 'Packet Capture',
     shortLabel: 'capture',
-    Icon: Activity,
+    Icon: Map,
     action: 'Capture',
     fields: [
+      { key: 'mode', label: 'Mode', type: 'select', compact: true, options: ['Capture', 'Open File'] },
       { key: 'interface', label: 'Interface', type: 'select', placeholder: 'Select interface', required: true },
-      { key: 'duration', label: 'Seconds', type: 'number', compact: true, placeholder: '5' },
+      { key: 'duration', label: 'Seconds', type: 'number', compact: true, placeholder: '5', min: 1, max: 3600, step: 1 },
       { key: 'filter', label: 'Filter', placeholder: 'tcp port 443' },
-      { key: 'max_packets', label: 'Packets', type: 'number', compact: true, placeholder: '1000' },
+      { key: 'max_packets', label: 'Packets', type: 'number', compact: true, placeholder: '1000', min: 1, max: 100000, step: 1 },
     ],
   },
 };
 
 export const DEFAULT_FORM: Record<ToolKind, Record<string, string>> = {
   scan: { host: '127.0.0.1', ports: DEFAULT_PORTS },
+  ping: { host: '127.0.0.1', count: '4' },
+  trace: { host: '1.1.1.1', max_hops: '30', resolve: 'Off' },
   discover: { subnet: '' },
   dns: { host: 'netscli.com', record: 'ALL' },
+  reverse: { ip: '127.0.0.1' },
   inspect: { host: '127.0.0.1', ports: DEFAULT_PORTS },
   sweep: { subnet: '', ports: '22,80,443' },
+  mdns: { timeout_ms: '3000', service_types: '' },
   interfaces: {},
   arp: {},
-  pcap: { interface: '', duration: '5', filter: '', max_packets: '1000' },
+  pcap: { mode: 'Capture', interface: '', duration: '5', filter: '', max_packets: '1000' },
 };
 
 export const DEFAULT_SORT: Record<ToolKind, string> = {
   scan: 'port',
+  ping: 'metric',
+  trace: 'hop',
   discover: 'ip',
   dns: 'record_type',
+  reverse: 'ip',
   inspect: 'port',
   sweep: 'ip',
+  mdns: 'hostname',
   interfaces: 'name',
   arp: 'ip',
   pcap: 'no',

--- a/apps/netscli-gui/src/tools/types.ts
+++ b/apps/netscli-gui/src/tools/types.ts
@@ -5,14 +5,19 @@ import type { PortResult } from '../types/netscli';
 
 export type ToolKind =
   | 'scan'
+  | 'ping'
+  | 'trace'
   | 'discover'
   | 'dns'
+  | 'reverse'
   | 'inspect'
   | 'sweep'
+  | 'mdns'
   | 'interfaces'
   | 'arp'
   | 'pcap';
 
+export type ToolCapabilityMap = Partial<Record<ToolKind, boolean>>;
 export type DetailTab = 'details' | 'overview' | 'ports' | 'banner' | 'headers' | 'tls' | 'selection' | 'raw';
 export type SortDir = 'asc' | 'desc';
 export type RowSelectionMode = 'single' | 'toggle' | 'range' | 'focus';
@@ -23,6 +28,9 @@ export interface ToolField {
   placeholder?: string;
   type?: 'text' | 'number' | 'select';
   options?: string[];
+  min?: number;
+  max?: number;
+  step?: number;
   required?: boolean;
   compact?: boolean;
 }

--- a/apps/netscli-gui/src/types/app.ts
+++ b/apps/netscli-gui/src/types/app.ts
@@ -4,9 +4,14 @@ import type {
   Host,
   InspectResult,
   InterfaceInfo,
+  MdnsService,
+  PcapParseResult,
   PcapResult,
+  PingSummary,
   PortResult,
+  ReverseDnsResult,
   SweepEntry,
+  TraceResult,
 } from './netscli';
 
 type ToolResultMeta = {
@@ -16,9 +21,13 @@ type ToolResultMeta = {
 export type ToolResult =
   | ({ kind: 'discover'; data: Host[] } & ToolResultMeta)
   | ({ kind: 'scan'; data: PortResult[] } & ToolResultMeta)
+  | ({ kind: 'ping'; data: PingSummary } & ToolResultMeta)
+  | ({ kind: 'trace'; data: TraceResult } & ToolResultMeta)
+  | ({ kind: 'reverse'; data: ReverseDnsResult } & ToolResultMeta)
   | ({ kind: 'inspect'; data: InspectResult } & ToolResultMeta)
   | ({ kind: 'sweep'; data: SweepEntry[] } & ToolResultMeta)
   | ({ kind: 'dns'; data: DnsRecord[] } & ToolResultMeta)
+  | ({ kind: 'mdns'; data: MdnsService[] } & ToolResultMeta)
   | ({ kind: 'interfaces'; data: InterfaceInfo[] } & ToolResultMeta)
   | ({ kind: 'arp'; data: ArpEntry[] } & ToolResultMeta)
-  | ({ kind: 'pcap'; data: PcapResult } & ToolResultMeta);
+  | ({ kind: 'pcap'; data: PcapResult | PcapParseResult } & ToolResultMeta);

--- a/apps/netscli-gui/src/types/netscli.ts
+++ b/apps/netscli-gui/src/types/netscli.ts
@@ -51,6 +51,29 @@ export interface PingResult {
   method?: string;
 }
 
+export interface PingSummary {
+  host: string;
+  ip: string;
+  sent: number;
+  received: number;
+  loss_pct: number;
+  rtt_ms_min?: number | null;
+  rtt_ms_max?: number | null;
+  rtt_ms_avg?: number | null;
+}
+
+export interface TraceResult {
+  host: string;
+  tool: string;
+  exit_code?: number | null;
+  lines: string[];
+}
+
+export interface ReverseDnsResult {
+  ip: string;
+  hostname?: string | null;
+}
+
 export interface InspectResult {
   host: string;
   ip?: string | null;
@@ -59,6 +82,15 @@ export interface InspectResult {
   ports?: PortResult[];
   open_ports: PortResult[];
   hostname?: string | null;
+}
+
+export interface MdnsService {
+  full_name: string;
+  hostname: string;
+  service_type: string;
+  addresses: string[];
+  port: number;
+  properties: Record<string, string>;
 }
 
 export interface SweepEntry {
@@ -130,8 +162,15 @@ export interface PcapPacketSummary {
 }
 
 export interface PcapCapability {
+  compiled: boolean;
   available: boolean;
   interfaces: string[];
+  message?: string | null;
+}
+
+export interface OptionalCapability {
+  compiled: boolean;
+  available: boolean;
   message?: string | null;
 }
 
@@ -146,6 +185,14 @@ export interface PcapResult {
   file_path: string;
   packets: PcapPacketSummary[];
   packets_truncated: boolean;
+}
+
+export interface PcapParseResult {
+  file_path: string;
+  link_type: number;
+  total_packets: number;
+  packets: PcapPacketSummary[];
+  truncated: boolean;
 }
 
 export interface DnsRecord {

--- a/apps/netscli-gui/src/workspace/operations.ts
+++ b/apps/netscli-gui/src/workspace/operations.ts
@@ -50,11 +50,6 @@ export async function runWorkspaceTab({
     selectedIndices: [0],
     selectionAnchor: 0,
   });
-  showToast({
-    message: `${TOOL_CONFIG[tab.kind].label} started`,
-    kind: 'operation',
-    tabId: tab.id,
-  });
 
   try {
     const result = await executeTool(tab, opId);
@@ -106,32 +101,36 @@ export async function runWorkspaceTab({
 
 export async function cancelWorkspaceTab(
   tabId: string,
-  tab: WorkspaceTab | undefined,
   activeOps: RefObject<Record<string, string>>,
   patchTab: (id: string, patch: Partial<WorkspaceTab>) => void,
-  showToast: (toast: Omit<WorkspaceToast, 'id'>) => void,
 ) {
   const opId = activeOps.current[tabId];
   if (opId && isTauri()) {
     await netscli.cancelOperation(opId).catch(() => undefined);
   }
   delete activeOps.current[tabId];
-  patchTab(tabId, { busy: false, progress: null, error: 'Operation cancelled' });
-  showToast({
-    message: `${tab ? TOOL_CONFIG[tab.kind].label : 'Operation'} stopped`,
-    kind: 'operation',
-    tabId,
-  });
+  patchTab(tabId, { busy: false, progress: null, error: null });
 }
 
 function initialProgressDetail(tab: WorkspaceTab): string {
   switch (tab.kind) {
     case 'scan':
       return 'Preparing port probes';
+    case 'ping':
+      return 'Sending probes';
+    case 'trace':
+      return 'Starting route trace';
     case 'discover':
       return 'Preparing host discovery';
+    case 'dns':
+    case 'reverse':
+      return 'Querying DNS';
     case 'sweep':
       return 'Preparing network sweep';
+    case 'mdns':
+      return 'Listening for mDNS services';
+    case 'pcap':
+      return tab.form.mode === 'Open File' ? 'Opening capture file' : 'Starting packet capture';
     default:
       return 'Running operation';
   }

--- a/apps/netscli-gui/src/workspace/toolExecution.ts
+++ b/apps/netscli-gui/src/workspace/toolExecution.ts
@@ -43,6 +43,21 @@ export async function executeTool(tab: WorkspaceTab, opId: string): Promise<Tool
         kind: 'scan',
         data: await netscli.scanPorts(tab.form.host.trim(), emptyToUndefined(tab.form.ports), opId),
       };
+    case 'ping':
+      return {
+        kind: 'ping',
+        data: await netscli.pingHost(tab.form.host.trim(), boundedNumberOrUndefined(tab, 'count'), opId),
+      };
+    case 'trace':
+      return {
+        kind: 'trace',
+        data: await netscli.traceRoute(
+          tab.form.host.trim(),
+          boundedNumberOrUndefined(tab, 'max_hops'),
+          tab.form.resolve === 'On',
+          opId,
+        ),
+      };
     case 'discover':
       return {
         kind: 'discover',
@@ -50,6 +65,11 @@ export async function executeTool(tab: WorkspaceTab, opId: string): Promise<Tool
       };
     case 'dns':
       return executeDns(tab, opId);
+    case 'reverse':
+      return {
+        kind: 'reverse',
+        data: await netscli.reverseDnsLookup(tab.form.ip.trim(), opId),
+      };
     case 'inspect':
       return {
         kind: 'inspect',
@@ -65,24 +85,59 @@ export async function executeTool(tab: WorkspaceTab, opId: string): Promise<Tool
           true,
         ),
       };
+    case 'mdns':
+      return {
+        kind: 'mdns',
+        data: await netscli.discoverMdns(
+          numberOrUndefined(tab.form.timeout_ms),
+          serviceTypes(tab.form.service_types),
+          opId,
+        ),
+      };
     case 'interfaces':
       return { kind: 'interfaces', data: await netscli.listInterfaces(opId) };
     case 'arp':
       return { kind: 'arp', data: await netscli.getArpTable(opId) };
     case 'pcap':
+      if (tab.form.mode === 'Open File') {
+        return {
+          kind: 'pcap',
+          data: await netscli.openPcapFile(boundedNumberOrUndefined(tab, 'max_packets')),
+        };
+      }
       return {
         kind: 'pcap',
         data: await netscli.capturePcap(
           {
             interface: tab.form.interface.trim(),
-            duration: numberOrUndefined(tab.form.duration),
+            duration: boundedNumberOrUndefined(tab, 'duration'),
             filter: emptyToUndefined(tab.form.filter),
-            max_packets: numberOrUndefined(tab.form.max_packets),
+            max_packets: boundedNumberOrUndefined(tab, 'max_packets'),
           },
           opId,
         ),
       };
   }
+}
+
+function boundedNumberOrUndefined(tab: WorkspaceTab, key: string): number | undefined {
+  const parsed = numberOrUndefined(tab.form[key]);
+  if (parsed === undefined) return undefined;
+  const field = TOOL_CONFIG[tab.kind].fields.find((candidate) => candidate.key === key);
+  if (!field) return parsed;
+
+  const step = field.step ?? 1;
+  const stepped = Number.isInteger(step) ? Math.trunc(parsed) : parsed;
+  const lowerBounded = field.min === undefined ? stepped : Math.max(field.min, stepped);
+  return field.max === undefined ? lowerBounded : Math.min(field.max, lowerBounded);
+}
+
+function serviceTypes(value: string | undefined): string[] | undefined {
+  const items = value
+    ?.split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return items && items.length > 0 ? items : undefined;
 }
 
 async function executeDns(tab: WorkspaceTab, opId: string): Promise<ToolResult> {
@@ -125,6 +180,9 @@ function failureRecordTypes(failures: string[]): string {
 }
 
 export function validateTab(tab: WorkspaceTab): string | null {
+  if (tab.kind === 'pcap' && tab.form.mode === 'Open File') {
+    return null;
+  }
   const missing = TOOL_CONFIG[tab.kind].fields.find(
     (field) => field.required && !tab.form[field.key]?.trim(),
   );

--- a/apps/netscli-gui/src/workspace/transfer.test.ts
+++ b/apps/netscli-gui/src/workspace/transfer.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseResultBundle, RESULT_BUNDLE_SCHEMA } from './transfer';
+
+function bundle(overrides: Record<string, unknown> = {}) {
+  return {
+    schema: RESULT_BUNDLE_SCHEMA,
+    exportedAt: '2026-06-13T00:00:00.000Z',
+    title: 'Scan',
+    command: 'netscli scan 127.0.0.1 --json',
+    kind: 'scan',
+    form: { host: '127.0.0.1' },
+    result: { kind: 'scan', data: [] },
+    ...overrides,
+  };
+}
+
+describe('parseResultBundle', () => {
+  it('accepts a structurally valid bundle', () => {
+    expect(parseResultBundle(bundle()).kind).toBe('scan');
+  });
+
+  it('rejects unsupported tool kinds', () => {
+    expect(() => parseResultBundle(bundle({ kind: 'unknown', result: { kind: 'unknown', data: [] } }))).toThrow(
+      /unsupported result bundle tool kind/i,
+    );
+  });
+
+  it('rejects mismatched result kinds', () => {
+    expect(() => parseResultBundle(bundle({ result: { kind: 'dns', data: [] } }))).toThrow(/kind does not match/i);
+  });
+
+  it('rejects array-backed result kinds without array data', () => {
+    expect(() => parseResultBundle(bundle({ result: { kind: 'scan', data: {} } }))).toThrow(
+      /data for scan must be an array/i,
+    );
+  });
+
+  it('rejects pcap data without packets', () => {
+    expect(() => parseResultBundle(bundle({ kind: 'pcap', result: { kind: 'pcap', data: {} } }))).toThrow(
+      /pcap data must include packets/i,
+    );
+  });
+});

--- a/apps/netscli-gui/src/workspace/transfer.ts
+++ b/apps/netscli-gui/src/workspace/transfer.ts
@@ -1,6 +1,33 @@
-import type { ResultColumn, ResultRow, WorkspaceTab } from '../tools/types';
+import type { ToolKind, ResultColumn, ResultRow, WorkspaceTab } from '../tools/types';
+import type { ToolResult } from '../types/app';
 import { serializeRowsAsCsv } from '../tools/presentation';
 import { downloadText } from './toolExecution';
+
+export const RESULT_BUNDLE_SCHEMA = 'netscli.result.v1';
+const TOOL_KINDS = [
+  'scan',
+  'ping',
+  'trace',
+  'discover',
+  'dns',
+  'reverse',
+  'inspect',
+  'sweep',
+  'mdns',
+  'interfaces',
+  'arp',
+  'pcap',
+] as const satisfies readonly ToolKind[];
+
+export interface ResultBundle {
+  schema: typeof RESULT_BUNDLE_SCHEMA;
+  exportedAt: string;
+  title: string;
+  command: string;
+  kind: ToolKind;
+  form: Record<string, string>;
+  result: ToolResult;
+}
 
 export function exportCurrentResult(
   activeTab: WorkspaceTab | undefined,
@@ -32,6 +59,52 @@ export function exportCurrentResult(
     onSuccess,
     onError,
   );
+}
+
+export function buildResultBundle(activeTab: WorkspaceTab, command: string): ResultBundle | null {
+  if (!activeTab.result) return null;
+  return {
+    schema: RESULT_BUNDLE_SCHEMA,
+    exportedAt: new Date().toISOString(),
+    title: activeTab.title,
+    command,
+    kind: activeTab.kind,
+    form: { ...activeTab.form },
+    result: activeTab.result,
+  };
+}
+
+export function parseResultBundle(value: unknown): ResultBundle {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Result bundle must be a JSON object');
+  }
+  const bundle = value as Partial<ResultBundle>;
+  if (bundle.schema !== RESULT_BUNDLE_SCHEMA) {
+    throw new Error('Unsupported result bundle schema');
+  }
+  if (!bundle.kind || typeof bundle.kind !== 'string') {
+    throw new Error('Result bundle is missing a tool kind');
+  }
+  if (!isToolKind(bundle.kind)) {
+    throw new Error(`Unsupported result bundle tool kind: ${bundle.kind}`);
+  }
+  if (!bundle.result || typeof bundle.result !== 'object') {
+    throw new Error('Result bundle is missing result data');
+  }
+  const result = bundle.result as { kind?: unknown; data?: unknown };
+  if (result.kind !== bundle.kind) {
+    throw new Error('Result bundle kind does not match its result payload');
+  }
+  validateResultDataShape(bundle.kind, result.data);
+  return {
+    schema: RESULT_BUNDLE_SCHEMA,
+    exportedAt: typeof bundle.exportedAt === 'string' ? bundle.exportedAt : new Date().toISOString(),
+    title: typeof bundle.title === 'string' ? bundle.title : bundle.kind,
+    command: typeof bundle.command === 'string' ? bundle.command : '',
+    kind: bundle.kind,
+    form: isStringRecord(bundle.form) ? bundle.form : {},
+    result: bundle.result as ToolResult,
+  };
 }
 
 export function exportSelectedRows(
@@ -100,3 +173,39 @@ function exportText(
     .catch(onError);
 }
 
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== 'object') return false;
+  return Object.values(value).every((item) => typeof item === 'string');
+}
+
+function isToolKind(value: string): value is ToolKind {
+  return (TOOL_KINDS as readonly string[]).includes(value);
+}
+
+function validateResultDataShape(kind: ToolKind, data: unknown) {
+  if (
+    kind === 'scan' ||
+    kind === 'discover' ||
+    kind === 'dns' ||
+    kind === 'sweep' ||
+    kind === 'mdns' ||
+    kind === 'interfaces' ||
+    kind === 'arp'
+  ) {
+    if (!Array.isArray(data)) {
+      throw new Error(`Result bundle data for ${kind} must be an array`);
+    }
+    return;
+  }
+
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error(`Result bundle data for ${kind} must be an object`);
+  }
+
+  if (kind === 'trace' && !Array.isArray((data as { lines?: unknown }).lines)) {
+    throw new Error('Result bundle trace data must include lines');
+  }
+  if (kind === 'pcap' && !Array.isArray((data as { packets?: unknown }).packets)) {
+    throw new Error('Result bundle pcap data must include packets');
+  }
+}

--- a/apps/netscli-gui/src/workspace/types.ts
+++ b/apps/netscli-gui/src/workspace/types.ts
@@ -37,6 +37,8 @@ export interface WorkspaceModel {
   exportCurrent: (format: 'json' | 'csv') => void;
   exportSelectedJson: () => void;
   exportSelectedCsv: () => void;
+  saveResultBundle: () => Promise<void>;
+  openResultBundle: () => Promise<void>;
   copyCellValue: (label: string, value: string) => Promise<void>;
   openCaptureFile: (path: string) => Promise<void>;
   revealCaptureFile: (path: string) => Promise<void>;

--- a/apps/netscli-gui/src/workspace/useWorkspace.ts
+++ b/apps/netscli-gui/src/workspace/useWorkspace.ts
@@ -2,14 +2,22 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { isTauri } from '../services/env';
 import * as netscli from '../services/netscli';
-import { createTab } from '../tools/registry';
+import { createTab, TOOL_CONFIG } from '../tools/registry';
 import { buildCommand, buildRows, columnsFor, filterAndSortRows } from '../tools/presentation';
-import type { HistoryEntry, ResultColumn, RowSelectionMode, ToolKind, WorkspaceTab } from '../tools/types';
+import type { ToolResult } from '../types/app';
+import type { HistoryEntry, OperationProgressState, ResultColumn, RowSelectionMode, ToolKind, WorkspaceTab } from '../tools/types';
 import { applyContextDefaults, shouldAutoRun } from './networkDefaults';
 import { cancelWorkspaceTab, runWorkspaceTab } from './operations';
 import { clampIndex, normalizeSelection, rangeBetween } from './selection';
 import { loadHistory, saveHistory } from './historyStorage';
-import { copyRowsDetails, copyRowsRaw, exportCurrentResult, exportSelectedRows } from './transfer';
+import {
+  buildResultBundle,
+  copyRowsDetails,
+  copyRowsRaw,
+  exportCurrentResult,
+  exportSelectedRows,
+  parseResultBundle,
+} from './transfer';
 import type { WorkspaceModel, WorkspaceOptions } from './types';
 import { useNetworkStatus } from './useNetworkStatus';
 import { useWorkspaceToast } from './useWorkspaceToast';
@@ -82,7 +90,7 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
     void netscli.listenOperationProgress((progress) => {
       const tabId = Object.entries(activeOps.current).find(([, opId]) => opId === progress.op_id)?.[0];
       if (!tabId) return;
-      patchTab(tabId, { progress });
+      setTabs((prev) => prev.map((tab) => (tab.id === tabId ? applyProgressUpdate(tab, progress) : tab)));
     }).then((dispose) => {
       if (cancelled) {
         dispose();
@@ -247,6 +255,9 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
 
   async function runTab(tabId: string) {
     const tab = tabs.find((item) => item.id === tabId);
+    if (toast?.kind === 'operation') {
+      dismissToast();
+    }
     await runWorkspaceTab({
       activeOps,
       patchTab,
@@ -258,8 +269,7 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
   }
 
   async function cancelTab(tabId: string) {
-    const tab = tabs.find((item) => item.id === tabId);
-    await cancelWorkspaceTab(tabId, tab, activeOps, patchTab, showToast);
+    await cancelWorkspaceTab(tabId, activeOps, patchTab);
   }
 
   function exportCurrent(format: 'json' | 'csv') {
@@ -272,6 +282,39 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
 
   function exportSelectedJson() {
     exportSelectedRows(activeTab, columns, selectedRows, 'json', showExportToast, showExportError);
+  }
+
+  async function saveResultBundle() {
+    if (!activeTab?.result) return;
+    const bundle = buildResultBundle(activeTab, commandPreview);
+    if (!bundle) return;
+    try {
+      const path = await netscli.saveResultBundle(JSON.stringify(bundle, null, 2));
+      showExportToast(path, 'Saved result bundle');
+    } catch (error) {
+      if (!/cancelled/i.test(String(error))) showExportError(error);
+    }
+  }
+
+  async function openResultBundle() {
+    try {
+      const bundle = parseResultBundle(await netscli.openResultBundle());
+      if (!(bundle.kind in TOOL_CONFIG)) {
+        throw new Error(`Unsupported tool kind '${bundle.kind}'`);
+      }
+      const tab = createTab(bundle.kind);
+      tab.title = bundle.title || TOOL_CONFIG[bundle.kind].shortLabel;
+      tab.form = { ...tab.form, ...bundle.form };
+      tab.result = bundle.result;
+      tab.detailTab = bundle.kind === 'scan' ? 'banner' : bundle.kind === 'inspect' ? 'overview' : 'details';
+      setTabs((prev) => [...prev, tab]);
+      setActiveTabId(tab.id);
+      showToast({ message: 'Result bundle opened', kind: 'interaction' });
+    } catch (error) {
+      if (!/cancelled/i.test(String(error))) {
+        showToast({ message: `Open failed: ${String(error)}`, kind: 'interaction' });
+      }
+    }
   }
 
   async function copyCommand() {
@@ -386,6 +429,8 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
     exportCurrent,
     exportSelectedJson,
     exportSelectedCsv,
+    saveResultBundle,
+    openResultBundle,
     copyCellValue,
     openCaptureFile,
     revealCaptureFile,
@@ -397,6 +442,54 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
     clearHistory,
     clearCurrentResults,
   };
+}
+
+function applyProgressUpdate(tab: WorkspaceTab, progress: OperationProgressState): WorkspaceTab {
+  if (tab.kind !== 'trace') {
+    return { ...tab, progress };
+  }
+
+  const traceLine = traceLineFromProgress(progress.detail);
+  if (!traceLine) {
+    return { ...tab, progress };
+  }
+
+  const existing = tab.result?.kind === 'trace' ? tab.result : null;
+  const lines = existing?.data.lines ?? [];
+  if (lines.includes(traceLine)) {
+    return { ...tab, progress };
+  }
+
+  const result: ToolResult = {
+    kind: 'trace',
+    data: {
+      host: existing?.data.host ?? tab.form.host?.trim() ?? '',
+      tool: existing?.data.tool ?? 'trace',
+      exit_code: existing?.data.exit_code ?? null,
+      lines: [...lines, traceLine],
+    },
+  };
+  if (existing?.warnings) result.warnings = existing.warnings;
+
+  return {
+    ...tab,
+    progress,
+    result,
+    selectedIndex: tab.result ? tab.selectedIndex : 0,
+    selectedIndices: tab.result ? tab.selectedIndices : [0],
+  };
+}
+
+function traceLineFromProgress(detail: string | null | undefined): string | null {
+  const value = detail?.trim();
+  if (!value) return null;
+  const separator = ' - ';
+  const line = value.includes(separator)
+    ? value.slice(value.indexOf(separator) + separator.length).trim()
+    : value;
+  if (!line) return null;
+  const firstToken = line.split(/\s+/)[0];
+  return /^\d+$/.test(firstToken) ? line : null;
 }
 
 function enrichInterfaceRows(rows: ReturnType<typeof buildRows>, defaultName: string | undefined, selectedName: string | null) {


### PR DESCRIPTION
Builds on #104 by wiring the shared network operations into the desktop app.

Adds GUI support for ping, trace, reverse DNS, mDNS, PCAP open-file parsing, stronger result bundle import validation, and better packet capture unavailable states. It also fixes the Tauri render harness sizing issue that produced the white strip in the automated browser window.

Validation used for the full stack:
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `npm run test:unit` in `apps/netscli-gui`
- `npm run build` in `apps/netscli-gui`
- `npm run test:tauri-render`

This replaces #101 so the branch name does not use the `codex/` prefix. It is draft until #104 lands, because this PR depends on the core and MCP operation surface from that branch.