### PR TITLE
Gate GitHub Pages deploy behind manual trigger only

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,19 +1,21 @@
 name: Deploy GitHub Pages
 
 # Builds the Astro site in `site/` and deploys the static output to
-# GitHub Pages on every push to main. Also re-runs on manual trigger
-# (e.g. after updating analytics config).
+# GitHub Pages. Manual trigger ONLY (workflow_dispatch) — deployment is
+# deliberately NOT wired to push-to-main right now. site/ currently holds
+# a redesign that's still mid review/design-pass; auto-deploying on every
+# main merge shipped it to netscli.com prematurely once already. Restore
+# the `push: branches: [main], paths: ['site/**', ...]` trigger once the
+# redesign is actually approved to ship, then deploys resume automatically.
+#
+# Until then: Actions tab → Deploy GitHub Pages → Run workflow, or
+# `gh workflow run pages.yml`.
 #
 # Prerequisite: in the repo Settings → Pages, set "Source" to
 # "GitHub Actions" (NOT "Deploy from a branch"). This workflow expects
 # that mode.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'site/**'
-      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Removes the `push: branches: [main]` trigger from `pages.yml`; deploys are now `workflow_dispatch`-only.
- `site/` currently holds a redesign that's still mid review/design-pass (just reverted to its pre-redesign state in #135 after it shipped prematurely). Without this change, the next unrelated merge touching `site/**` would auto-deploy again.
- Restore the push trigger once the redesign is deliberately approved to ship — the workflow file comments document exactly what to re-add.
- No effect on any other CI (`ci.yml`, `site.yml`, `gui-render.yml` are untouched) — this only changes when the *deploy* step runs, not when checks run on PRs.

## Test plan
- [ ] CI green on this PR
- [x] Verified `pages.yml`'s `on:` block only contains `workflow_dispatch` after this change