### PR TITLE
Remove duplicate TOOL_KINDS list and detailTab ternary in GUI

### DIFF
--- a/apps/netscli-gui/src/tools/registry.ts
+++ b/apps/netscli-gui/src/tools/registry.ts
@@ -12,7 +12,7 @@ import {
   SweepIcon,
   TraceRouteIcon,
 } from './operationIcons';
-import type { ToolCapabilityMap, ToolConfig, ToolKind, WorkspaceTab } from './types';
+import type { DetailTab, ToolCapabilityMap, ToolConfig, ToolKind, WorkspaceTab } from './types';
 
 export const DEFAULT_PORTS = '22,80,443,8080,8443';
 
@@ -205,6 +205,15 @@ export function generateId(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
+/** The detail pane tab a newly-created or newly-populated tab should open
+ *  to: scan/inspect results default to their most relevant tab, everything
+ *  else defaults to the generic details view. */
+export function defaultDetailTab(kind: ToolKind): DetailTab {
+  if (kind === 'scan') return 'banner';
+  if (kind === 'inspect') return 'overview';
+  return 'details';
+}
+
 export function createTab(kind: ToolKind): WorkspaceTab {
   const config = TOOL_CONFIG[kind];
   return {
@@ -219,7 +228,7 @@ export function createTab(kind: ToolKind): WorkspaceTab {
     selectedIndex: 0,
     selectedIndices: [0],
     selectionAnchor: 0,
-    detailTab: kind === 'scan' ? 'banner' : kind === 'inspect' ? 'overview' : 'details',
+    detailTab: defaultDetailTab(kind),
     sortKey: DEFAULT_SORT[kind],
     sortDir: 'asc',
   };

--- a/apps/netscli-gui/src/workspace/operations.ts
+++ b/apps/netscli-gui/src/workspace/operations.ts
@@ -2,7 +2,7 @@ import type { Dispatch, RefObject, SetStateAction } from 'react';
 
 import { isTauri } from '../services/env';
 import * as netscli from '../services/netscli';
-import { generateId, TOOL_CONFIG } from '../tools/registry';
+import { defaultDetailTab, generateId, TOOL_CONFIG } from '../tools/registry';
 import { buildCommand } from '../tools/presentation';
 import type { HistoryEntry, WorkspaceTab } from '../tools/types';
 import { compactHistory } from './historyStorage';
@@ -64,7 +64,7 @@ export async function runWorkspaceTab({
       selectedIndex: 0,
       selectedIndices: [0],
       selectionAnchor: 0,
-      detailTab: tab.kind === 'scan' ? 'banner' : tab.kind === 'inspect' ? 'overview' : 'details',
+      detailTab: defaultDetailTab(tab.kind),
     });
     showToast({
       message: `${TOOL_CONFIG[tab.kind].label} complete`,

--- a/apps/netscli-gui/src/workspace/transfer.ts
+++ b/apps/netscli-gui/src/workspace/transfer.ts
@@ -1,23 +1,10 @@
 import type { ToolKind, ResultColumn, ResultRow, WorkspaceTab } from '../tools/types';
 import type { ToolResult } from '../types/app';
 import { serializeRowsAsCsv } from '../tools/presentation';
+import { TOOL_KINDS } from '../tools/registry';
 import { downloadText } from './toolExecution';
 
 export const RESULT_BUNDLE_SCHEMA = 'netscli.result.v1';
-const TOOL_KINDS = [
-  'scan',
-  'ping',
-  'trace',
-  'discover',
-  'dns',
-  'reverse',
-  'inspect',
-  'sweep',
-  'mdns',
-  'interfaces',
-  'arp',
-  'pcap',
-] as const satisfies readonly ToolKind[];
 
 export interface ResultBundle {
   schema: typeof RESULT_BUNDLE_SCHEMA;

--- a/apps/netscli-gui/src/workspace/useWorkspace.ts
+++ b/apps/netscli-gui/src/workspace/useWorkspace.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { isTauri } from '../services/env';
 import * as netscli from '../services/netscli';
-import { createTab, TOOL_CONFIG } from '../tools/registry';
+import { createTab, defaultDetailTab, TOOL_CONFIG } from '../tools/registry';
 import { buildCommand, buildRows, columnsFor, filterAndSortRows } from '../tools/presentation';
 import type { HistoryEntry, ResultColumn, RowSelectionMode, ToolKind, WorkspaceTab } from '../tools/types';
 import { applyContextDefaults, shouldAutoRun } from './networkDefaults';
@@ -140,7 +140,7 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
         if (tab.id !== id || tab.busy) return tab;
         return {
           ...tab,
-          detailTab: tab.kind === 'scan' ? 'banner' : tab.kind === 'inspect' ? 'overview' : 'details',
+          detailTab: defaultDetailTab(tab.kind),
           error: null,
           form: { ...tab.form, [key]: value },
           result: null,
@@ -322,7 +322,6 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
       tab.title = bundle.title || TOOL_CONFIG[bundle.kind].shortLabel;
       tab.form = { ...tab.form, ...bundle.form };
       tab.result = bundle.result;
-      tab.detailTab = bundle.kind === 'scan' ? 'banner' : bundle.kind === 'inspect' ? 'overview' : 'details';
       setTabs((prev) => [...prev, tab]);
       setActiveTabId(tab.id);
       showToast({ message: 'Result bundle opened', kind: 'interaction' });


### PR DESCRIPTION
## Summary

**Scope narrowed after verifying the premise.** The original plan called for collapsing ~15 per-tool-kind `switch` statements into one big `Record<ToolKind, ToolPresentation>` registry, justified by "compile-time exhaustiveness." Checked this directly: `columnsFor`, `buildCommand`, `placeholderFor`, etc. already have explicit non-void return types with no `default:` case — TypeScript already requires every `ToolKind` to be handled or the function fails to typecheck. That gain already exists. Collapsing ~15 genuinely bespoke per-kind switch bodies (real logic, not lookup tables — e.g. `columnsFor`'s zero-ports special case, `rows.ts`'s trace-line regex parsing) into object properties would mostly relocate the same code at high regression risk across all 12 tool kinds, for no additional exhaustiveness gain.

Fixed the two real, verified duplications instead:
- `workspace/transfer.ts` re-declared the same 12-entry `TOOL_KINDS` array as `tools/registry.ts` — now imports it.
- The `detailTab` ternary was duplicated 4× — extracted into `registry.ts`'s `defaultDetailTab(kind)`. Found the 4th occurrence (`useWorkspace.openResultBundle`) was fully dead code (`createTab` already sets it correctly on the preceding line) — deleted.

**Did not touch** `details.ts`'s `labelForKind` (looked like a duplicate of `TOOL_CONFIG[kind].label` but isn't — 7 of 12 values differ in wording, e.g. "Discover" vs "Discovery"; it's deliberately sentence-case prose vs. Title Case for buttons). Unifying them would have silently changed visible UI text.

Fifth in the sequenced audit-remediation batch (see #123–#126).

## Test plan
- [x] `npm run build` (tsc + vite, clean)
- [x] `npm run test:unit` (46/46 pass)
- [x] `node scripts/check-file-size.mjs` — `registry.ts`/`transfer.ts` don't appear
- [x] Live GUI smoke check via preview browser (tab creation, default detail-tab selection, command preview) — zero console errors