### PR TITLE
Reject port 0 on every surface, not just MCP

### DIFF
--- a/crates/netscli-core/src/common.rs
+++ b/crates/netscli-core/src/common.rs
@@ -10,5 +10,7 @@ pub use constants::{
 pub use network::{
     default_ipv4_subnet_string, detect_default_ipv4_addr, detect_default_ipv4_subnet,
 };
-pub use ports::{default_ports, parse_ports, parse_ports_checked, MAX_PORTS_PER_SCAN};
+pub use ports::{
+    default_ports, parse_ports, parse_ports_checked, validate_ports, MAX_PORTS_PER_SCAN,
+};
 pub use terminal::sanitize_for_terminal;

--- a/crates/netscli-core/src/common/ports.rs
+++ b/crates/netscli-core/src/common/ports.rs
@@ -3,6 +3,35 @@ use crate::error::{Error, Result};
 
 pub const MAX_PORTS_PER_SCAN: usize = 4096;
 
+/// Validate an already-parsed port list.
+///
+/// Lives here, next to `MAX_PORTS_PER_SCAN`, so every interface answers the
+/// same way. The CLI and GUI reach it through `parse_ports_checked`; the MCP
+/// server and any library consumer reach it through `Ops`, which validates
+/// whatever it is handed rather than trusting the caller to have parsed it
+/// from a string.
+///
+/// Port 0 is rejected. It is not a connectable TCP port — in a `bind` it
+/// means "pick any free port", and in a `connect` it is meaningless. The MCP
+/// server has always rejected it while the CLI happily reported
+/// "Scanned 1 port (0 open)", which is the divergence this function exists
+/// to remove.
+pub fn validate_ports(ports: &[u16]) -> Result<()> {
+    if ports.contains(&0) {
+        return Err(Error::invalid_input(
+            "port 0 is invalid (not a connectable TCP port)",
+        ));
+    }
+    if ports.len() > MAX_PORTS_PER_SCAN {
+        return Err(Error::invalid_input(format!(
+            "too many ports requested ({} > {})",
+            ports.len(),
+            MAX_PORTS_PER_SCAN
+        )));
+    }
+    Ok(())
+}
+
 /// Lenient parser used by internal defaults — silently drops invalid tokens.
 /// Prefer `parse_ports_checked` for user input so typos are surfaced.
 pub fn parse_ports(input: Option<&str>) -> Option<Vec<u16>> {
@@ -60,25 +89,30 @@ pub fn parse_ports_checked(input: Option<&str>) -> Result<Option<Vec<u16>>> {
     let mut ports = Vec::new();
     for part in raw.split(',') {
         let mut expanded = parse_port_token(part).map_err(|e| {
-            // Wrap the inner parser's per-token message with the caller's
-            // context so consumers see both "why" and "where" in one Error.
-            Error::invalid_input(format!("Invalid port list '{raw}': {e}"))
+            // Add the caller's context so consumers see both "why" and
+            // "where" in one Error. Match on the variant rather than
+            // formatting `e`, whose Display already carries an
+            // "invalid input: " prefix — interpolating it produced
+            // "invalid input: Invalid port list 'x': invalid input: …".
+            let detail = match e {
+                Error::InvalidInput(detail) => detail,
+                other => other.to_string(),
+            };
+            Error::invalid_input(format!("invalid port list '{raw}': {detail}"))
         })?;
         ports.append(&mut expanded);
     }
     if ports.is_empty() {
-        return Err(Error::invalid_input(format!("Invalid port list: {raw}")));
+        return Err(Error::invalid_input(format!("invalid port list: {raw}")));
     }
     // Sort + dedup so downstream scanners don't probe the same port twice.
     ports.sort_unstable();
     ports.dedup();
-    if ports.len() > MAX_PORTS_PER_SCAN {
-        return Err(Error::invalid_input(format!(
-            "too many ports requested ({} > {})",
-            ports.len(),
-            MAX_PORTS_PER_SCAN
-        )));
-    }
+    // Propagate as-is rather than re-wrapping. `validate_ports` already
+    // returns an `Error::InvalidInput` naming the offending rule, and
+    // wrapping it in another one rendered as
+    // "invalid input: Invalid port list '0': invalid input: port 0 is …".
+    validate_ports(&ports)?;
     Ok(Some(ports))
 }
 
@@ -142,7 +176,7 @@ mod tests {
     #[test]
     fn test_parse_ports_checked_invalid() {
         let err = parse_ports_checked(Some("invalid")).unwrap_err();
-        assert!(err.to_string().contains("Invalid port list"));
+        assert!(err.to_string().contains("invalid port list"));
     }
 
     #[test]
@@ -150,7 +184,7 @@ mod tests {
         // Previously this silently returned [80,443]. Typos are now surfaced.
         let err = parse_ports_checked(Some("80,invalid,443")).unwrap_err();
         assert!(
-            err.to_string().contains("Invalid port list"),
+            err.to_string().contains("invalid port list"),
             "expected strict rejection, got: {err}"
         );
     }
@@ -158,13 +192,13 @@ mod tests {
     #[test]
     fn test_parse_ports_checked_rejects_out_of_range() {
         let err = parse_ports_checked(Some("22,99999")).unwrap_err();
-        assert!(err.to_string().contains("Invalid port list"));
+        assert!(err.to_string().contains("invalid port list"));
     }
 
     #[test]
     fn test_parse_ports_checked_rejects_inverted_range() {
         let err = parse_ports_checked(Some("90-80")).unwrap_err();
-        assert!(err.to_string().contains("Invalid port list"));
+        assert!(err.to_string().contains("invalid port list"));
     }
 
     #[test]
@@ -194,6 +228,47 @@ mod tests {
         assert_eq!(
             parse_ports_checked(Some("80,443")).unwrap(),
             Some(vec![80, 443])
+        );
+    }
+
+    // --- port 0 -----------------------------------------------------------
+    // Regression: the CLI accepted `-p 0` and reported "Scanned 1 port
+    // (0 open)" while the MCP server rejected the same input, because each
+    // surface carried its own validation. These pin the single shared rule.
+
+    #[test]
+    fn validate_ports_rejects_port_zero() {
+        assert!(validate_ports(&[0]).is_err());
+        assert!(validate_ports(&[22, 0, 443]).is_err());
+        assert!(validate_ports(&[22, 443]).is_ok());
+    }
+
+    #[test]
+    fn validate_ports_enforces_the_scan_cap() {
+        let ok: Vec<u16> = (1..=MAX_PORTS_PER_SCAN as u16).collect();
+        assert!(validate_ports(&ok).is_ok());
+        let too_many: Vec<u16> = (1..=(MAX_PORTS_PER_SCAN as u16 + 1)).collect();
+        assert!(validate_ports(&too_many).is_err());
+    }
+
+    #[test]
+    fn parse_ports_checked_rejects_port_zero() {
+        for input in ["0", "0,80", "80,0", "0-2"] {
+            let err = parse_ports_checked(Some(input))
+                .unwrap_err()
+                .to_string()
+                .to_lowercase();
+            assert!(err.contains("port 0"), "input {input:?} gave: {err}");
+        }
+    }
+
+    #[test]
+    fn parse_ports_checked_still_accepts_port_one() {
+        // Guard against an off-by-one turning "reject 0" into "reject <2".
+        assert_eq!(parse_ports_checked(Some("1")).unwrap(), Some(vec![1]));
+        assert_eq!(
+            parse_ports_checked(Some("1-3")).unwrap(),
+            Some(vec![1, 2, 3])
         );
     }
 }

--- a/crates/netscli-core/src/lib.rs
+++ b/crates/netscli-core/src/lib.rs
@@ -23,8 +23,8 @@ pub use arp::{ArpEntry, InterfaceInfo, NetworkManager};
 pub use common::{
     default_ipv4_subnet_string, default_ports, detect_default_ipv4_addr,
     detect_default_ipv4_subnet, parse_ports, parse_ports_checked, sanitize_for_terminal,
-    DEFAULT_CONCURRENCY, DEFAULT_DNS_TIMEOUT_MS, DEFAULT_PING_TIMEOUT_MS, DEFAULT_PORTS,
-    DEFAULT_SCAN_TIMEOUT_MS, DEFAULT_SUBNET, MAX_PORTS_PER_SCAN,
+    validate_ports, DEFAULT_CONCURRENCY, DEFAULT_DNS_TIMEOUT_MS, DEFAULT_PING_TIMEOUT_MS,
+    DEFAULT_PORTS, DEFAULT_SCAN_TIMEOUT_MS, DEFAULT_SUBNET, MAX_PORTS_PER_SCAN,
 };
 #[cfg(feature = "db")]
 pub use db::{Database, HostRecord, ScanHistoryRecord};

--- a/crates/netscli-core/src/ops/scan.rs
+++ b/crates/netscli-core/src/ops/scan.rs
@@ -5,9 +5,28 @@ use super::config::Ops;
 use super::validation::parse_limited_ipv4_subnet;
 use crate::error::Result;
 use crate::{
-    default_ipv4_subnet_string, default_ports, DiscoverEngine, Host, InspectEngine, InspectResult,
-    PortResult, PortScanner, SweepEngine, SweepEntry,
+    default_ipv4_subnet_string, default_ports, validate_ports, DiscoverEngine, Host, InspectEngine,
+    InspectResult, PortResult, PortScanner, SweepEngine, SweepEntry,
 };
+
+/// Resolve the caller's port list, validating it.
+///
+/// Every scanning entry point funnels through here so the limits hold no
+/// matter which surface the call arrives on. Previously the 4,096 cap and
+/// the port-0 rejection lived only in the *parsers* — `parse_ports_checked`
+/// for the CLI/GUI and the MCP server's own `normalize_ports` — so the
+/// answers diverged (`netscli scan -p 0` reported "Scanned 1 port" while
+/// the MCP tool rejected the same input), and a library consumer calling
+/// `Ops` with a hand-built `Vec<u16>` bypassed both.
+fn resolve_ports(ports: Option<Vec<u16>>) -> Result<Vec<u16>> {
+    match ports {
+        Some(ports) => {
+            validate_ports(&ports)?;
+            Ok(ports)
+        }
+        None => Ok(default_ports()),
+    }
+}
 
 impl Ops {
     pub async fn discover_ipv4(
@@ -53,7 +72,7 @@ impl Ops {
         progress: Option<Arc<dyn Fn(crate::scan::PortScanProgress) + Send + Sync>>,
     ) -> Result<(IpAddr, Vec<PortResult>)> {
         let ip = self.resolve_host_ip(host).await?;
-        let ports = ports.unwrap_or_else(default_ports);
+        let ports = resolve_ports(ports)?;
         let scanner = PortScanner::new(self.cfg.concurrency);
         let results = scanner
             .scan_host_with_progress(ip, ports, self.cfg.scan_timeout_ms, progress)
@@ -66,7 +85,7 @@ impl Ops {
         host: String,
         ports: Option<Vec<u16>>,
     ) -> Result<InspectResult> {
-        let ports = ports.unwrap_or_else(default_ports);
+        let ports = resolve_ports(ports)?;
         let engine = InspectEngine::new_with_timeouts(
             self.cfg.concurrency,
             self.cfg.ping_timeout_ms,
@@ -95,7 +114,7 @@ impl Ops {
     ) -> Result<(String, Vec<SweepEntry>)> {
         let subnet_str = subnet.unwrap_or_else(default_ipv4_subnet_string);
         let net = parse_limited_ipv4_subnet(&subnet_str)?;
-        let ports = ports.unwrap_or_else(default_ports);
+        let ports = resolve_ports(ports)?;
         let engine = SweepEngine::new_with_timeouts(
             self.cfg.concurrency,
             self.cfg.ping_timeout_ms,

--- a/crates/netscli-core/tests/config_safety.rs
+++ b/crates/netscli-core/tests/config_safety.rs
@@ -58,3 +58,42 @@ async fn ping_scanner_concurrency_zero_returns_result() {
     assert_eq!(res.seq, 1);
     assert!(res.method.is_some());
 }
+
+/// Port validation must not depend on which surface the call arrives on.
+///
+/// Regression: `netscli scan -p 0` reported "Scanned 1 port (0 open)" while
+/// the MCP `scan_ports` tool rejected the identical input, because the CLI
+/// path validated in `parse_ports_checked` and the MCP path validated in its
+/// own `normalize_ports`. `Ops` now validates whatever it is handed, so a
+/// library consumer building a `Vec<u16>` by hand cannot bypass it either.
+#[tokio::test]
+async fn ops_reject_port_zero_regardless_of_caller() {
+    let ops = netscli_core::Ops::default();
+
+    assert!(
+        ops.scan_ports("127.0.0.1", Some(vec![0])).await.is_err(),
+        "scan_ports accepted port 0"
+    );
+    assert!(
+        ops.inspect_host("127.0.0.1".to_string(), Some(vec![0]))
+            .await
+            .is_err(),
+        "inspect_host accepted port 0"
+    );
+    assert!(
+        ops.sweep_ipv4(Some("127.0.0.0/30".to_string()), Some(vec![0]), false)
+            .await
+            .is_err(),
+        "sweep_ipv4 accepted port 0"
+    );
+}
+
+#[tokio::test]
+async fn ops_reject_oversized_port_lists() {
+    let ops = netscli_core::Ops::default();
+    let too_many: Vec<u16> = (1..=(netscli_core::MAX_PORTS_PER_SCAN as u16 + 1)).collect();
+    assert!(
+        ops.scan_ports("127.0.0.1", Some(too_many)).await.is_err(),
+        "scan_ports accepted more than MAX_PORTS_PER_SCAN"
+    );
+}

--- a/crates/netscli-mcp/src/server/schemas.rs
+++ b/crates/netscli-mcp/src/server/schemas.rs
@@ -38,6 +38,14 @@ pub(super) fn validate_subnet(subnet: &str) -> Result<(), RpcError> {
     Ok(())
 }
 
+/// Normalize an MCP-supplied port list into what `Ops` expects.
+///
+/// The *rules* (port 0, the 4,096 cap) are not restated here — they live in
+/// `netscli_core::validate_ports` so every interface answers identically.
+/// This used to carry its own copy, which is how the CLI ended up accepting
+/// `-p 0` while this surface rejected it. Validating early still matters: it
+/// turns a core error into a proper `-32602` before the request reaches a
+/// tool, rather than surfacing as a generic tool failure.
 pub(super) fn normalize_ports(mut ports: Option<Vec<u16>>) -> Result<Option<Vec<u16>>, RpcError> {
     let Some(mut ps) = ports.take() else {
         return Ok(None);
@@ -45,18 +53,9 @@ pub(super) fn normalize_ports(mut ports: Option<Vec<u16>>) -> Result<Option<Vec<
     if ps.is_empty() {
         return Ok(None);
     }
-    if ps.len() > netscli_core::MAX_PORTS_PER_SCAN {
-        return Err(RpcError::InvalidParams(format!(
-            "too many ports requested ({} > {})",
-            ps.len(),
-            netscli_core::MAX_PORTS_PER_SCAN
-        )));
-    }
-    if ps.contains(&0) {
-        return Err(RpcError::InvalidParams("port 0 is invalid".to_string()));
-    }
     ps.sort_unstable();
     ps.dedup();
+    netscli_core::validate_ports(&ps).map_err(|e| RpcError::InvalidParams(e.to_string()))?;
     Ok(Some(ps))
 }
 


### PR DESCRIPTION
Found during the acceptance pass in step 5: the CLI and the MCP server gave **different answers to the same input**.

```
CLI  netscli scan 127.0.0.1 -p 0  ->  exit 0, "Scanned 1 port (0 open)"
MCP  scan_ports ports:[0]         ->  "port 0 is invalid"
```

Port 0 is not a connectable TCP port — in a `bind` it means "pick any free port", in a `connect` it is meaningless. So the CLI was reporting a successful scan of something it cannot have scanned.

## Why it diverged

The rules lived in the **parsers**, one per surface: `parse_ports_checked` for the CLI and GUI, and the MCP server's own `normalize_ports`. Two copies, and only one knew about port 0.

Worse, a library consumer calling `Ops` with a hand-built `Vec<u16>` bypassed both — the same shape as the earlier audit finding that the 4,096-port cap was enforced by the *string parser* rather than by the *operation*.

## The fix

The rule moves to one place, and the operation enforces it:

- **`netscli_core::validate_ports`**, next to `MAX_PORTS_PER_SCAN`, owns both the port-0 rejection and the scan cap.
- **`Ops::scan_ports` / `inspect_host` / `sweep_ipv4`** resolve their port list through a shared `resolve_ports` that validates whatever it is handed. **This is the part that actually closes the hole** — every surface and every library consumer goes through `Ops`.
- `parse_ports_checked` and MCP's `normalize_ports` now **delegate** rather than restating the rules. MCP still validates early so callers get a proper `-32602` rather than a generic tool failure.

## Error messages, while I was here

Wrapping an `Error::InvalidInput` inside another one interpolated its `Display`, which already carries the prefix:

| | |
|---|---|
| before | `invalid input: Invalid port list '0': invalid input: port 0 is invalid` |
| after | `invalid input: port 0 is invalid (not a connectable TCP port)` |
| before | `invalid input: Invalid port list 'hello': invalid input: invalid port: 'hello'` |
| after | `invalid input: invalid port list 'hello': invalid port: 'hello'` |

## Tests

Pin the divergence itself, not just the happy path: `validate_ports` directly, the parser path (`0`, `0,80`, `80,0`, `0-2`), all three `Ops` entry points, and **that port 1 still works** so "reject 0" cannot quietly drift into "reject < 2".

## Verification

`cargo fmt --check` · `clippy --workspace --all-targets -D warnings` · **121 tests, up from 115** · file-size guard · MCP acceptance pass still **25/25** · and the original probe that caught this now shows both surfaces rejecting `0`, `0,80` and `80,0` identically while still accepting `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)