### PR TITLE
Document how to get packet capture, and every publish channel

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,10 +1,48 @@
 # Publishing netscli
 
-This is a workspace with three publishable crates that depend on each other.
-Crates.io requires dependencies to be published before anything that depends
-on them, so the order matters.
+Per-channel reference: what each distribution channel is, what publishes to
+it, what it needs, and how to fix it when it breaks.
 
-## Publish order
+For the step-by-step *process* of cutting a release, see
+[`RELEASE.md`](RELEASE.md). This document is the reference you consult when
+one channel misbehaves.
+
+## Channels at a glance
+
+netscli publishes to **six** channels via **nine** automated jobs. Everything
+except the crates.io publish is triggered by promoting a GitHub release to
+public.
+
+| Channel | Artifacts | Job in `publish.yml` | Deployed to |
+| --- | --- | --- | --- |
+| crates.io | `netscli-core`, `netscli-mcp`, `netscli` | `crates-io` | crates.io |
+| GitHub Releases | 11 CLI assets + 5 GUI installers, each with `.sha256`/`.sig`/`.pem` | *(`release.yml`, not `publish.yml`)* | this repo's Releases |
+| Homebrew | CLI formula + GUI cask | `homebrew`, `homebrew-cask` | `fstubner/homebrew-tap` |
+| Scoop | CLI + GUI manifests | `scoop`, `scoop-gui` | `fstubner/scoop-bucket` |
+| winget | `fstubner.netscli`, `fstubner.netscli.gui` | `winget`, `winget-gui` | `microsoft/winget-pkgs` (PR) |
+| AUR | `netscli-bin`, `netscli-gui-bin` | `aur`, `aur-gui` | `aur.archlinux.org` |
+
+Templates for the packaging manifests live under [`packaging/`](../packaging/)
+for reference. The **deployed** copies live in the tap, bucket, AUR, and
+winget-pkgs — the jobs re-stamp those on every release; the templates in this
+repo are not what users install.
+
+### What is NOT published
+
+- **The desktop app is not on crates.io.** `netscli-gui` is a Tauri app,
+  distributed only as platform installers.
+- **No published artifact has packet capture.** Every release asset and
+  installer is built without `--features pcap`, deliberately, so the default
+  install has no libpcap/Npcap dependency and we do not redistribute Npcap.
+  The `-pcap` CLI variants are the exception and are published as separate
+  release assets. There is no packet-capture desktop installer at all.
+
+## Crates.io
+
+Three crates depend on each other, and crates.io requires dependencies to be
+published first, so the order matters.
+
+### Publish order
 
 1. `netscli-core` (the library — depends on nothing in-workspace)
 2. `netscli-mcp` (depends on `netscli-core`)
@@ -127,18 +165,149 @@ Finally, move the `## [Unreleased]` content in `CHANGELOG.md` under a
 `## [X.Y.Z] — YYYY-MM-DD` heading and add the matching link reference at
 the bottom of the file.
 
-## GitHub release
+## GitHub Releases
 
-Platform installers (and the download links in the install scripts) come
-from the GitHub release, not crates.io. The `release.yml` workflow fires
-when you publish a release on GitHub:
+Platform installers, and the download links the install scripts resolve,
+come from the GitHub release — not crates.io. `release.yml` fires on
+`release: published`.
 
 ```bash
-# Tag the commit
-git tag v0.2.0
-git push origin v0.2.0
-
-# Then on GitHub: Releases → Draft a new release → pick the tag →
-# fill in notes → publish. The workflow builds binaries for every
-# platform in the matrix and attaches them as release assets.
+git tag vX.Y.Z
+git push origin vX.Y.Z
+# Then: Releases → Draft a new release → pick the tag → notes → publish.
 ```
