### PR TITLE
Add per-PR site previews on Cloudflare Pages

### DIFF
--- a/.github/workflows/site-preview.yml
+++ b/.github/workflows/site-preview.yml
@@ -1,0 +1,134 @@
+name: Site Preview
+
+# Per-PR preview deploys of site/ to Cloudflare Pages.
+#
+# PRODUCTION IS NOT TOUCHED BY THIS WORKFLOW. netscli.com is served from
+# GitHub Pages via pages.yml, which stays manual-only. This deploys to a
+# separate Cloudflare Pages project and always passes an explicit
+# `--branch=pr-<N>`, which Cloudflare treats as a *preview* deployment.
+# There is no code path here that produces a production deployment.
+#
+# Until the two repository secrets exist this workflow runs and cleanly
+# reports "not configured" rather than failing — see docs/PUBLISHING.md.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/site-preview.yml'
+
+concurrency:
+  group: site-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Deploy preview
+    runs-on: ubuntu-latest
+    # Secrets are not exposed to pull_request runs from forks, so a fork PR
+    # would otherwise fail on an empty token. Skip rather than fail; the
+    # maintainer can deploy a preview from a local branch if needed.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Check configuration
+        id: cfg
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [[ -n "$CF_TOKEN" && -n "$CF_ACCOUNT" ]]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Cloudflare preview not configured — set CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID to enable. See docs/PUBLISHING.md."
+          fi
+
+      - name: npm ci
+        if: steps.cfg.outputs.configured == 'true'
+        run: npm ci
+        working-directory: site
+
+      # NETSCLI_PREVIEW=1 makes the build emit `robots: noindex, nofollow`
+      # and suppress the Web Analytics beacon. A preview is still a
+      # production Astro build, so without it every PR deploy would report
+      # into netscli.com's real analytics property and be crawlable.
+      - name: Build site (preview mode)
+        if: steps.cfg.outputs.configured == 'true'
+        run: npm run build
+        working-directory: site
+        env:
+          NETSCLI_PREVIEW: '1'
+
+      - name: Verify the preview build is not indexable
+        if: steps.cfg.outputs.configured == 'true'
+        working-directory: site
+        run: |
+          set -euo pipefail
+          missing=0
+          while IFS= read -r f; do
+            grep -q 'name="robots" content="noindex' "$f" || { echo "not noindexed: $f"; missing=1; }
+          done < <(find dist -name '*.html')
+          if [[ "$missing" -ne 0 ]]; then
+            echo "::error::Preview build produced indexable pages — refusing to deploy."
+            exit 1
+          fi
+          if grep -rq "cloudflareinsights" dist/ 2>/dev/null; then
+            echo "::error::Preview build still loads the analytics beacon — refusing to deploy."
+            exit 1
+          fi
+          echo "All $(find dist -name '*.html' | wc -l) pages are noindex, and no analytics beacon is present."
+
+      - name: Deploy to Cloudflare Pages (preview)
+        if: steps.cfg.outputs.configured == 'true'
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: site
+        run: |
+          set -euo pipefail
+          # --branch is what makes this a preview rather than a production
+          # deployment. Never pass the project's production branch here.
+          npx --yes wrangler@4 pages deploy dist \
+            --project-name=netscli-site-preview \
+            --branch="pr-${{ github.event.pull_request.number }}" \
+            --commit-dirty=true \
+            | tee deploy.log
+          url=$(grep -oE 'https://[a-z0-9.-]+\.pages\.dev' deploy.log | tail -1)
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment the preview URL
+        if: steps.cfg.outputs.configured == 'true' && steps.deploy.outputs.url != ''
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+        with:
+          script: |
+            const url = process.env.PREVIEW_URL;
+            const marker = '<!-- netscli-site-preview -->';
+            const body = `${marker}\n**Site preview:** ${url}\n\n` +
+              `Built from ${context.sha.slice(0, 7)} with \`NETSCLI_PREVIEW=1\` — ` +
+              `noindex, and analytics disabled so it does not report into netscli.com's numbers.\n\n` +
+              `Production is unaffected: netscli.com is served from GitHub Pages via \`pages.yml\`, which is manual-only.`;
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo, issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: context.issue.number, body });
+            }

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -196,6 +196,61 @@ managers rely on their own hash checks instead.
 downloads and verifies against a pinned SHA256. Bumping the SDK version
 means re-pinning that digest.
 
