### PR TITLE
Add always-reporting CI gates so branch protection can require them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,16 @@ on:
       - 'packaging/**'
       - 'LICENSE'
       - '.gitignore'
+  # NOTE: deliberately no `paths-ignore` here, unlike the push trigger
+  # above. `CI Gate` at the bottom of this file is a required status
+  # check, and a required check that never *reports* leaves a PR stuck on
+  # "Expected — waiting for status" forever. Filtering at the workflow
+  # level would do exactly that for any PR touching only site/docs/
+  # packaging. So the workflow always runs, and the expensive jobs skip
+  # themselves via the `changes` job below. A skipped job satisfies a
+  # required check; an absent one does not.
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'site/**'
-      - 'packaging/**'
-      - 'LICENSE'
-      - '.gitignore'
   # Let me run CI manually from the Actions tab, useful for re-running a
   # cache-warm build after tweaking the workflow without having to push.
   workflow_dispatch:
@@ -39,8 +40,50 @@ permissions:
   contents: read
 
 jobs:
+  # Classify the diff so the expensive jobs can skip themselves without
+  # the workflow disappearing from the PR's check list. Done with plain
+  # git rather than a paths-filter action to avoid adding another
+  # third-party action to a repo that signs and publishes binaries.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            # push / manual runs always do the full build.
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base='${{ github.event.pull_request.base.sha }}'
+          head='${{ github.event.pull_request.head.sha }}'
+          files=$(git diff --name-only "$base" "$head")
+          echo "Changed files:"
+          echo "$files" | sed 's/^/  /'
+
+          # Anything that is NOT purely docs/site/packaging counts as code.
+          # Mirrors the push trigger's paths-ignore list above; keep the two
+          # in step.
+          code=$(echo "$files" | grep -vE '(\.md$|^docs/|^site/|^packaging/|^LICENSE$|^\.gitignore$)' || true)
+          if [[ -n "$code" ]]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "No code changes — Rust/GUI jobs will skip."
+          fi
+
   maintainability:
     name: Maintainability
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -55,6 +98,8 @@ jobs:
   # ubuntu-latest/GitHub-hosted runners.
   script-lint:
     name: Installer Script Lint
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -84,7 +129,8 @@ jobs:
   # going to fail there's no point firing up the matrix below.
   lint:
     name: Format + Clippy
-    needs: maintainability
+    needs: [changes, maintainability]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -120,7 +166,8 @@ jobs:
 
   test:
     name: Test (${{ matrix.os }})
-    needs: lint
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -163,7 +210,8 @@ jobs:
 
   gui-build:
     name: GUI Build (TypeScript + Vite)
-    needs: lint
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -201,7 +249,8 @@ jobs:
   #     equivalent coverage.
   release-build:
     name: Release build (${{ matrix.os }})
-    needs: test
+    needs: [changes, test]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -232,3 +281,48 @@ jobs:
             target/release/netscli.exe
           if-no-files-found: ignore
           retention-days: 14
