### PR TITLE
Make the GUI render failure diagnosable (does not fix it yet)

### DIFF
--- a/.github/workflows/gui-render.yml
+++ b/.github/workflows/gui-render.yml
@@ -51,6 +51,74 @@ jobs:
       - name: Install tauri-driver
         run: cargo install tauri-driver --locked
 
+      # This job has been failing with "session not created:
+      # DevToolsActivePort file doesn't exist", which is msedgedriver's
+      # generic "the thing I launched never came up" error and says
+      # nothing about why. Capture the environment so the next failure is
+      # diagnosable from the log instead of by guesswork.
+      - name: Diagnose WebView2 / driver environment
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          function Get-Pv($id, $label) {
+            foreach ($root in @('HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients',
+                                'HKLM:\SOFTWARE\Microsoft\EdgeUpdate\Clients',
+                                'HKCU:\SOFTWARE\Microsoft\EdgeUpdate\Clients')) {
+              $key = Join-Path $root $id
+              if (Test-Path $key) {
+                $pv = (Get-ItemProperty $key -ErrorAction SilentlyContinue).pv
+                if ($pv) { Write-Host "${label}: $pv   [$root]"; return }
+              }
+            }
+            Write-Host "${label}: NOT FOUND"
+          }
+          # These GUIDs are Microsoft's stable product ids for the two
+          # separately-versioned components. A Tauri app renders in the
+          # WebView2 Runtime, but the `edgedriver` npm package version-
+          # matches against the Edge *browser* — if these differ, that is
+          # the bug.
+          Get-Pv '{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}' 'WebView2 Runtime'
+          Get-Pv '{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}' 'Edge (stable) '
+
+          $edge = 'C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe'
+          if (Test-Path $edge) {
+            Write-Host "msedge.exe      : $((Get-Item $edge).VersionInfo.ProductVersion)"
+          } else { Write-Host "msedge.exe      : NOT FOUND" }
+
+          Write-Host "tauri-driver    : $(tauri-driver --version 2>&1)"
+          Write-Host "session type    : $([Environment]::UserInteractive)"
+
       - name: Run Tauri render test
         run: npm run test:tauri-render
         working-directory: apps/netscli-gui
