### PR TITLE
Add MCP dispatch tests and dedupe the tool-dispatch table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,10 @@ jobs:
         if: runner.os == 'Linux'
         run: cargo test -p netscli-core --features pcap --no-fail-fast
 
+      - name: cargo test netscli-mcp with pcap
+        if: runner.os == 'Linux'
+        run: cargo test -p netscli-mcp --features pcap --no-fail-fast
+
   gui-build:
     name: GUI Build (TypeScript + Vite)
     needs: lint

--- a/crates/netscli-mcp/src/server/dispatch.rs
+++ b/crates/netscli-mcp/src/server/dispatch.rs
@@ -1,22 +1,14 @@
 use serde::Deserialize;
 use serde_json::{json, Value};
-#[cfg(feature = "pcap")]
-use std::collections::HashMap;
-#[cfg(feature = "pcap")]
-use std::sync::{Arc, Mutex};
 
 use super::errors::RpcError;
 #[cfg(feature = "pcap")]
-use super::jobs::{PcapCaptureJob, PcapJobHandle};
+use super::jobs::{pcap_job_result, pcap_job_status, start_pcap_capture_job, PcapJobMap};
 use super::operations::{
     op_capture_pcap, op_discover, op_dns_lookup, op_get_arp_table, op_inspect_host,
     op_list_interfaces, op_ping_host, op_scan_ports, op_sweep,
 };
-#[cfg(feature = "pcap")]
-use super::operations::{run_pcap_capture, validate_pcap_capture_params};
 use super::protocol::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