+## Site previews (Cloudflare Pages)
+
+**Production is not involved.** netscli.com is served from GitHub Pages via
+`pages.yml`, which stays manual-only. `site-preview.yml` deploys to a
+separate Cloudflare Pages project and always passes an explicit
+`--branch=pr-<N>`, which Cloudflare treats as a preview deployment. There is
+no code path in that workflow that produces a production deploy.
+
+### Enabling it
+
+The workflow runs today and reports "not configured" until two repository
+secrets exist. Nothing fails in the meantime.
+
+1. **Create the Pages project** (one-off, direct-upload mode — do *not*
+   connect it to Git, or Cloudflare will start building on its own and you
+   will have two things deploying the site):
+
+   ```bash
+   npx wrangler@4 pages project create netscli-site-preview \
+     --production-branch=unused-production-branch
+   ```
+
+   The production branch is deliberately a name no PR will ever use, so the
+   project has no reachable production deployment.
+
+2. **Add two repository secrets** under Settings → Secrets and variables →
+   Actions:
+
+   | Secret | Where from |
+   | --- | --- |
+   | `CLOUDFLARE_API_TOKEN` | Cloudflare dashboard → My Profile → API Tokens → Create Token. Template "Edit Cloudflare Workers", or a custom token with **Account → Cloudflare Pages → Edit**. Scope it to the one account. |
+   | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare dashboard → Workers & Pages → Account ID in the right-hand pane |
+
+3. Open a PR touching `site/**`. The workflow comments the preview URL and
+   updates that same comment on later pushes.
+
+### What a preview build changes
+
+Preview builds set `NETSCLI_PREVIEW=1`, which does two things that matter:
+
+- **`robots: noindex, nofollow` on every page.** Emitted by
+  `src/layouts/Page.astro` for the landing/changelog/404 pages *and* by the
+  `head` entry in `astro.config.mjs` for the Starlight docs pages — those use
+  Starlight's own layout, so the first mechanism alone leaves 11 of 14 pages
+  crawlable.
+- **The Cloudflare Web Analytics beacon is suppressed.** A preview is still a
+  production Astro build (`import.meta.env.PROD` is true), so without this
+  every PR deploy would report into netscli.com's real analytics property.
+
+The workflow **verifies both before deploying** and fails the job rather than
+publishing an indexable or analytics-reporting preview.
+
+Neither affects a normal build: production still emits the beacon, and only
+the 404 carries `noindex`.
+
 ## Homebrew
 
 Two artifacts in one tap, `fstubner/homebrew-tap`:

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -8,6 +8,14 @@ export default defineConfig({
   site: 'https://netscli.com',
   integrations: [
     starlight({
+      // Starlight renders the docs pages with its own layout, not
+      // src/layouts/Page.astro, so the noindex that layout emits for a
+      // preview build does not reach them. Inject it here too, or a
+      // preview deploy leaves 11 of 14 pages crawlable.
+      head:
+        process.env.NETSCLI_PREVIEW === '1'
+          ? [{ tag: 'meta', attrs: { name: 'robots', content: 'noindex, nofollow' } }]
+          : [],
       title: 'NetsCLI docs',
       description:
         'Technical documentation for NetsCLI, a Rust-based network scanner and diagnostics toolkit with a desktop app, terminal UI, CLI, MCP server, and shared core library.',

--- a/site/src/layouts/Page.astro
+++ b/site/src/layouts/Page.astro
@@ -9,6 +9,10 @@ interface Props {
   ogDescription?: string;
   includeFaqSchema?: boolean;
   bodyClass?: string;
+  /** Emit `robots: noindex, nofollow`. Set on pages that should never be
+   *  indexed regardless of build (currently the 404). Preview builds set
+   *  it globally via NETSCLI_PREVIEW — see `isPreviewBuild` below. */
+  noindex?: boolean;
 }
 
 const {
@@ -18,6 +22,7 @@ const {
   ogDescription,
   includeFaqSchema = true,
   bodyClass,
+  noindex = false,
 } = Astro.props;
 const { meta, analytics, faq, version } = site;
 const canonicalUrl =
@@ -61,7 +66,16 @@ const graph = includeFaqSchema ? [softwareApp, faqPage] : [softwareApp];
 const ldJson = JSON.stringify({ '@context': 'https://schema.org', '@graph': graph }, null, 2);
 
 const ogDesc = ogDescription ?? meta.ogDescription ?? description;
-const shouldLoadAnalytics = import.meta.env.PROD && Boolean(analytics.cloudflareToken);
+
+// A per-PR preview deploy is still a production Astro build
+// (import.meta.env.PROD is true), so without an explicit signal it would
+// (a) report its traffic to the real Web Analytics property, polluting
+// netscli.com's numbers with CI, and (b) be crawlable. NETSCLI_PREVIEW is
+// set by .github/workflows/site-preview.yml and turns both off.
+const isPreviewBuild = process.env.NETSCLI_PREVIEW === '1';
+const shouldLoadAnalytics =
+  import.meta.env.PROD && !isPreviewBuild && Boolean(analytics.cloudflareToken);
+const shouldNoindex = noindex || isPreviewBuild;
 ---
 
 <!doctype html>
@@ -84,6 +98,7 @@ const shouldLoadAnalytics = import.meta.env.PROD && Boolean(analytics.cloudflare
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={ogDesc} />
 <meta name="twitter:image" content={meta.ogImage} />
+{shouldNoindex && <meta name="robots" content="noindex, nofollow" />}
 <link rel="canonical" href={canonicalUrl} />
 <link rel="icon" type="image/svg+xml" href={meta.faviconPath} />
 <link rel="apple-touch-icon" href={meta.faviconPath} />

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -10,6 +10,7 @@ import Footer from '../components/Footer.astro';
   canonicalPath="/404.html"
   includeFaqSchema={false}
   bodyClass="not-found-page"
+  noindex
 >
   <Nav />
   <main class="not-found" aria-labelledby="not-found-title">


### PR DESCRIPTION
Step 6. Reviewing a site change currently means building locally or deploying to production. This gives each PR a preview URL.

## Production is not involved

netscli.com stays on **GitHub Pages** via `pages.yml`, which remains manual-only after the accidental-deploy incident. This uses a **separate** Cloudflare Pages project and always passes an explicit `--branch=pr-<N>`, which Cloudflare treats as a preview. There is no code path in this workflow that produces a production deployment.

## Two non-obvious hazards, both handled

A preview deploy is still a **production Astro build** — `import.meta.env.PROD` is `true`. Left alone that means:

1. **The Web Analytics beacon fires.** Every PR deploy would report into netscli.com's real analytics property, quietly polluting the numbers with CI traffic.
2. **The preview is crawlable.**

`NETSCLI_PREVIEW=1` turns both off, and the workflow **verifies both before deploying** rather than trusting the build — it fails the job if any page lacks the robots meta or if the beacon is still present.

That guard earned its place immediately. My first implementation only covered `src/layouts/Page.astro` — the landing, changelog and 404 pages. The docs are rendered by **Starlight's own layout**, so 11 of 14 pages were still indexable:

```
take 1:  noindex: 3 / 14 pages
take 2:  noindex: 14 / 14 pages     (after adding Starlight's `head` config)
```

## Also fixes B-25

The 404 was indexable and self-canonicalised. The `noindex` prop the preview mode needed made it a one-line fix, so it is set explicitly there rather than only in previews.

## Enabling it

The workflow **runs today and reports "not configured"** until two secrets exist — it does not fail every PR in the meantime. Fork PRs are skipped, since secrets aren't exposed to them and the job would fail on an empty token.

Setup is one command plus two secrets, documented in `docs/PUBLISHING.md`:

```bash
npx wrangler@4 pages project create netscli-site-preview \
  --production-branch=unused-production-branch
```

The production branch is deliberately a name no PR will ever use, so the project has no reachable production deployment. Create it in **direct-upload mode — do not connect it to Git**, or Cloudflare will start building independently and you'll have two things deploying the site.

Then `CLOUDFLARE_API_TOKEN` (Account → Cloudflare Pages → Edit) and `CLOUDFLARE_ACCOUNT_ID`.

## Verification

| | noindex | analytics beacon |
|---|---|---|
| preview build | **14 / 14** | suppressed |
| normal build | 1 / 14 (the 404) | present, as production needs |

Plus `astro check` 0 errors and the file-size guard.

I could not create the Cloudflare project or secrets myself — those need your account — so the deploy step is unexercised. Everything up to and including the pre-deploy verification is tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)