+
+      # On failure, show what the app itself did. msedgedriver's error
+      # cannot distinguish "app crashed" from "driver could not attach",
+      # and those need completely different fixes.
+      - name: Probe the built app directly (on failure)
+        if: failure()
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          $app = Get-ChildItem -Path target\debug\netscli-gui.exe -ErrorAction SilentlyContinue
+          if (-not $app) {
+            Write-Host "app binary not found under target\debug"
+            Get-ChildItem -Recurse -Filter netscli-gui.exe -Depth 4 -ErrorAction SilentlyContinue |
+              Select-Object -First 5 FullName
+            exit 0
+          }
+          Write-Host "app: $($app.FullName)  size=$($app.Length)"
+          $p = Start-Process -FilePath $app.FullName -PassThru `
+                 -RedirectStandardError app-stderr.txt -RedirectStandardOutput app-stdout.txt
+          Start-Sleep -Seconds 12
+          if ($p.HasExited) {
+            Write-Host "app EXITED early with code $($p.ExitCode)"
+          } else {
+            Write-Host "app is still running after 12s (so it launches fine)"
+            Stop-Process -Id $p.Id -Force
+          }
+          foreach ($f in 'app-stdout.txt','app-stderr.txt') {
+            if ((Test-Path $f) -and (Get-Item $f).Length -gt 0) {
+              Write-Host "--- $f ---"; Get-Content $f -Tail 40
+            }
+          }

--- a/.github/workflows/gui-render.yml
+++ b/.github/workflows/gui-render.yml
@@ -92,6 +92,16 @@ jobs:
         run: npm run test:tauri-render
         working-directory: apps/netscli-gui
 
+      # Talk to msedgedriver directly with --verbose, bypassing
+      # tauri-driver. tauri-driver relays none of the native driver's
+      # output, so this is the only way to see why the debug port never
+      # appears.
+      - name: msedgedriver verbose session probe (on failure)
+        if: failure()
+        continue-on-error: true
+        run: node e2e/tauri-render/diagnose-driver.mjs
+        working-directory: apps/netscli-gui
+
       # On failure, show what the app itself did. msedgedriver's error
       # cannot distinguish "app crashed" from "driver could not attach",
       # and those need completely different fixes.

--- a/apps/netscli-gui/e2e/tauri-render.mjs
+++ b/apps/netscli-gui/e2e/tauri-render.mjs
@@ -55,7 +55,21 @@ async function main() {
   process.env.NETSCLI_EXPORT_DIR = artifactsDir;
   tauriDriverProcess = await startTauriDriver(nativeDriverPath, webdriverPort);
 
-  const driver = await createDriver(webdriverPort, application);
+  let driver;
+  try {
+    driver = await createDriver(webdriverPort, application);
+  } catch (error) {
+    // Session creation is where this harness fails most often, and the
+    // WebDriver error alone ("session not created: DevToolsActivePort
+    // file doesn't exist") says nothing about the cause. Everything
+    // useful is in the native driver's own output.
+    const driverLog = tauriDriverProcess?.getDriverOutput?.() ?? '';
+    console.error('\n--- tauri-driver / native driver output ---');
+    console.error(driverLog.trim() || '(no output captured)');
+    console.error('--- end driver output ---');
+    console.error(`app under test: ${application}`);
+    throw error;
+  }
 
   try {
     await driver.manage().window().setRect(DESKTOP_WINDOW);

--- a/apps/netscli-gui/e2e/tauri-render/diagnose-driver.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/diagnose-driver.mjs
@@ -1,0 +1,141 @@
+/**
+ * Drive msedgedriver directly against the built Tauri app, bypassing
+ * tauri-driver, with verbose logging on.
+ *
+ * Why this exists: the render harness fails with selenium's
+ * "session not created: DevToolsActivePort file doesn't exist", which
+ * only means "the thing I launched never exposed a debug port". Neither
+ * selenium nor tauri-driver relays msedgedriver's own reasoning — we
+ * confirmed tauri-driver captures no output at all on this path. Talking
+ * to msedgedriver directly, with --verbose, is the only way to see what
+ * it actually tried.
+ *
+ * Run:  node e2e/tauri-render/diagnose-driver.mjs
+ */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { findApplication, resolveNativeDriverPath } from './driver.mjs';
+
+const LOG_PATH = 'msedgedriver-verbose.log';
+
+async function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForPort(port, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const ok = await new Promise((resolve) => {
+      const socket = net.connect(port, '127.0.0.1');
+      socket.on('connect', () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.on('error', () => {
+        socket.destroy();
+        resolve(false);
+      });
+    });
+    if (ok) return;
+    await delay(250);
+  }
+  throw new Error(`msedgedriver never listened on ${port}`);
+}
+
+/** Ask msedgedriver for a session, the same way tauri-driver would. */
+async function trySession(port, label, capabilities) {
+  console.log(`\n=== attempt: ${label} ===`);
+  console.log(JSON.stringify(capabilities, null, 2));
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/session`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ capabilities }),
+    });
+    const text = await response.text();
+    console.log(`HTTP ${response.status}`);
+    console.log(text.slice(0, 1200));
+    if (response.ok) {
+      const sessionId = JSON.parse(text)?.value?.sessionId;
+      if (sessionId) {
+        console.log(`SUCCESS — sessionId ${sessionId}; closing it again`);
+        await fetch(`http://127.0.0.1:${port}/session/${sessionId}`, { method: 'DELETE' }).catch(
+          () => undefined,
+        );
+        return true;
+      }
+    }
+  } catch (error) {
+    console.log(`request failed: ${error.message}`);
+  }
+  return false;
+}
+
+const application = findApplication();
+const driverPath = await resolveNativeDriverPath();
+const port = await freePort();
+
+console.log(`app         : ${application}`);
+console.log(`msedgedriver: ${driverPath}`);
+console.log(`port        : ${port}`);
+
+fs.rmSync(LOG_PATH, { force: true });
+
+const driver = spawn(
+  driverPath,
+  [`--port=${port}`, '--verbose', `--log-path=${LOG_PATH}`, '--allowed-ips=', '--allowed-origins=*'],
+  { stdio: ['ignore', 'inherit', 'inherit'] },
+);
+
+let succeeded = false;
+try {
+  await waitForPort(port);
+
+  // The shape tauri-driver uses for a Tauri app on Windows: point
+  // msedgedriver at the app binary and tell it this is a WebView2 host.
+  succeeded = await trySession(port, 'browserName=webview2 + ms:edgeOptions.binary', {
+    alwaysMatch: {
+      browserName: 'webview2',
+      'ms:edgeOptions': { binary: application, args: [] },
+    },
+  });
+
+  if (!succeeded) {
+    // If the app is never given a remote-debugging-port it cannot write
+    // a DevToolsActivePort file at all. wry forwards this env var into
+    // the WebView2 host, so pass it explicitly and see if that is the
+    // missing piece.
+    succeeded = await trySession(port, 'webview2 + explicit remote-debugging-port', {
+      alwaysMatch: {
+        browserName: 'webview2',
+        'ms:edgeOptions': {
+          binary: application,
+          args: ['--remote-debugging-port=9222'],
+        },
+      },
+    });
+  }
+} finally {
+  driver.kill();
+  await delay(500);
+  console.log(`\n=== ${LOG_PATH} ===`);
+  if (fs.existsSync(LOG_PATH)) {
+    const log = fs.readFileSync(LOG_PATH, 'utf8');
+    console.log(log.length > 20_000 ? `${log.slice(0, 20_000)}\n…truncated…` : log);
+  } else {
+    console.log('(msedgedriver wrote no log file)');
+  }
+}
+
+console.log(`\nresult: ${succeeded ? 'a session WAS created' : 'no session could be created'}`);