+
+  # ─── Required status check ────────────────────────────────────────────
+  #
+  # This is the ONLY job from this workflow that should be marked required
+  # in branch protection. It runs unconditionally (`if: always()`, no path
+  # filter), so it always reports — which is the whole point. Marking the
+  # individual jobs required instead would deadlock any PR that legitimately
+  # skips them.
+  #
+  # `needs` result values: success | failure | cancelled | skipped.
+  # Skipped is a pass here: it means the `changes` job decided this PR does
+  # not touch code, which is a real answer, not a missing one.
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs:
+      - changes
+      - maintainability
+      - script-lint
+      - lint
+      - test
+      - gui-build
+      - release-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no upstream job failed
+        shell: bash
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS" | jq -r 'to_entries[] | "  \(.key): \(.value.result)"'
+
+          failed=$(echo "$NEEDS" | jq -r '
+            to_entries
+            | map(select(.value.result == "failure" or .value.result == "cancelled"))
+            | map(.key)
+            | join(", ")
+          ')
+
+          if [[ -n "$failed" ]]; then
+            echo "::error::CI Gate failed — these jobs did not succeed: ${failed}"
+            exit 1
+          fi
+          echo "CI Gate passed (all jobs succeeded or were legitimately skipped)."

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -5,18 +5,60 @@ on:
     branches: [main]
     paths:
       - 'site/**'
+  # NOTE: deliberately unfiltered, unlike the push trigger above. `Site
+  # Gate` below is a required status check, and a required check that
+  # never *reports* leaves a PR stuck on "Expected — waiting for status"
+  # forever. A `paths:` filter here would do exactly that for every PR
+  # that does not touch site/. So the workflow always runs and the real
+  # jobs skip themselves via `changes`. A skipped job satisfies a
+  # required check; an absent one does not.
   pull_request:
     branches: [main]
-    paths:
-      - 'site/**'
   workflow_dispatch:
+
+concurrency:
+  group: site-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect site changes
+    runs-on: ubuntu-latest
+    outputs:
+      site: ${{ steps.filter.outputs.site }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "site=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base='${{ github.event.pull_request.base.sha }}'
+          head='${{ github.event.pull_request.head.sha }}'
+          files=$(git diff --name-only "$base" "$head")
+          echo "Changed files:"
+          echo "$files" | sed 's/^/  /'
+
+          if echo "$files" | grep -qE '^site/'; then
+            echo "site=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "site=false" >> "$GITHUB_OUTPUT"
+            echo "No site/ changes — site jobs will skip."
+          fi
+
   maintainability:
     name: File size guard
+    needs: changes
+    if: needs.changes.outputs.site == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -27,7 +69,8 @@ jobs:
 
   build:
     name: Build + typecheck
-    needs: maintainability
+    needs: [changes, maintainability]
+    if: needs.changes.outputs.site == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -42,5 +85,41 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run check
+      # Runs axe against both themes; see site/scripts/a11y.mjs for why
+      # both are needed, and why it prefers the runner's matched
+      # chromedriver over the one the npm package downloads.
       - name: Accessibility check
         run: npm run test:a11y
+
+  # ─── Required status check ────────────────────────────────────────────
+  # The only job here that should be marked required in branch protection.
+  # See the equivalent note in ci.yml.
+  site-gate:
+    name: Site Gate
+    if: always()
+    needs:
+      - changes
+      - maintainability
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no upstream job failed
+        shell: bash
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS" | jq -r 'to_entries[] | "  \(.key): \(.value.result)"'
+
+          failed=$(echo "$NEEDS" | jq -r '
+            to_entries
+            | map(select(.value.result == "failure" or .value.result == "cancelled"))
+            | map(.key)
+            | join(", ")
+          ')
+
+          if [[ -n "$failed" ]]; then
+            echo "::error::Site Gate failed — these jobs did not succeed: ${failed}"
+            exit 1
+          fi
+          echo "Site Gate passed (all jobs succeeded or were legitimately skipped)."


### PR DESCRIPTION
`main` has **no required status checks**, so a red PR can merge. Switching them on naively does not work, because **no check currently runs on every PR**:

| PR touches | Checks that report |
|---|---|
| Rust / GUI code | Format + Clippy, Test ×3, Maintainability, GUI Build, Release build |
| `site/**` only | Build + typecheck, File size guard |
| docs / packaging only | *(none)* |

`ci.yml` has `paths-ignore` for `site/**` and `site.yml` only fires on `site/**`. Requiring "Format + Clippy" would leave every site-only PR stuck on *"Expected — waiting for status"* for a check that will never report. Verified against #157, which reported only 3 checks, none from `ci.yml`.

## The fix

One always-reporting aggregator per workflow:

- Both workflows now trigger on **every** `pull_request` with no path filter, so they always appear in the check list.
- A `changes` job classifies the diff and the expensive jobs gate themselves on its output. **A skipped job satisfies a required check; an absent one does not** — that asymmetry is the whole mechanism.
- `CI Gate` / `Site Gate` run with `if: always()`, inspect every upstream job's `result`, and fail only on `failure` or `cancelled`. `skipped` is a pass: it means `changes` determined the PR does not touch that area, which is a real answer rather than a missing one.

`changes` uses plain `git diff --name-only` rather than a paths-filter action — this repo signs and publishes binaries, and I'd rather not add another third-party action to the supply chain for something a three-line shell script does.

The **push-to-main** triggers keep their path filters, so a README typo still does not fire the 3-OS matrix.

## After merge

Mark exactly two checks required — `CI Gate` and `Site Gate`. Nothing else.

```bash
gh api -X PATCH repos/fstubner/netscli/branches/main/protection/required_status_checks \
  --input - <<'JSON'
{"strict": false, "contexts": ["CI Gate", "Site Gate"]}
JSON
```

## Verification

Gate logic was unit-checked against all five cases: all-skipped, all-success, one-failure, cancelled, and the `changes` job itself failing. This PR touches `.github/**`, which classifies as code, so it exercises the full matrix path; the skip path is exercised by the next site-only PR.

Deliberately **not** included in the required set: "Tauri render automation" (fails on `main` and every branch — WebView2/msedgedriver version skew, fixed separately) and "update_release_draft" (informational).

🤖 Generated with [Claude Code](https://claude.com/claude-code)