### PR TITLE
Split useWorkspace god-hook and fix requestRunRef indirection

### DIFF
--- a/apps/netscli-gui/src/App.tsx
+++ b/apps/netscli-gui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type MouseEvent } from 'react';
+import { useEffect, useRef, useState, type MouseEvent } from 'react';
 
 import './App.css';
 
@@ -75,14 +75,12 @@ function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [workspaceSearchOpen, setWorkspaceSearchOpen] = useState(false);
   const filterInputRef = useRef<HTMLInputElement | null>(null);
-  const requestRunRef = useRef<(tabId: string) => void>(() => {});
 
   const workspace = useWorkspace({
     interactionToasts,
     maxConcurrentProbes,
     operationToasts,
     persistentHistory,
-    requestRun: (tabId) => requestRunRef.current(tabId),
   });
   const activeTab = workspace.activeTab;
 
@@ -110,7 +108,12 @@ function App() {
     void workspace.runTab(tabId);
   }
 
-  requestRunRef.current = requestRun;
+  useEffect(() => {
+    if (!activeTab || !workspace.needsAutoRun(activeTab.id)) return;
+    if (activeTab.busy || activeTab.result) return;
+    workspace.clearAutoRun(activeTab.id);
+    requestRun(activeTab.id);
+  }, [activeTab?.id, activeTab?.busy, activeTab?.result]);
 
   useKeyboardShortcuts({
     focusResultFilter: () => {

--- a/apps/netscli-gui/src/workspace/operations.test.ts
+++ b/apps/netscli-gui/src/workspace/operations.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createTab } from '../tools/registry';
+import type { ToolResult } from '../types/app';
+import { runWorkspaceTab } from './operations';
+
+vi.mock('./toolExecution', () => ({
+  executeTool: vi.fn(),
+  validateTab: vi.fn(() => null),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function scanResult(): ToolResult {
+  return { kind: 'scan', data: [] };
+}
+
+describe('runWorkspaceTab op-id race guard', () => {
+  it('ignores a stale executeTool resolution once a newer run has started for the same tab', async () => {
+    const { executeTool } = await import('./toolExecution');
+    const first = deferred<ToolResult>();
+    const second = deferred<ToolResult>();
+    vi.mocked(executeTool).mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const tab = createTab('scan');
+    tab.form.host = '127.0.0.1';
+    const activeOps = { current: {} as Record<string, string> };
+    const patchTab = vi.fn();
+    const setHistory = vi.fn();
+    const showToast = vi.fn();
+
+    const firstRun = runWorkspaceTab({
+      activeOps,
+      maxConcurrentProbes: 256,
+      patchTab,
+      persistentHistory: false,
+      setHistory,
+      showToast,
+      tab,
+    });
+
+    // A second run starts for the same tab before the first has resolved,
+    // simulating the user re-triggering the operation (or an auto-run
+    // racing a manual run). This overwrites activeOps.current[tab.id].
+    const secondRun = runWorkspaceTab({
+      activeOps,
+      maxConcurrentProbes: 256,
+      patchTab,
+      persistentHistory: false,
+      setHistory,
+      showToast,
+      tab,
+    });
+
+    // Resolve the newer call first, then the stale one — the stale
+    // resolution must not be allowed to patch the tab with its result.
+    second.resolve(scanResult());
+    await secondRun;
+    patchTab.mockClear();
+
+    first.resolve(scanResult());
+    await firstRun;
+
+    expect(patchTab).not.toHaveBeenCalledWith(tab.id, expect.objectContaining({ result: expect.anything() }));
+  });
+
+  it('applies the result when no newer run has superseded it', async () => {
+    const { executeTool } = await import('./toolExecution');
+    const result = scanResult();
+    vi.mocked(executeTool).mockResolvedValue(result);
+
+    const tab = createTab('scan');
+    tab.form.host = '127.0.0.1';
+    const activeOps = { current: {} as Record<string, string> };
+    const patchTab = vi.fn();
+    const setHistory = vi.fn();
+    const showToast = vi.fn();
+
+    await runWorkspaceTab({
+      activeOps,
+      maxConcurrentProbes: 256,
+      patchTab,
+      persistentHistory: false,
+      setHistory,
+      showToast,
+      tab,
+    });
+
+    expect(patchTab).toHaveBeenCalledWith(tab.id, expect.objectContaining({ result, busy: false }));
+    expect(activeOps.current[tab.id]).toBeUndefined();
+  });
+
+  it('clears busy state and shows an error toast when execution fails', async () => {
+    const { executeTool } = await import('./toolExecution');
+    vi.mocked(executeTool).mockRejectedValue(new Error('boom'));
+
+    const tab = createTab('scan');
+    tab.form.host = '127.0.0.1';
+    const activeOps = { current: {} as Record<string, string> };
+    const patchTab = vi.fn();
+    const setHistory = vi.fn();
+    const showToast = vi.fn();
+
+    await runWorkspaceTab({
+      activeOps,
+      maxConcurrentProbes: 256,
+      patchTab,
+      persistentHistory: false,
+      setHistory,
+      showToast,
+      tab,
+    });
+
+    expect(patchTab).toHaveBeenCalledWith(
+      tab.id,
+      expect.objectContaining({ error: 'boom', busy: false, result: null }),
+    );
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('failed: boom') }),
+    );
+  });
+});

--- a/apps/netscli-gui/src/workspace/toolExecution.test.ts
+++ b/apps/netscli-gui/src/workspace/toolExecution.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createTab } from '../tools/registry';
+import { executeTool, validateTab } from './toolExecution';
+
+vi.mock('../services/env', () => ({
+  isTauri: () => true,
+}));
+
+vi.mock('../services/netscli', () => ({
+  dnsLookup: vi.fn(),
+}));
+
+describe('validateTab', () => {
+  it('requires fields marked required', () => {
+    const tab = createTab('scan');
+    tab.form.host = '';
+    expect(validateTab(tab)).toBe('Host is required');
+  });
+
+  it('passes once required fields are filled', () => {
+    const tab = createTab('scan');
+    tab.form.host = '127.0.0.1';
+    expect(validateTab(tab)).toBeNull();
+  });
+
+  it('does not require the interface field for pcap Open File mode', () => {
+    const tab = createTab('pcap');
+    tab.form.mode = 'Open File';
+    tab.form.interface = '';
+    expect(validateTab(tab)).toBeNull();
+  });
+
+  it('requires the interface field for pcap capture mode', () => {
+    const tab = createTab('pcap');
+    tab.form.mode = 'Capture';
+    tab.form.interface = '';
+    expect(validateTab(tab)).toBe('Interface is required');
+  });
+});
+
+describe('executeTool DNS "ALL" aggregation', () => {
+  it('returns every record type when all lookups succeed', async () => {
+    const netscli = await import('../services/netscli');
+    vi.mocked(netscli.dnsLookup).mockImplementation(async (host, recordType) => [
+      { record_type: recordType, value: `${recordType}-value`, name: host } as never,
+    ]);
+
+    const tab = createTab('dns');
+    tab.form.host = 'netscli.com';
+    tab.form.record = 'ALL';
+
+    const result = await executeTool(tab, 'op-1', 256);
+    expect(result.kind).toBe('dns');
+    if (result.kind !== 'dns') throw new Error('expected dns result');
+    expect(result.data).toHaveLength(10);
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('aggregates partial results and surfaces a warning when some record types fail', async () => {
+    const netscli = await import('../services/netscli');
+    vi.mocked(netscli.dnsLookup).mockImplementation(async (host, recordType) => {
+      if (recordType === 'AAAA' || recordType === 'MX') {
+        throw new Error(`no ${recordType} records`);
+      }
+      return [{ record_type: recordType, value: `${recordType}-value`, name: host } as never];
+    });
+
+    const tab = createTab('dns');
+    tab.form.host = 'netscli.com';
+    tab.form.record = 'ALL';
+
+    const result = await executeTool(tab, 'op-2', 256);
+    expect(result.kind).toBe('dns');
+    if (result.kind !== 'dns') throw new Error('expected dns result');
+    expect(result.data).toHaveLength(8);
+    expect(result.warnings).toEqual(['Partial DNS results: no answers for AAAA, MX']);
+  });
+
+  it('throws when every record type fails', async () => {
+    const netscli = await import('../services/netscli');
+    vi.mocked(netscli.dnsLookup).mockRejectedValue(new Error('resolver unreachable'));
+
+    const tab = createTab('dns');
+    tab.form.host = 'netscli.com';
+    tab.form.record = 'ALL';
+
+    await expect(executeTool(tab, 'op-3', 256)).rejects.toThrow(/DNS resolution failed/);
+  });
+
+  it('propagates cancellation instead of treating it as a per-record failure', async () => {
+    const netscli = await import('../services/netscli');
+    vi.mocked(netscli.dnsLookup).mockRejectedValue(new Error('Operation cancelled'));
+
+    const tab = createTab('dns');
+    tab.form.host = 'netscli.com';
+    tab.form.record = 'ALL';
+
+    await expect(executeTool(tab, 'op-4', 256)).rejects.toThrow(/cancelled/i);
+  });
+});

--- a/apps/netscli-gui/src/workspace/types.ts
+++ b/apps/netscli-gui/src/workspace/types.ts
@@ -32,6 +32,13 @@ export interface WorkspaceModel {
   closeTab: (id: string) => void;
   closeAllTabs: () => void;
   closeOtherTabs: () => void;
+  /** Whether this tab was auto-created (e.g. interfaces/arp) and still
+   *  needs its first run triggered. App.tsx's own requestRun (which applies
+   *  operation guards and capability checks) watches this and calls
+   *  clearAutoRun once it has acted on it — kept out of this hook so
+   *  auto-run still goes through the same guard path as a manual run. */
+  needsAutoRun: (tabId: string) => boolean;
+  clearAutoRun: (tabId: string) => void;
   runTab: (tabId: string) => Promise<void>;
   cancelTab: (tabId: string) => Promise<void>;
   exportCurrent: (format: 'json' | 'csv') => void;
@@ -58,7 +65,6 @@ export interface WorkspaceOptions {
   maxConcurrentProbes: number;
   operationToasts: boolean;
   persistentHistory: boolean;
-  requestRun?: (tabId: string) => void;
 }
 
 export interface WorkspaceToast {

--- a/apps/netscli-gui/src/workspace/useResultActions.ts
+++ b/apps/netscli-gui/src/workspace/useResultActions.ts
@@ -1,0 +1,156 @@
+import type { Dispatch, SetStateAction } from 'react';
+
+import * as netscli from '../services/netscli';
+import { createTab, TOOL_CONFIG } from '../tools/registry';
+import type { ResultColumn, ResultRow, WorkspaceTab } from '../tools/types';
+import {
+  buildResultBundle,
+  copyRowsDetails,
+  copyRowsRaw,
+  exportCurrentResult,
+  exportSelectedRows,
+  parseResultBundle,
+} from './transfer';
+import type { WorkspaceToast } from './types';
+
+interface UseResultActionsArgs {
+  activeTab: WorkspaceTab | undefined;
+  columns: ResultColumn[];
+  rows: ResultRow[];
+  selectedRow: ResultRow | undefined;
+  selectedRows: ResultRow[];
+  commandPreview: string;
+  setTabs: Dispatch<SetStateAction<WorkspaceTab[]>>;
+  setActiveTabId: (tabId: string) => void;
+  showToast: (toast: Omit<WorkspaceToast, 'id'>) => void;
+}
+
+/** Everything that acts on the active/selected result: export, copy, and
+ *  the result-bundle save/open round trip. Doesn't own any state of its
+ *  own beyond what's passed in — tabs/selection stay in useWorkspace since
+ *  they're needed by far more than just these actions. */
+export function useResultActions({
+  activeTab,
+  columns,
+  rows,
+  selectedRow,
+  selectedRows,
+  commandPreview,
+  setTabs,
+  setActiveTabId,
+  showToast,
+}: UseResultActionsArgs) {
+  function showExportToast(path: string | null | undefined, fallback: string) {
+    if (path === undefined) return;
+    showToast({ message: path ? `Exported to ${path}` : fallback, kind: 'interaction' });
+  }
+
+  function showExportError(error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    showToast({ message: `Export failed: ${message}`, kind: 'interaction' });
+  }
+
+  function exportCurrent(format: 'json' | 'csv') {
+    exportCurrentResult(activeTab, columns, rows, format, showExportToast, showExportError);
+  }
+
+  function exportSelectedCsv() {
+    exportSelectedRows(activeTab, columns, selectedRows, 'csv', showExportToast, showExportError);
+  }
+
+  function exportSelectedJson() {
+    exportSelectedRows(activeTab, columns, selectedRows, 'json', showExportToast, showExportError);
+  }
+
+  async function saveResultBundle() {
+    if (!activeTab?.result) return;
+    const bundle = buildResultBundle(activeTab, commandPreview);
+    if (!bundle) return;
+    try {
+      const path = await netscli.saveResultBundle(JSON.stringify(bundle, null, 2));
+      showExportToast(path, 'Saved result bundle');
+    } catch (error) {
+      if (!/cancelled/i.test(String(error))) showExportError(error);
+    }
+  }
+
+  async function openResultBundle() {
+    try {
+      const bundle = parseResultBundle(await netscli.openResultBundle());
+      if (!(bundle.kind in TOOL_CONFIG)) {
+        throw new Error(`Unsupported tool kind '${bundle.kind}'`);
+      }
+      const tab = createTab(bundle.kind);
+      tab.title = bundle.title || TOOL_CONFIG[bundle.kind].shortLabel;
+      tab.form = { ...tab.form, ...bundle.form };
+      tab.result = bundle.result;
+      setTabs((prev) => [...prev, tab]);
+      setActiveTabId(tab.id);
+      showToast({ message: 'Result bundle opened', kind: 'interaction' });
+    } catch (error) {
+      if (!/cancelled/i.test(String(error))) {
+        showToast({ message: `Open failed: ${String(error)}`, kind: 'interaction' });
+      }
+    }
+  }
+
+  async function copyCommand() {
+    if (!commandPreview) return;
+    await navigator.clipboard?.writeText(commandPreview).catch(() => undefined);
+    showToast({ message: 'Command copied', kind: 'interaction' });
+  }
+
+  async function copyCellValue(label: string, value: string) {
+    if (!value) return;
+    await navigator.clipboard?.writeText(value).catch(() => undefined);
+    showToast({ message: `${label} copied`, kind: 'interaction' });
+  }
+
+  async function openCaptureFile(path: string) {
+    if (!path) return;
+    await netscli.openFilesystemPath(path).catch((error) => {
+      showToast({ message: `Open failed: ${String(error)}`, kind: 'interaction' });
+    });
+  }
+
+  async function revealCaptureFile(path: string) {
+    if (!path) return;
+    await netscli.revealFilesystemPath(path).catch((error) => {
+      showToast({ message: `Reveal failed: ${String(error)}`, kind: 'interaction' });
+    });
+  }
+
+  async function copySelectedDetails() {
+    const rowsToCopy = selectedRows.length > 0 ? selectedRows : selectedRow ? [selectedRow] : [];
+    if (rowsToCopy.length === 0) return;
+    await copyRowsDetails(rowsToCopy);
+    showToast({
+      message: rowsToCopy.length === 1 ? 'Details copied' : `${rowsToCopy.length} rows copied`,
+      kind: 'interaction',
+    });
+  }
+
+  async function copySelectedRaw() {
+    const rowsToCopy = selectedRows.length > 0 ? selectedRows : selectedRow ? [selectedRow] : [];
+    if (rowsToCopy.length === 0) return;
+    await copyRowsRaw(rowsToCopy);
+    showToast({
+      message: rowsToCopy.length === 1 ? 'Raw row copied' : `Raw ${rowsToCopy.length} rows copied`,
+      kind: 'interaction',
+    });
+  }
+
+  return {
+    exportCurrent,
+    exportSelectedCsv,
+    exportSelectedJson,
+    saveResultBundle,
+    openResultBundle,
+    copyCommand,
+    copyCellValue,
+    openCaptureFile,
+    revealCaptureFile,
+    copySelectedDetails,
+    copySelectedRaw,
+  };
+}

--- a/apps/netscli-gui/src/workspace/useTabLifecycle.ts
+++ b/apps/netscli-gui/src/workspace/useTabLifecycle.ts
@@ -1,0 +1,114 @@
+import { useRef, type Dispatch, type SetStateAction } from 'react';
+
+import { isTauri } from '../services/env';
+import * as netscli from '../services/netscli';
+import { createTab } from '../tools/registry';
+import type { ToolKind, WorkspaceTab } from '../tools/types';
+import type { DefaultInterfaceInfo, InterfaceInfo } from '../types/netscli';
+import { applyContextDefaults, shouldAutoRun } from './networkDefaults';
+
+interface UseTabLifecycleArgs {
+  tabs: WorkspaceTab[];
+  setTabs: Dispatch<SetStateAction<WorkspaceTab[]>>;
+  activeTabId: string;
+  setActiveTabId: (tabId: string) => void;
+  setFilterText: (filterText: string) => void;
+  defaultInterface: DefaultInterfaceInfo | null;
+  trafficInterfaceName: string | null;
+  interfaces: InterfaceInfo[];
+}
+
+/** Tab CRUD (create/close) plus the auto-run flag that App.tsx's own
+ *  requestRun effect consults — kept here alongside the tabs it applies to
+ *  rather than routed back through a ref, since only this hook knows which
+ *  tabs were auto-created and still need their first run triggered. */
+export function useTabLifecycle({
+  tabs,
+  setTabs,
+  activeTabId,
+  setActiveTabId,
+  setFilterText,
+  defaultInterface,
+  trafficInterfaceName,
+  interfaces,
+}: UseTabLifecycleArgs) {
+  const activeOps = useRef<Record<string, string>>({});
+  const autoRunTabIds = useRef<Set<string>>(new Set());
+
+  function addTab(kind: ToolKind) {
+    const tab = applyContextDefaults(createTab(kind), defaultInterface, trafficInterfaceName, interfaces);
+    if (shouldAutoRun(kind)) {
+      autoRunTabIds.current.add(tab.id);
+    }
+    setTabs((prev) => [...prev, tab]);
+    setActiveTabId(tab.id);
+  }
+
+  function openHostTool(kind: 'scan' | 'inspect', host: string) {
+    const value = host.trim();
+    if (!value) return;
+    const tab = applyContextDefaults(createTab(kind), defaultInterface, trafficInterfaceName, interfaces);
+    tab.form = { ...tab.form, host: value };
+    setTabs((prev) => [...prev, tab]);
+    setActiveTabId(tab.id);
+  }
+
+  function cancelOperationIds(tabIds: string[]) {
+    for (const tabId of tabIds) {
+      autoRunTabIds.current.delete(tabId);
+      const opId = activeOps.current[tabId];
+      if (opId && isTauri()) {
+        void netscli.cancelOperation(opId).catch(() => undefined);
+      }
+      delete activeOps.current[tabId];
+    }
+  }
+
+  function closeTab(id: string) {
+    cancelOperationIds([id]);
+    setTabs((prev) => {
+      const index = prev.findIndex((tab) => tab.id === id);
+      if (index < 0) return prev;
+      const next = prev.filter((tab) => tab.id !== id);
+      if (id === activeTabId) {
+        const replacement = next[Math.max(0, index - 1)] ?? next[0];
+        setActiveTabId(replacement?.id ?? '');
+      }
+      return next;
+    });
+  }
+
+  function closeAllTabs() {
+    cancelOperationIds(tabs.map((tab) => tab.id));
+    setTabs([]);
+    setActiveTabId('');
+    setFilterText('');
+  }
+
+  function closeOtherTabs(activeTab: WorkspaceTab | undefined) {
+    if (!activeTab) return;
+    cancelOperationIds(tabs.filter((tab) => tab.id !== activeTab.id).map((tab) => tab.id));
+    setTabs([activeTab]);
+    setActiveTabId(activeTab.id);
+  }
+
+  function needsAutoRun(tabId: string): boolean {
+    return autoRunTabIds.current.has(tabId);
+  }
+
+  function clearAutoRun(tabId: string): void {
+    autoRunTabIds.current.delete(tabId);
+  }
+
+  return {
+    activeOps,
+    addTab,
+    openHostTool,
+    cancelOperationIds,
+    closeTab,
+    closeAllTabs,
+    closeOtherTabs,
+    needsAutoRun,
+    clearAutoRun,
+  };
+}

--- a/apps/netscli-gui/src/workspace/useWorkspace.ts
+++ b/apps/netscli-gui/src/workspace/useWorkspace.ts
@@ -1,25 +1,19 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { isTauri } from '../services/env';
 import * as netscli from '../services/netscli';
-import { createTab, defaultDetailTab, TOOL_CONFIG } from '../tools/registry';
+import { createTab, defaultDetailTab } from '../tools/registry';
 import { buildCommand, buildRows, columnsFor, filterAndSortRows } from '../tools/presentation';
-import type { HistoryEntry, ResultColumn, RowSelectionMode, ToolKind, WorkspaceTab } from '../tools/types';
-import { applyContextDefaults, shouldAutoRun } from './networkDefaults';
+import type { HistoryEntry, ResultColumn, RowSelectionMode, WorkspaceTab } from '../tools/types';
+import { applyContextDefaults } from './networkDefaults';
 import { createDemoScreenshotTabs, isDemoScreenshotMode } from './demoMode';
 import { cancelWorkspaceTab, runWorkspaceTab } from './operations';
 import { clampIndex, normalizeSelection, rangeBetween } from './selection';
 import { loadHistory, saveHistory } from './historyStorage';
 import { enrichInterfaceRows } from './interfaceRows';
 import { applyProgressUpdate } from './traceProgress';
-import {
-  buildResultBundle,
-  copyRowsDetails,
-  copyRowsRaw,
-  exportCurrentResult,
-  exportSelectedRows,
-  parseResultBundle,
-} from './transfer';
+import { useResultActions } from './useResultActions';
+import { useTabLifecycle } from './useTabLifecycle';
 import type { WorkspaceModel, WorkspaceOptions } from './types';
 import { useNetworkStatus } from './useNetworkStatus';
 import { useWorkspaceToast } from './useWorkspaceToast';
@@ -32,8 +26,6 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
   const [activeTabId, setActiveTabId] = useState(() => tabs[0]?.id ?? '');
   const [filterText, setFilterText] = useState('');
   const [history, setHistory] = useState<HistoryEntry[]>(() => (options.persistentHistory ? loadHistory() : []));
-  const activeOps = useRef<Record<string, string>>({});
-  const autoRunTabIds = useRef<Set<string>>(new Set());
   const { dismissToast, showToast, showUpdateToast, toast } = useWorkspaceToast(options);
   const {
     defaultInterface,
@@ -61,6 +53,38 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
   const columns = columnsFor(activeTab?.kind ?? 'scan', activeTab?.result ?? null, baseRows);
   const commandPreview = activeTab ? buildCommand(activeTab) : '';
 
+  const {
+    activeOps,
+    addTab,
+    openHostTool,
+    closeTab,
+    closeAllTabs,
+    closeOtherTabs: closeOtherTabsFor,
+    needsAutoRun,
+    clearAutoRun,
+  } = useTabLifecycle({
+    tabs,
+    setTabs,
+    activeTabId,
+    setActiveTabId,
+    setFilterText,
+    defaultInterface,
+    trafficInterfaceName,
+    interfaces,
+  });
+
+  const resultActions = useResultActions({
+    activeTab,
+    columns,
+    rows,
+    selectedRow,
+    selectedRows,
+    commandPreview,
+    setTabs,
+    setActiveTabId,
+    showToast,
+  });
+
   useEffect(() => {
     if (options.persistentHistory) {
       saveHistory(history);
@@ -81,14 +105,6 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
       return changed ? next : prev;
     });
   }, [defaultInterface, interfaces, trafficInterfaceName]);
-
-  useEffect(() => {
-    if (!activeTab || !autoRunTabIds.current.has(activeTab.id)) return;
-    if (activeTab.busy || activeTab.result) return;
-    autoRunTabIds.current.delete(activeTab.id);
-    const run = options.requestRun ?? ((tabId: string) => void runTab(tabId));
-    run(activeTab.id);
-  }, [activeTab?.id, activeTab?.busy, activeTab?.result, options.requestRun]);
 
   useEffect(() => {
     if (!activeTab) return;
@@ -119,16 +135,6 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
       unlisten?.();
     };
   }, []);
-
-  function showExportToast(path: string | null | undefined, fallback: string) {
-    if (path === undefined) return;
-    showToast({ message: path ? `Exported to ${path}` : fallback, kind: 'interaction' });
-  }
-
-  function showExportError(error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    showToast({ message: `Export failed: ${message}`, kind: 'interaction' });
-  }
 
   function patchTab(id: string, patch: Partial<WorkspaceTab>) {
     setTabs((prev) => prev.map((tab) => (tab.id === id ? { ...tab, ...patch } : tab)));
@@ -211,61 +217,8 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
     });
   }
 
-  function addTab(kind: ToolKind) {
-    const tab = applyContextDefaults(createTab(kind), defaultInterface, trafficInterfaceName, interfaces);
-    if (shouldAutoRun(kind)) {
-      autoRunTabIds.current.add(tab.id);
-    }
-    setTabs((prev) => [...prev, tab]);
-    setActiveTabId(tab.id);
-  }
-
-  function openHostTool(kind: 'scan' | 'inspect', host: string) {
-    const value = host.trim();
-    if (!value) return;
-    const tab = applyContextDefaults(createTab(kind), defaultInterface, trafficInterfaceName, interfaces);
-    tab.form = { ...tab.form, host: value };
-    setTabs((prev) => [...prev, tab]);
-    setActiveTabId(tab.id);
-  }
-
-  function cancelOperationIds(tabIds: string[]) {
-    for (const tabId of tabIds) {
-      autoRunTabIds.current.delete(tabId);
-      const opId = activeOps.current[tabId];
-      if (opId && isTauri()) {
-        void netscli.cancelOperation(opId).catch(() => undefined);
-      }
-      delete activeOps.current[tabId];
-    }
-  }
-
-  function closeTab(id: string) {
-    cancelOperationIds([id]);
-    setTabs((prev) => {
-      const index = prev.findIndex((tab) => tab.id === id);
-      if (index < 0) return prev;
-      const next = prev.filter((tab) => tab.id !== id);
-      if (id === activeTabId) {
-        const replacement = next[Math.max(0, index - 1)] ?? next[0];
-        setActiveTabId(replacement?.id ?? '');
-      }
-      return next;
-    });
-  }
-
-  function closeAllTabs() {
-    cancelOperationIds(tabs.map((tab) => tab.id));
-    setTabs([]);
-    setActiveTabId('');
-    setFilterText('');
-  }
-
   function closeOtherTabs() {
-    if (!activeTab) return;
-    cancelOperationIds(tabs.filter((tab) => tab.id !== activeTab.id).map((tab) => tab.id));
-    setTabs([activeTab]);
-    setActiveTabId(activeTab.id);
+    closeOtherTabsFor(activeTab);
   }
 
   async function runTab(tabId: string) {
@@ -286,96 +239,6 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
 
   async function cancelTab(tabId: string) {
     await cancelWorkspaceTab(tabId, activeOps, patchTab);
-  }
-
-  function exportCurrent(format: 'json' | 'csv') {
-    exportCurrentResult(activeTab, columns, rows, format, showExportToast, showExportError);
-  }
-
-  function exportSelectedCsv() {
-    exportSelectedRows(activeTab, columns, selectedRows, 'csv', showExportToast, showExportError);
-  }
-
-  function exportSelectedJson() {
-    exportSelectedRows(activeTab, columns, selectedRows, 'json', showExportToast, showExportError);
-  }
-
-  async function saveResultBundle() {
-    if (!activeTab?.result) return;
-    const bundle = buildResultBundle(activeTab, commandPreview);
-    if (!bundle) return;
-    try {
-      const path = await netscli.saveResultBundle(JSON.stringify(bundle, null, 2));
-      showExportToast(path, 'Saved result bundle');
-    } catch (error) {
-      if (!/cancelled/i.test(String(error))) showExportError(error);
-    }
-  }
-
-  async function openResultBundle() {
-    try {
-      const bundle = parseResultBundle(await netscli.openResultBundle());
-      if (!(bundle.kind in TOOL_CONFIG)) {
-        throw new Error(`Unsupported tool kind '${bundle.kind}'`);
-      }
-      const tab = createTab(bundle.kind);
-      tab.title = bundle.title || TOOL_CONFIG[bundle.kind].shortLabel;
-      tab.form = { ...tab.form, ...bundle.form };
-      tab.result = bundle.result;
-      setTabs((prev) => [...prev, tab]);
-      setActiveTabId(tab.id);
-      showToast({ message: 'Result bundle opened', kind: 'interaction' });
-    } catch (error) {
-      if (!/cancelled/i.test(String(error))) {
-        showToast({ message: `Open failed: ${String(error)}`, kind: 'interaction' });
-      }
-    }
-  }
-
-  async function copyCommand() {
-    if (!commandPreview) return;
-    await navigator.clipboard?.writeText(commandPreview).catch(() => undefined);
-    showToast({ message: 'Command copied', kind: 'interaction' });
-  }
-
-  async function copyCellValue(label: string, value: string) {
-    if (!value) return;
-    await navigator.clipboard?.writeText(value).catch(() => undefined);
-    showToast({ message: `${label} copied`, kind: 'interaction' });
-  }
-
-  async function openCaptureFile(path: string) {
-    if (!path) return;
-    await netscli.openFilesystemPath(path).catch((error) => {
-      showToast({ message: `Open failed: ${String(error)}`, kind: 'interaction' });
-    });
-  }
-
-  async function revealCaptureFile(path: string) {
-    if (!path) return;
-    await netscli.revealFilesystemPath(path).catch((error) => {
-      showToast({ message: `Reveal failed: ${String(error)}`, kind: 'interaction' });
-    });
-  }
-
-  async function copySelectedDetails() {
-    const rowsToCopy = selectedRows.length > 0 ? selectedRows : selectedRow ? [selectedRow] : [];
-    if (rowsToCopy.length === 0) return;
-    await copyRowsDetails(rowsToCopy);
-    showToast({
-      message: rowsToCopy.length === 1 ? 'Details copied' : `${rowsToCopy.length} rows copied`,
-      kind: 'interaction',
-    });
-  }
-
-  async function copySelectedRaw() {
-    const rowsToCopy = selectedRows.length > 0 ? selectedRows : selectedRow ? [selectedRow] : [];
-    if (rowsToCopy.length === 0) return;
-    await copyRowsRaw(rowsToCopy);
-    showToast({
-      message: rowsToCopy.length === 1 ? 'Raw row copied' : `Raw ${rowsToCopy.length} rows copied`,
-      kind: 'interaction',
-    });
   }
 
   function sortBy(column: ResultColumn) {
@@ -440,23 +303,15 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
     closeTab,
     closeAllTabs,
     closeOtherTabs,
+    needsAutoRun,
+    clearAutoRun,
     runTab,
     cancelTab,
-    exportCurrent,
-    exportSelectedJson,
-    exportSelectedCsv,
-    saveResultBundle,
-    openResultBundle,
-    copyCellValue,
-    openCaptureFile,
-    revealCaptureFile,
-    copyCommand,
-    copySelectedDetails,
-    copySelectedRaw,
     sortBy,
     openHistoryEntry,
     clearHistory,
     clearCurrentResults,
     showInteractionToast: (message: string) => showToast({ message, kind: 'interaction' }),
+    ...resultActions,
   };
 }


### PR DESCRIPTION
## Summary

**Scope narrowed to what's safely verifiable at this point** — extracted the two largest, most self-contained groups of `useWorkspace.ts`'s functions into their own hooks, keeping the `useState` model rather than converting to `useReducer` (same file-size win, much lower regression risk for the app's central state hook):
- `workspace/useTabLifecycle.ts`: tab CRUD (`addTab`, `openHostTool`, `closeTab`, `closeAllTabs`, `closeOtherTabs`) plus auto-run tracking.
- `workspace/useResultActions.ts`: every export/copy/save/open-bundle action.

`useWorkspace.ts` composes both and returns the identical `WorkspaceModel` shape — no consumer changes anywhere. **463 → 317 lines.**

**Also fixed the `requestRunRef` circular indirection**: `App.tsx` needed `useWorkspace`'s internal auto-run effect to call App's own guard-checking `requestRun`, but `requestRun` needs the `workspace` object `useWorkspace` itself returns — a mutable ref bridged that cycle. Now `useWorkspace` just exposes `needsAutoRun(tabId)`/`clearAutoRun(tabId)`, and `App.tsx`'s own effect (which already has `requestRun` in scope) checks and calls it directly. `requestRunRef` and `WorkspaceOptions.requestRun` are gone.

**Verified live** in the preview browser: opened an "Interfaces" tab via the Tools menu and confirmed via the resulting UI text ("Tauri backend not available...") that `runTab` fired automatically — proving the new auto-run chain actually executes, not just type-checks. Also verified tab close/reactivation. Zero console errors.

**11 new tests**: `toolExecution.test.ts` covers `validateTab` and `executeTool`'s DNS "ALL" aggregation (all-succeed / partial-failure-with-warning / all-fail / cancellation-not-swallowed). `operations.test.ts` covers the op-id race guard via a deferred-promise test proving a stale `executeTool` resolution doesn't clobber state once a newer run has superseded it, plus success/failure paths.

**Deferred, flagged rather than attempted under time/risk pressure**: a `useReducer` conversion for tabs/selection, `App.tsx`'s menu-context extraction and `AppDialogs`'s `workspace` prop narrowing (App.tsx remains over its 345-line cap, grew +3 lines for the new effect), and `MenuBar` keyboard/focus tests.

Sixth in the sequenced audit-remediation batch (see #123–#127).

## Test plan
- [x] `npm run build` (tsc + vite, clean)
- [x] `npm run test:unit` (57/57 pass, 11 new)
- [x] `node scripts/check-file-size.mjs` — `useWorkspace.ts` no longer listed; new files well under cap
- [x] Live GUI verification: added/ran/closed an auto-run "Interfaces" tab via the Tools menu, confirmed the full `needsAutoRun` → `requestRun` → `runTab` chain fires correctly, zero console errors