-#[cfg(feature = "pcap")]
-use super::schemas::PcapJobParams;
 use super::schemas::{
     parse_params, DiscoverParams, DnsParams, InitializeParams, PcapParams, PingHostParams,
     ScanParams, SweepParams,
@@ -28,65 +20,13 @@ use super::operations::op_discover_mdns;
 #[cfg(feature = "mdns")]
 use super::schemas::MdnsParams;
 
-#[cfg(feature = "pcap")]
-const MAX_RUNNING_PCAP_JOBS: usize = 4;
-#[cfg(feature = "pcap")]
-const MAX_STORED_PCAP_JOBS: usize = 16;
-#[cfg(feature = "pcap")]
-const MAX_COMPLETED_PCAP_JOBS: usize = 8;
-
 #[derive(Debug, Default)]
 pub(super) struct ServerState {
     pub(super) initialized: bool,
     #[cfg(feature = "pcap")]
-    pcap_jobs: HashMap<String, PcapJobHandle>,
+    pub(super) pcap_jobs: PcapJobMap,
     #[cfg(feature = "pcap")]
-    next_pcap_job_id: u64,
-}
-
-#[cfg(feature = "pcap")]
-impl ServerState {
-    fn allocate_pcap_job_id(&mut self) -> String {
-        self.next_pcap_job_id = self.next_pcap_job_id.saturating_add(1);
-        format!("pcap-{}", self.next_pcap_job_id)
-    }
-
-    fn pcap_job(&self, job_id: &str) -> Result<PcapJobHandle, RpcError> {
-        self.pcap_jobs
-            .get(job_id)
-            .cloned()
-            .ok_or_else(|| RpcError::InvalidParams(format!("unknown pcap jobId: {job_id}")))
-    }
-
-    fn running_pcap_jobs(&self) -> usize {
-        self.pcap_jobs
-            .values()
-            .filter(|job| job.lock().map(|guard| guard.is_running()).unwrap_or(true))
-            .count()
-    }
-
-    fn prune_pcap_jobs(&mut self) {
-        let mut finished: Vec<(String, std::time::Instant)> = self
-            .pcap_jobs
-            .iter()
-            .filter_map(|(job_id, job)| {
-                let finished_at = job.lock().ok()?.finished_at()?;
-                Some((job_id.clone(), finished_at))
-            })
-            .collect();
-
-        finished.sort_by_key(|(_, finished_at)| *finished_at);
-        let remove_count = self
-            .pcap_jobs
-            .len()
-            .saturating_sub(MAX_STORED_PCAP_JOBS)
-            .max(finished.len().saturating_sub(MAX_COMPLETED_PCAP_JOBS))
-            .min(finished.len());
-
-        for (job_id, _) in finished.into_iter().take(remove_count) {
-            self.pcap_jobs.remove(&job_id);
-        }
-    }
+    pub(super) next_pcap_job_id: u64,
 }
 
 pub(super) async fn handle_request(
@@ -183,7 +123,30 @@ async fn handle_request_inner(
         "tools/list" => Ok(tools_list()),
         "tools/call" => handle_tools_call(state, params).await,
 
-        // Backwards-compatible direct JSON-RPC methods
+        // Backwards-compatible direct JSON-RPC methods for the pcap job
+        // lifecycle. These are stateful (server-held job handles, in
+        // `jobs.rs`), so they stay separate from `dispatch_tool`'s
+        // stateless tool table below.
+        #[cfg(feature = "pcap")]
+        "start_pcap_capture" => start_pcap_capture_job(state, params).await,
+        #[cfg(feature = "pcap")]
+        "get_pcap_capture_status" => pcap_job_status(state, params),
+        #[cfg(feature = "pcap")]
+        "get_pcap_capture_result" => pcap_job_result(state, params),
+
+        // Every other backwards-compatible direct method name maps 1:1 onto
+        // a `tools/call` tool of the same name; share that table instead of
+        // duplicating each arm here and in `handle_tools_call`.
+        other => dispatch_tool(other, params).await,
+    }
+}
+
+/// Stateless tool dispatch shared by the legacy direct JSON-RPC methods and
+/// `tools/call`. Returns the tool's raw result value — callers decide how to
+/// shape it (legacy methods return it as-is; `tools/call` wraps it via
+/// `mcp_tool_result_text`).
+async fn dispatch_tool(name: &str, params: Value) -> Result<Value, RpcError> {
+    match name {
         "discover_network" => {
             let p: DiscoverParams = parse_params(params)?;
             let hosts = op_discover(p).await?;
@@ -224,12 +187,6 @@ async fn handle_request_inner(
             let res = op_capture_pcap(p).await?;
             serde_json::to_value(res).map_err(|e| RpcError::Internal(e.to_string()))
         }
-        #[cfg(feature = "pcap")]
-        "start_pcap_capture" => start_pcap_capture_job(state, params).await,
-        #[cfg(feature = "pcap")]
-        "get_pcap_capture_status" => pcap_job_status(state, params),
-        #[cfg(feature = "pcap")]
-        "get_pcap_capture_result" => pcap_job_result(state, params),
         #[cfg(feature = "mdns")]
         "discover_mdns" => {
             let p: MdnsParams = parse_params(params)?;
@@ -261,119 +218,31 @@ async fn handle_tools_call(
         p.args
     };
 
-    let output = match p.name.as_str() {
-        "discover_network" => {
-            let p: DiscoverParams = parse_params(args)?;
-            let hosts = op_discover(p).await?;
-            json!(hosts)
+    #[cfg(feature = "pcap")]
+    {
+        match p.name.as_str() {
+            "start_pcap_capture" => {
+                return Ok(mcp_tool_result_text(
+                    start_pcap_capture_job(state, args).await?,
+                ))
+            }
+            "get_pcap_capture_status" => {
+                return Ok(mcp_tool_result_text(pcap_job_status(state, args)?))
+            }
+            "get_pcap_capture_result" => {
+                return Ok(mcp_tool_result_text(pcap_job_result(state, args)?))
+            }
+            _ => {}
         }
-        "scan_ports" => {
-            let p: ScanParams = parse_params(args)?;
-            let res = op_scan_ports(p).await?;
-            json!(res)
-        }
-        "ping_host" => {
-            let p: PingHostParams = parse_params(args)?;
-            let res = op_ping_host(p).await?;
-            json!(res)
-        }
-        "dns_lookup" => {
-            let p: DnsParams = parse_params(args)?;
-            let res = op_dns_lookup(p).await?;
-            json!(res)
-        }
-        "get_arp_table" => {
-            json!(op_get_arp_table()?)
-        }
-        "inspect_host" => {
-            let p: ScanParams = parse_params(args)?;
-            let res = op_inspect_host(p).await?;
-            json!(res)
-        }
-        "sweep_network" => {
-            let p: SweepParams = parse_params(args)?;
-            let res = op_sweep(p).await?;
-            json!(res)
-        }
-        "list_network_interfaces" => {
-            json!(op_list_interfaces())
-        }
-        "capture_pcap" => {
-            let p: PcapParams = parse_params(args)?;
-            let res = op_capture_pcap(p).await?;
-            json!(res)
-        }
-        #[cfg(feature = "pcap")]
-        "start_pcap_capture" => start_pcap_capture_job(state, args).await?,
-        #[cfg(feature = "pcap")]
-        "get_pcap_capture_status" => pcap_job_status(state, args)?,
-        #[cfg(feature = "pcap")]
-        "get_pcap_capture_result" => pcap_job_result(state, args)?,
-        #[cfg(feature = "mdns")]
-        "discover_mdns" => {
-            let p: MdnsParams = parse_params(args)?;
-            let res = op_discover_mdns(p).await?;
-            json!(res)
-        }
-        other => {
-            return Err(RpcError::InvalidParams(format!("Unknown tool: {other}")));
-        }
-    };
+    }
+
+    let output = dispatch_tool(&p.name, args).await.map_err(|e| match e {
+        RpcError::MethodNotFound => RpcError::InvalidParams(format!("Unknown tool: {}", p.name)),
+        other => other,
+    })?;
 
     Ok(mcp_tool_result_text(output))
 }
 
-#[cfg(feature = "pcap")]
-async fn start_pcap_capture_job(state: &mut ServerState, params: Value) -> Result<Value, RpcError> {
-    let p: PcapParams = parse_params(params)?;
-    let mut request = validate_pcap_capture_params(p)?;
-    state.prune_pcap_jobs();
-    if state.running_pcap_jobs() >= MAX_RUNNING_PCAP_JOBS {
-        return Err(RpcError::ToolError(format!(
-            "too many pcap captures are already running (max {MAX_RUNNING_PCAP_JOBS})"
-        )));
-    }
-    let job_id = state.allocate_pcap_job_id();
-    request.ensure_default_output_file(format!("netscli-{job_id}.pcap"));
-    let job = Arc::new(Mutex::new(PcapCaptureJob::new()));
-    state.pcap_jobs.insert(job_id.clone(), job.clone());
-
-    tokio::spawn(async move {
-        let outcome = run_pcap_capture(request).await;
-        let Ok(mut guard) = job.lock() else {
-            return;
-        };
-        match outcome {
-            Ok(result) => guard.complete(result),
-            Err(err) => guard.fail(err.to_string()),
-        }
-    });
-
-    let job = state.pcap_job(&job_id)?;
-    pcap_status_value(job_id, &job)
-}
-
-#[cfg(feature = "pcap")]
-fn pcap_job_status(state: &ServerState, params: Value) -> Result<Value, RpcError> {
-    let p: PcapJobParams = parse_params(params)?;
-    let job = state.pcap_job(&p.job_id)?;
-    pcap_status_value(p.job_id, &job)
-}
-
-#[cfg(feature = "pcap")]
-fn pcap_job_result(state: &ServerState, params: Value) -> Result<Value, RpcError> {
-    let p: PcapJobParams = parse_params(params)?;
-    let job = state.pcap_job(&p.job_id)?;
-    let guard = job
-        .lock()
-        .map_err(|_| RpcError::Internal("pcap job state lock poisoned".to_string()))?;
-    serde_json::to_value(guard.result(p.job_id)).map_err(|e| RpcError::Internal(e.to_string()))
-}
-
-#[cfg(feature = "pcap")]
-fn pcap_status_value(job_id: String, job: &PcapJobHandle) -> Result<Value, RpcError> {
-    let guard = job
-        .lock()
-        .map_err(|_| RpcError::Internal("pcap job state lock poisoned".to_string()))?;
-    serde_json::to_value(guard.status(job_id)).map_err(|e| RpcError::Internal(e.to_string()))
-}
+#[cfg(test)]
+mod tests;

--- a/crates/netscli-mcp/src/server/dispatch/tests.rs
+++ b/crates/netscli-mcp/src/server/dispatch/tests.rs
@@ -1,0 +1,233 @@
+use serde_json::json;
+
+use super::*;
+use crate::server::protocol::JsonRpcRequest;
+
+fn request(method: &str, params: Option<Value>, id: i64) -> JsonRpcRequest {
+    JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        method: method.to_string(),
+        params,
+        id: Some(json!(id)),
+    }
+}
+
+async fn initialized_state() -> ServerState {
+    let mut state = ServerState::default();
+    let resp = handle_request(&mut state, request("initialize", Some(json!({})), 0)).await;
+    assert!(resp.error.is_none(), "initialize failed: {:?}", resp.error);
+    state
+}
+
+#[tokio::test]
+async fn methods_before_initialize_are_rejected() {
+    let mut state = ServerState::default();
+    let resp = handle_request(
+        &mut state,
+        request(
+            "tools/call",
+            Some(json!({"name": "list_network_interfaces", "arguments": {}})),
+            1,
+        ),
+    )
+    .await;
+    let err = resp.error.expect("expected NotInitialized error");
+    assert_eq!(err.code, -32002);
+}
+
+#[tokio::test]
+async fn tools_list_and_initialize_are_allowed_before_initialize() {
+    let mut state = ServerState::default();
+    let resp = handle_request(&mut state, request("tools/list", None, 1)).await;
+    assert!(resp.error.is_none(), "tools/list failed: {:?}", resp.error);
+
+    let resp = handle_request(&mut state, request("initialize", Some(json!({})), 2)).await;
+    assert!(resp.error.is_none(), "initialize failed: {:?}", resp.error);
+}
+
+#[tokio::test]
+async fn invalid_params_return_invalid_params_code() {
+    let mut state = initialized_state().await;
+    // scan_ports requires "host"; omit it to trigger a deserialize failure.
+    let resp = handle_request(
+        &mut state,
+        request(
+            "tools/call",
+            Some(json!({"name": "scan_ports", "arguments": {}})),
+            3,
+        ),
+    )
+    .await;
+    let err = resp.error.expect("expected invalid params error");
+    assert_eq!(err.code, -32602);
+}
+
+#[tokio::test]
+async fn unknown_tool_name_is_invalid_params() {
+    let mut state = initialized_state().await;
+    let resp = handle_request(
+        &mut state,
+        request(
+            "tools/call",
+            Some(json!({"name": "does_not_exist", "arguments": {}})),
+            4,
+        ),
+    )
+    .await;
+    let err = resp.error.expect("expected error for unknown tool");
+    assert_eq!(err.code, -32602);
+    assert!(
+        err.message.contains("Unknown tool: does_not_exist"),
+        "message: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn unknown_method_is_method_not_found() {
+    let mut state = initialized_state().await;
+    let resp = handle_request(&mut state, request("does_not_exist", None, 5)).await;
+    let err = resp.error.expect("expected method-not-found error");
+    assert_eq!(err.code, -32601);
+}
+
+#[tokio::test]
+async fn oversized_subnet_is_rejected() {
+    let mut state = initialized_state().await;
+    let resp = handle_request(
+        &mut state,
+        request(
+            "tools/call",
+            Some(json!({"name": "discover_network", "arguments": {"subnet": "10.0.0.0/8"}})),
+            6,
+        ),
+    )
+    .await;
+    let err = resp.error.expect("expected subnet-too-large error");
+    assert_eq!(err.code, -32602);
+    assert!(
+        err.message.contains("too large"),
+        "message: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn too_many_ports_is_rejected() {
+    let mut state = initialized_state().await;
+    let ports: Vec<u16> = (1u16..=(netscli_core::MAX_PORTS_PER_SCAN as u16 + 1)).collect();
+    let resp = handle_request(
+        &mut state,
+        request(
+            "tools/call",
+            Some(json!({"name": "scan_ports", "arguments": {"host": "127.0.0.1", "ports": ports}})),
+            7,
+        ),
+    )
+    .await;
+    let err = resp.error.expect("expected too-many-ports error");
+    assert_eq!(err.code, -32602);
+    assert!(
+        err.message.contains("too many ports"),
+        "message: {}",
+        err.message
+    );
+}
+
+// The pcap job tools only exist in `--features pcap` builds; verify they're
+// unreachable (not a silent no-op) when the feature is off, since they share
+// `dispatch_tool`'s catch-all with every other unknown tool name.
+#[cfg(not(feature = "pcap"))]
+#[tokio::test]
+async fn pcap_job_tools_are_unknown_without_pcap_feature() {
+    let mut state = initialized_state().await;
+    for tool in [
+        "start_pcap_capture",
+        "get_pcap_capture_status",
+        "get_pcap_capture_result",
+    ] {
+        let resp = handle_request(
+            &mut state,
+            request(
+                "tools/call",
+                Some(json!({"name": tool, "arguments": {}})),
+                8,
+            ),
+        )
+        .await;
+        let err = resp
+            .error
+            .unwrap_or_else(|| panic!("expected error for {tool}"));
+        assert_eq!(err.code, -32602);
+    }
+}
+
+#[cfg(feature = "pcap")]
+#[tokio::test]
+async fn pcap_job_lifecycle_start_status_result() {
+    let mut state = initialized_state().await;
+
+    let start = handle_request(
+        &mut state,
+        request(
+            "tools/call",
+            Some(
+                json!({"name": "start_pcap_capture", "arguments": {"interface": "netscli-test0"}}),
+            ),
+            9,
+        ),
+    )
+    .await;
+    assert!(start.error.is_none(), "start failed: {:?}", start.error);
+    let job_id = extract_job_id(&start).expect("start response should include a jobId");
+
+    let status = handle_request(
+        &mut state,
+        request(
+            "tools/call",
+            Some(json!({"name": "get_pcap_capture_status", "arguments": {"jobId": job_id}})),
+            10,
+        ),
+    )
+    .await;
+    assert!(status.error.is_none(), "status failed: {:?}", status.error);
+
+    let result = handle_request(
+        &mut state,
+        request(
+            "tools/call",
+            Some(json!({"name": "get_pcap_capture_result", "arguments": {"jobId": job_id}})),
+            11,
+        ),
+    )
+    .await;
+    assert!(result.error.is_none(), "result failed: {:?}", result.error);
+}
+
+#[cfg(feature = "pcap")]
+#[tokio::test]
+async fn pcap_job_status_rejects_unknown_job_id() {
+    let mut state = initialized_state().await;
+    let resp = handle_request(
+        &mut state,
+        request(
+            "tools/call",
+            Some(json!({"name": "get_pcap_capture_status", "arguments": {"jobId": "pcap-does-not-exist"}})),
+            12,
+        ),
+    )
+    .await;
+    let err = resp.error.expect("expected unknown-jobId error");
+    assert_eq!(err.code, -32602);
+}
+
+#[cfg(feature = "pcap")]
+fn extract_job_id(resp: &JsonRpcResponse) -> Option<String> {
+    let result = resp.result.as_ref()?;
+    let text = result.get("content")?.get(0)?.get("text")?.as_str()?;
+    let parsed: Value = serde_json::from_str(text).ok()?;
+    parsed
+        .get("jobId")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}

--- a/crates/netscli-mcp/src/server/jobs.rs
+++ b/crates/netscli-mcp/src/server/jobs.rs
@@ -1,9 +1,21 @@
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use serde::Serialize;
+use serde_json::Value;
+
+use super::dispatch::ServerState;
+use super::errors::RpcError;
+use super::operations::{run_pcap_capture, validate_pcap_capture_params};
+use super::schemas::{parse_params, PcapJobParams, PcapParams};
 
 pub(super) type PcapJobHandle = Arc<Mutex<PcapCaptureJob>>;
+pub(super) type PcapJobMap = HashMap<String, PcapJobHandle>;
+
+const MAX_RUNNING_PCAP_JOBS: usize = 4;
+const MAX_STORED_PCAP_JOBS: usize = 16;
+const MAX_COMPLETED_PCAP_JOBS: usize = 8;
 
 #[derive(Debug)]
 pub(super) struct PcapCaptureJob {
@@ -104,4 +116,102 @@ impl PcapCaptureJob {
         let end = self.finished_at.unwrap_or_else(Instant::now);
         end.duration_since(self.started_at).as_millis() as u64
     }
+}
+
+impl ServerState {
+    pub(super) fn allocate_pcap_job_id(&mut self) -> String {
+        self.next_pcap_job_id = self.next_pcap_job_id.saturating_add(1);
+        format!("pcap-{}", self.next_pcap_job_id)
+    }
+
+    pub(super) fn pcap_job(&self, job_id: &str) -> Result<PcapJobHandle, RpcError> {
+        self.pcap_jobs
+            .get(job_id)
+            .cloned()
+            .ok_or_else(|| RpcError::InvalidParams(format!("unknown pcap jobId: {job_id}")))
+    }
+
+    pub(super) fn running_pcap_jobs(&self) -> usize {
+        self.pcap_jobs
+            .values()
+            .filter(|job| job.lock().map(|guard| guard.is_running()).unwrap_or(true))
+            .count()
+    }
+
+    pub(super) fn prune_pcap_jobs(&mut self) {
+        let mut finished: Vec<(String, Instant)> = self
+            .pcap_jobs
+            .iter()
+            .filter_map(|(job_id, job)| {
+                let finished_at = job.lock().ok()?.finished_at()?;
+                Some((job_id.clone(), finished_at))
+            })
+            .collect();
+
+        finished.sort_by_key(|(_, finished_at)| *finished_at);
+        let remove_count = self
+            .pcap_jobs
+            .len()
+            .saturating_sub(MAX_STORED_PCAP_JOBS)
+            .max(finished.len().saturating_sub(MAX_COMPLETED_PCAP_JOBS))
+            .min(finished.len());
+
+        for (job_id, _) in finished.into_iter().take(remove_count) {
+            self.pcap_jobs.remove(&job_id);
+        }
+    }
+}
+
+pub(super) async fn start_pcap_capture_job(
+    state: &mut ServerState,
+    params: Value,
+) -> Result<Value, RpcError> {
+    let p: PcapParams = parse_params(params)?;
+    let mut request = validate_pcap_capture_params(p)?;
+    state.prune_pcap_jobs();
+    if state.running_pcap_jobs() >= MAX_RUNNING_PCAP_JOBS {
+        return Err(RpcError::ToolError(format!(
+            "too many pcap captures are already running (max {MAX_RUNNING_PCAP_JOBS})"
+        )));
+    }
+    let job_id = state.allocate_pcap_job_id();
+    request.ensure_default_output_file(format!("netscli-{job_id}.pcap"));
+    let job = Arc::new(Mutex::new(PcapCaptureJob::new()));
+    state.pcap_jobs.insert(job_id.clone(), job.clone());
+
+    tokio::spawn(async move {
+        let outcome = run_pcap_capture(request).await;
+        let Ok(mut guard) = job.lock() else {
+            return;
+        };
+        match outcome {
+            Ok(result) => guard.complete(result),
+            Err(err) => guard.fail(err.to_string()),
+        }
+    });
+
+    let job = state.pcap_job(&job_id)?;
+    pcap_status_value(job_id, &job)
+}
+
+pub(super) fn pcap_job_status(state: &ServerState, params: Value) -> Result<Value, RpcError> {
+    let p: PcapJobParams = parse_params(params)?;
+    let job = state.pcap_job(&p.job_id)?;
+    pcap_status_value(p.job_id, &job)
+}
+
+pub(super) fn pcap_job_result(state: &ServerState, params: Value) -> Result<Value, RpcError> {
+    let p: PcapJobParams = parse_params(params)?;
+    let job = state.pcap_job(&p.job_id)?;
+    let guard = job
+        .lock()
+        .map_err(|_| RpcError::Internal("pcap job state lock poisoned".to_string()))?;
+    serde_json::to_value(guard.result(p.job_id)).map_err(|e| RpcError::Internal(e.to_string()))
+}
+
+fn pcap_status_value(job_id: String, job: &PcapJobHandle) -> Result<Value, RpcError> {
+    let guard = job
+        .lock()
+        .map_err(|_| RpcError::Internal("pcap job state lock poisoned".to_string()))?;
+    serde_json::to_value(guard.status(job_id)).map_err(|e| RpcError::Internal(e.to_string()))
 }


### PR DESCRIPTION
## Summary
- Add `crates/netscli-mcp/src/server/dispatch/tests.rs` covering init lifecycle ordering, invalid params, unknown tool/method, subnet and port cap rejection, and pcap job tools being correctly feature-gated (netscli-mcp previously had ~1 test total).
- Collapse the duplicated stateless tool arms between the legacy direct JSON-RPC methods and `tools/call` into a single `dispatch_tool()` table.
- Move `ServerState`'s pcap job fields/methods and the job-dispatch functions into `jobs.rs` (already the pcap-job-types module) — this brings both `dispatch.rs` (248 lines) and `jobs.rs` (217 lines) under the repo's 300-line maintainability cap with no exception needed.
- Add a pcap-feature test step for `netscli-mcp` in `ci.yml`'s Linux job so the new pcap-gated tests actually run in CI.

Investigated but found already fixed: the audit flagged the MCP pcap `outputFile` as potentially unconstrained, but `validate_mcp_pcap_output_file` in `operations.rs` already restricts it to a bare `.pcap` filename (no path components) for both the blocking and job-based capture paths. No change made there.

Second in the sequenced audit-remediation batch (see #123 for the first).

## Test plan
- [x] `cargo test -p netscli-mcp` (default features — 8 new tests + 1 existing, all pass)
- [x] `cargo check` / `cargo clippy -p netscli-mcp --features pcap -- -D warnings` (type-checks clean)
- [ ] `cargo test -p netscli-mcp --features pcap` could not link locally on this Windows machine (missing Npcap SDK `wpcap.lib`, a pre-existing documented requirement) — will run via the new CI step on Linux, which has `libpcap-dev`
- [x] `cargo test --all` (full workspace, 191 tests pass)
- [x] `cargo clippy --all-targets -- -D warnings` (full workspace)
- [x] `cargo fmt --check`
- [x] `node scripts/check-file-size.mjs` — `dispatch.rs`/`jobs.rs` no longer listed