--- a/apps/netscli-gui/e2e/tauri-render/driver.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/driver.mjs
@@ -60,6 +60,15 @@ export async function startTauriDriver(nativeDriverPath, webdriverPort) {
     }),
   ]);
 
+  // tauri-driver proxies to the native driver (msedgedriver on Windows)
+  // and relays its diagnostics here. Previously this buffer was only
+  // ever read if tauri-driver exited *early* — so when the far more
+  // common failure happened instead (the session failing to start, e.g.
+  // "DevToolsActivePort file doesn't exist"), everything the native
+  // driver said about why was silently discarded. Expose it so the
+  // caller can print it on any failure.
+  child.getDriverOutput = () => output;
+
   return child;
 }
 

--- a/apps/netscli-gui/src-tauri/tauri.conf.json
+++ b/apps/netscli-gui/src-tauri/tauri.conf.json
@@ -17,7 +17,6 @@
         "height": 700,
         "minWidth": 520,
         "minHeight": 600,
-        "devtools": false,
         "decorations": false
       }
     ],

--- a/apps/netscli-gui/src-tauri/tauri.conf.json
+++ b/apps/netscli-gui/src-tauri/tauri.conf.json
@@ -17,6 +17,7 @@
         "height": 700,
         "minWidth": 520,
         "minHeight": 600,
+        "devtools": false,
         "decorations": false
       }
     ],


### PR DESCRIPTION
The `Tauri render automation` job has failed on **every recorded run** since 2026-07-21 with msedgedriver's generic `session not created: DevToolsActivePort file doesn't exist`. That message only means *"the thing I launched never exposed a debug port"* and says nothing about why, so the job has been effectively un-debuggable — and un-gating, since it can't be a required check while it's permanently red.

**This PR does not fix it.** It adds the instrumentation that made the investigation possible and rules out most of the candidate causes. Opening it so the narrowing isn't lost.

## Ruled out, with evidence from the runner

```
WebView2 Runtime: 151.0.4129.72
Edge (stable)   : 151.0.4129.72
msedge.exe      : 151.0.4129.72
session type    : True   (interactive desktop session)
app is still running after 12s (so it launches fine)
```

| Hypothesis | Verdict |
|---|---|
| msedgedriver version-matched to Edge, but Tauri runs on the separately-versioned WebView2 Runtime | **No** — all three are byte-identical `151.0.4129.72` |
| The app crashes on launch | **No** — runs 12s standalone under the failure probe |
| No interactive desktop session on the runner | **No** — `UserInteractive = True` |
| `"devtools": false` (added 2026-07-09, correlates with the failures) disables the CDP surface WebDriver attaches to | **No** — removing it changed nothing; reverted in this PR |
| `tauri-driver` too old / Tauri-1 era | **No** — 2.0.6, current, Tauri 2 native |

The `devtools` revert is deliberate: its only justification was "this fixes CI", and that turned out to be false, so the original hardening intent stands unchanged.

## What this PR adds

- **Workflow diagnostics** (`gui-render.yml`): WebView2 Runtime, Edge, msedge.exe, tauri-driver and session-type versions before the run, plus an on-failure probe that launches the built app directly and reports whether it survives 12s and what it wrote to stdout/stderr. This is what produced the table above.
- **Driver output surfacing** (`driver.mjs` / `tauri-render.mjs`): `startTauriDriver` already buffered tauri-driver's stdout/stderr, but only ever read it if the process exited *early*. On the far more common failure — the session failing to start — everything the native driver said was silently discarded. Now printed on any `createDriver` failure.

That last one is a real gap regardless of this bug, though it turned out tauri-driver relays nothing useful here (`(no output captured)`), which is itself a finding.

## Next step

Run msedgedriver directly against the built app with `--verbose --log-path`, bypassing tauri-driver, to get the real reason the debug port never appears. Remaining suspects: WebView2 options tauri-driver isn't passing for this app, the custom `decorations: false` window, or a user-data-dir permission issue on the runner.

Until then `Tauri render automation` stays out of the required-checks set (`CI Gate` / `Site Gate`), so it blocks nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)