+
+It builds and attaches, per asset, four files: the artifact, `.sha256`,
+`.sig`, and `.pem`.
+
+- **11 CLI assets** — linux x86_64/aarch64 (gnu, each with a `-pcap`
+  variant), linux x86_64 musl (no `-pcap`), windows x86_64 (plus `-pcap`),
+  macos x86_64/aarch64 (each plus `-pcap`).
+- **5 GUI installers** from 4 matrix entries — the Linux entry emits both
+  `.deb` and `.AppImage`; then two `.dmg` (aarch64, x86_64) and one `.msi`.
+
+Signing is Sigstore keyless via `cosign sign-blob`, using the Actions OIDC
+token — no key material is stored. Consumers verify with the command in
+[`RELEASE.md`](RELEASE.md#sigstore-signature-verification). Note that
+**nothing downstream verifies these signatures automatically**; the package
+managers rely on their own hash checks instead.
+
+**Windows pcap builds** link against the Npcap SDK, which `release.yml`
+downloads and verifies against a pinned SHA256. Bumping the SDK version
+means re-pinning that digest.
+
+## Homebrew
+
+Two artifacts in one tap, `fstubner/homebrew-tap`:
+
+| Artifact | File | Job | Install |
+| --- | --- | --- | --- |
+| CLI | `Formula/netscli.rb` | `homebrew` | `brew install fstubner/tap/netscli` |
+| Desktop | `Casks/netscli.rb` | `homebrew-cask` | `brew install --cask fstubner/tap/netscli` |
+
+**The Formula and the Cask share the token `netscli`.** A bare
+`brew install netscli` is ambiguous — always qualify with `--cask` for the
+desktop app, and prefer the fully-qualified `fstubner/tap/netscli` form in
+documentation so it works without a separate `brew tap` step.
+
+`publish-homebrew.sh` sed-patches the version and awk-patches each `sha256`
+that follows a matching url line. `publish-homebrew-cask.sh` regenerates the
+Cask wholesale from a quoted heredoc, because the Cask block puts `sha256`
+*before* `url` and a single-pass awk would need a backwards lookup.
+
+Needs `HOMEBREW_TAP_TOKEN`.
+
+## Scoop
+
+Two manifests in `fstubner/scoop-bucket`, both patched with `jq`:
+
+| Artifact | File | Job | Install |
+| --- | --- | --- | --- |
+| CLI | `bucket/netscli.json` | `scoop` | `scoop install netscli` |
+| Desktop | `bucket/netscli-gui.json` | `scoop-gui` | `scoop install netscli-gui` |
+
+Users add the bucket once with
+`scoop bucket add fstubner https://github.com/fstubner/scoop-bucket`.
+
+Needs `SCOOP_BUCKET_TOKEN`.
+
+## winget
+
+Two package identifiers submitted to `microsoft/winget-pkgs` by
+`vedantmgoyal9/winget-releaser`, which forks the repo under your account and
+opens a PR.
+
+| Identifier | Job | Install |
+| --- | --- | --- |
+| `fstubner.netscli` | `winget` | `winget install fstubner.netscli` |
+| `fstubner.netscli.gui` | `winget-gui` | `winget install fstubner.netscli.gui` |
+
+**A moderator has to merge the PR** — usually hours to days. This is the one
+channel that is not fully automated, and the CLA must be signed once per
+account.
+
+Both jobs poll for the relevant `.sha256` sidecar for up to 15 minutes before
+invoking the action, because `release.yml` and `publish.yml` both fire on
+`release: published` and race each other. Without the poll the action sees no
+matching asset and fails with an empty `--urls`.
+
+winget is the **recommended Windows install path** because it verifies the
+installer against the SHA256 in the manifest. Direct MSI/NSIS downloads are
+unsigned and show SmartScreen warnings — see
+[`RELEASE.md`](RELEASE.md#windows-trust-and-signing-policy). Do not describe
+winget as a substitute for Authenticode signing.
+
+The `packaging/winget/<pkg>/<version>/` directories are **reference copies**
+of submitted manifests, one directory per version. Do not edit an existing
+version's directory to hold a different version's content — winget-pkgs keys
+on the directory name, and a mismatch files a conflicting duplicate.
+
+Needs `WINGET_TOKEN` (classic PAT, `public_repo`).
+
+## AUR
+
+Two packages pushed over SSH by `KSXGitHub/github-actions-deploy-aur`, which
+regenerates `.SRCINFO` server-side.
+
+| Package | Job | Install |
+| --- | --- | --- |
+| `netscli-bin` | `aur` | `yay -S netscli-bin` |
+| `netscli-gui-bin` | `aur-gui` | `yay -S netscli-gui-bin` |
+
+Each job computes the asset SHA256s, renders a bumped PKGBUILD with `sed`,
+and pushes. The render happens **inside `$GITHUB_WORKSPACE`**, not `/tmp` —
+the deploy action runs in a container that mounts the workspace only, and a
+`/tmp` path produces a confusing `bash: --command: invalid option` error.
+
+AUR has **no review step**. A bad push is live immediately.
+
+Needs `AUR_SSH_PRIVATE_KEY`.
+
+## When a channel fails
+
+Every job is independent and re-runnable. `publish.yml` accepts a
+`workflow_dispatch` tag input, so you can re-run a single channel without
+rebuilding binaries or touching the others:
+
+```bash
+gh workflow run publish.yml -f tag=vX.Y.Z
+```
+
+The publish scripts are idempotent — re-running a channel that already
+succeeded commits nothing and exits cleanly, rather than failing on "nothing
+to commit".
+
+Failure modes worth knowing:
+
+| Symptom | Cause |
+| --- | --- |
+| `refusing to publish malformed tag` | The tag input is not `vMAJOR.MINOR.PATCH[-prerelease]`. Deliberate — the tag reaches `sed` replacements and commit messages. |
+| `checksum mismatch for <asset>` | The `.sha256` sidecar disagrees with the actual bytes. The scripts download and re-hash rather than trusting the sidecar; investigate before overriding. |
+| `<asset>.sha256 is not a 64-char hex digest` | Sidecar truncated or missing. Previously this silently produced a manifest with blank hashes. |
+| `never became available` after 15 min | `release.yml` did not attach the asset. Check that job first; publishing cannot proceed without it. |
+| winget job fails with empty `--urls` | Asset poll passed but the action ran too early, or the package has never been accepted into winget-pkgs. |
+| crates.io "no matching package named …" | An earlier crate in the order has not indexed yet. Wait and re-run; the job sleeps 90s between publishes. |
+
+Because crates.io publishes are **permanent** — you can yank but not delete,
+and a yanked version keeps its number — a failed crates.io publish means
+bumping the patch version, not retrying the same one.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,8 +1,12 @@
 # Release process
 
-netscli ships through five distribution channels. As of v0.2.1 every step
-after "publish the GitHub release" is automated by
+netscli ships through six distribution channels. Every step after "publish
+the GitHub release" is automated by
 [`.github/workflows/publish.yml`](../.github/workflows/publish.yml).
+
+This document is the **process** — what a human does, in order. For a
+per-channel reference (what each channel is, what it needs, how to fix it
+when it breaks), see [`PUBLISHING.md`](PUBLISHING.md).
 
 ## One-time secret setup
 
@@ -19,8 +23,11 @@ Before the first automated release runs, add these secrets at
 
 ## The release flow
 
-1. **Bump versions + CHANGELOG**, merge to main. (Already done for v0.2.1
-   via [#30](https://github.com/fstubner/netscli/pull/30).)
+1. **Bump versions + CHANGELOG**, merge to main. Seven files have to move
+   together — see
+   [`PUBLISHING.md`](PUBLISHING.md#version-bumps) for the list and a
+   verification command; missing the GUI's three is what got the v0.2.4
+   winget submission rejected.
    Before tagging, run the local release gate:
    ```bash
    cargo fmt --check
@@ -104,8 +111,9 @@ Before the first automated release runs, add these secrets at
    installers, attaches them to the release) and `publish.yml` (fans out
    to package managers).
 5. **Watch the dashboard.** From the release page or the Actions tab:
-   - `Release` workflow: 13 CLI assets + 4 GUI installers attached.
-   - `Publish to package managers` workflow: 5 jobs, one per channel.
+   - `Release` workflow: 11 CLI assets + 5 GUI installers attached.
+   - `Publish to package managers` workflow: 9 jobs — a CLI and a GUI job
+     for each of Homebrew, Scoop, winget and AUR, plus `crates-io`.
 
    The `homebrew`, `scoop`, and `aur` jobs poll for asset availability
    (up to 15 minutes) so they tolerate the parallel race against
@@ -206,17 +214,30 @@ listing) so the app does not invent a competing updater path.
 | Platform | Command |
 |----------|---------|
 | Windows | `winget install fstubner.netscli.gui` |
-| macOS | `brew install --cask netscli` |
+| macOS | `brew install --cask fstubner/tap/netscli` |
 | Linux (any distro, AppImage) | `yay -S netscli-gui-bin` |
 | Windows (Scoop) | `scoop install netscli-gui` |
 
 ## Action pin policy
 
-The two third-party actions used by `publish.yml` are referenced by
-version tag, not commit SHA:
-- `vedantmgoyal2009/winget-releaser@v2`
-- `KSXGitHub/github-actions-deploy-aur@v4.1.3`
+Every third-party action in `release.yml` and `publish.yml` is pinned to a
+**commit SHA**, with the human-readable version in a trailing comment:
 
-These are stable, widely-used actions; pinning to SHA is on the radar
-but not blocking. If you want stricter supply-chain hygiene, swap each
-`@vN` for the matching `@<sha>` and let Dependabot bump them.
+```yaml
+uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+```
+
+Both workflows hold `contents: write` and `id-token: write`, so a retagged
+or compromised action could exfiltrate the OIDC token and mint Fulcio
+certificates as this repository. Tag refs are mutable; SHAs are not.
+
+Dependabot updates SHA pins and rewrites the comment. When bumping by hand,
+resolve the tag first:
+
+```bash
+gh api repos/<owner>/<repo>/commits/<tag> --jq .sha
+```
+
+The workflows that only hold `contents: read` (`ci.yml`, `site.yml`,
+`audit.yml`, `gui-render.yml`) still use tag refs — the blast radius there
+is a failed build, not a forged signature.

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -103,14 +103,60 @@ brew upgrade netscli
 
 For direct release artifacts, download the [latest GitHub release](https://github.com/fstubner/netscli/releases/latest) and replace the previous install with the matching package for your platform.
 
-## Packet capture requirements
+## Packet capture
 
-Normal scan, discovery, DNS, ARP, ping, trace, and interface workflows do not require packet-capture libraries.
+**No install on this page includes packet capture.** It is a compile-time feature, and every published build — the desktop installers, the standard CLI release assets, and `cargo install netscli` — is built without it. That keeps the default install free of any libpcap/Npcap dependency and avoids redistributing Npcap.
 
-Packet capture is the exception:
+Normal scan, discovery, DNS, ARP, ping, trace, and interface workflows are unaffected and need none of this.
 
-- Windows requires Npcap at runtime.
-- Linux requires libpcap and appropriate capture permissions.
-- macOS requires libpcap availability and may require capture permissions.
+If you do want packet capture, you need **both** a build that has the feature compiled in **and** the system capture library.
 
-If a build does not include packet capture support, the desktop app hides Packet Capture and the CLI omits that command path. If support is included but the runtime library is missing, only packet capture is unavailable.
+### CLI with packet capture
+
+The install script does both at once — it selects the `-pcap` build *and* installs the system library:
+
+```bash
+NETSCLI_PCAP=1 curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | NETSCLI_PCAP=1 bash
+```
+
+```powershell
+$env:NETSCLI_PCAP=1; iwr -useb https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.ps1 | iex
+```
+
+On Windows this runs the Npcap installer, which needs administrator rights. Add `NETSCLI_SKIP_NPCAP=1` (or `NETSCLI_SKIP_LIBPCAP=1` on Unix) if you manage the capture library yourself.
+
+Alternatively, download the `-pcap` asset directly from the [latest release](https://github.com/fstubner/netscli/releases/latest) — `netscli-linux-x86_64-pcap`, `netscli-macos-aarch64-pcap`, `netscli-windows-x86_64-pcap.exe`, and so on — and install the capture library separately. There is no `-pcap` musl build.
+
+Or build it yourself, which needs the development headers (`libpcap-dev` on Debian/Ubuntu, or the [Npcap SDK](https://npcap.com/#download) on Windows):
+
+```bash
+cargo install netscli --features pcap
+```
+
+### Desktop app with packet capture
+
+There is **no published desktop installer with packet capture**. The Packet Capture tool appears in the app but shows setup guidance instead of running. To get a capture-capable desktop build you have to build from source:
+
+```bash
+cd apps/netscli-gui
+npm install
+npm run tauri build -- --features pcap
+```
+
+### System requirements
+
+| Platform | Requirement |
+| --- | --- |
+| Windows | Npcap installed. `wpcap.dll` lives in `C:\Windows\System32\Npcap\`, which is not on `PATH` by default — add it, or let `NETSCLI_PCAP=1` do it. |
+| Linux | libpcap installed, plus capture permissions (`CAP_NET_RAW` or root). |
+| macOS | libpcap available, plus capture permissions where required. |
+
+### Checking what you have
+
+`netscli doctor` works on **every** build and reports whether packet capture is compiled in and whether the runtime library is present:
+
+```bash
+netscli doctor
+```
+
+Note that `netscli pcap --check` only exists on builds that were compiled with the feature — on a standard build the subcommand is absent entirely and you will get an "unrecognized subcommand" error rather than a useful message. Use `doctor` to find out which build you have.

--- a/site/src/content/docs/docs/packet-capture.md
+++ b/site/src/content/docs/docs/packet-capture.md
@@ -5,6 +5,12 @@ description: NetsCLI packet capture support, runtime requirements, output format
 
 Packet capture is optional. It needs a build with packet-capture support and a system packet-capture library.
 
+:::caution[No published build has packet capture]
+It is a compile-time feature, and every published artifact — the desktop installers, the standard CLI release assets, and `cargo install netscli` — is built without it. Nothing on this page will work until you install a capture-capable build. See [Packet capture in the install guide](/docs/install/#packet-capture) for the three ways to get one.
+
+Run `netscli doctor` to check which build you have. It works on every build, unlike `netscli pcap --check` below.
+:::
+
 ## Requirements
 
 <div data-netscli-table="row-headers"></div>
@@ -19,7 +25,7 @@ If the desktop build does not include packet capture support, the Packet Capture
 
 ## CLI Capture
 
-Check packet-capture support and list available capture devices:
+List available capture devices. This subcommand only exists on capture-capable builds — on a standard build clap reports an unrecognized subcommand, so use `netscli doctor` if you are checking which build you have:
 
 ```bash
 netscli pcap --check


### PR DESCRIPTION
Step 4 of the review plan, with the packet-capture documentation defects folded in since they are the same subject.

## The site promised packet capture and never explained how to get it

`grep -rniE "NETSCLI_PCAP|--features pcap|-pcap\b" site/src/` returned **zero matches**, while packet capture is referenced across **14 files** including a six-step desktop workflow in `packet-capture.md:68-81`.

It is a compile-time feature and **every published artifact is built without it**:

- `release.yml:212` — "GUI installers intentionally do not pass `--features pcap`"
- `apps/netscli-cli/Cargo.toml:38` — `default = []`, so `cargo install netscli` has none

Every visitor who installed from netscli.com got a build where the documented workflow could not run, with no explanation and no remedy anywhere on the site.

`install.md` now leads with that fact and gives the three routes to a capture-capable build, notes there is **no** desktop installer with capture at all, and lists per-platform runtime requirements. `packet-capture.md` gains a caution pointing at it.

**Also fixes the capability check.** The docs told users to run `netscli pcap --check` — but `args.rs:226` gates the entire `Pcap` subcommand behind `#[cfg(feature = "pcap")]`, so on a standard build clap reports "unrecognized subcommand". `netscli doctor` works on every build and is now the documented check.

## PUBLISHING.md covered one channel of six

It was crates.io only. It now covers all six — crates.io, GitHub Releases, Homebrew, Scoop, winget, AUR — with per channel: what publishes, which of the nine jobs does it, where it deploys, which secret it needs, and the failure modes worth recognising. Plus a troubleshooting table mapping every error the publish scripts can emit to its cause.

The split is now stated explicitly: **`RELEASE.md` is the process, `PUBLISHING.md` is the per-channel reference.**

Two pieces of tribal knowledge are now written down: the Homebrew Formula and Cask share the token `netscli` so a bare `brew install netscli` is ambiguous, and the winget version directories are keyed by directory name so editing one to hold another version's content files a conflicting duplicate.

## RELEASE.md corrections

| Was | Now |
|---|---|
| "five distribution channels" | six |
| "5 jobs, one per channel" — then describes 4 more GUI jobs | nine |
| "13 CLI assets + 4 GUI installers" | **11 and 5** |
| "Action pin policy: referenced by version tag… pinning to SHA is on the radar" | describes the SHA pins landed in #158, and how to bump one by hand |
| Stale v0.2.1 / PR #30 example | pointer to the seven-file version-bump list |
| `brew install --cask netscli` | fully-qualified, unambiguous form |

On the asset counts: I copied "13 + 4" from the existing doc before checking, then verified against the workflow — the matrices yield 11 CLI entries and 4 GUI entries, and the Linux GUI entry emits **both** `.deb` and `.AppImage`, so 5 installers. Both docs corrected.

## Verification

`astro check` 0 errors · site builds, 14 pages · file-size guard passes · the `/docs/install/#packet-capture` anchor resolves in the built output · `NETSCLI_PCAP` now appears on the site for the first time · every count above was read back out of the workflow YAML rather than trusted from the old docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)