### PR TITLE
Restore the winget GUI 0.2.4 reference manifests

### DIFF
--- a/packaging/winget/gui/0.2.4/fstubner.netscli.gui.installer.yaml
+++ b/packaging/winget/gui/0.2.4/fstubner.netscli.gui.installer.yaml
@@ -1,0 +1,19 @@
+# Winget installer manifest for the netscli desktop app.
+#
+# Distinct PackageIdentifier (`fstubner.netscli.gui`) from the CLI
+# (`fstubner.netscli`) so users can install one without the other:
+#   winget install netscli       -> CLI
+#   winget install netscli-gui   -> GUI
+# Moniker resolves to the chosen identifier as long as it's unique in
+# the catalog.
+
+PackageIdentifier: fstubner.netscli.gui
+PackageVersion: 0.2.4
+Installers:
+  - Architecture: x64
+    InstallerType: wix
+    InstallerUrl: https://github.com/fstubner/netscli/releases/download/v0.2.4/netscli-gui-windows-x86_64.msi
+    InstallerSha256: BDEF02B05D636627057DB8B395F9D38D76D9F884C634310D17F078D1EC86788D
+    Scope: user
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/packaging/winget/gui/0.2.4/fstubner.netscli.gui.locale.en-US.yaml
+++ b/packaging/winget/gui/0.2.4/fstubner.netscli.gui.locale.en-US.yaml
@@ -1,0 +1,31 @@
+PackageIdentifier: fstubner.netscli.gui
+PackageVersion: 0.2.4
+PackageLocale: en-US
+Publisher: Felix Stubner
+PublisherUrl: https://github.com/fstubner
+PublisherSupportUrl: https://github.com/fstubner/netscli/issues
+Author: Felix Stubner
+PackageName: NetsCLI Desktop
+PackageUrl: https://netscli.com
+License: MIT
+LicenseUrl: https://github.com/fstubner/netscli/blob/main/LICENSE
+Copyright: Copyright (c) Felix Stubner
+ShortDescription: Network scanner desktop app — discover hosts, scan ports, look up DNS records, inspect ARP table.
+Description: |
+  NetsCLI Desktop is the GUI surface of netscli — a network scanner
+  with CLI, terminal UI, desktop app, and MCP server interfaces all
+  backed by the same Rust core. The desktop app provides a Tauri 2 +
+  React window for visual host discovery, port scanning, DNS lookups,
+  and ARP table inspection without opening a terminal.
+Moniker: netscli-gui
+Tags:
+  - network
+  - scanner
+  - port-scanner
+  - dns
+  - arp
+  - tauri
+  - rust
+  - desktop
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/packaging/winget/gui/0.2.4/fstubner.netscli.gui.yaml
+++ b/packaging/winget/gui/0.2.4/fstubner.netscli.gui.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: fstubner.netscli.gui
+PackageVersion: 0.2.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
`e20b0ec` deleted `packaging/winget/gui/0.2.4/` — the same commit that overwrote the 0.2.6 manifests with 0.3.0 content, restored separately in #158. Both look like collateral from the v0.3.0 baseline landing rather than deliberate removals: 0.2.6 and 0.3.0 are still tracked, so dropping 0.2.4 alone leaves the reference set with a hole in the middle.

Restored verbatim from `30f6511`, the commit that introduced them.

## Verified, not assumed

- All three files declare `PackageVersion: 0.2.4`
- The `InstallerUrl` points at `v0.2.4`, and that release asset still resolves (**HTTP 200**)
- The recorded `InstallerSha256` matches the actual bytes:

```
manifest claims: bdef02b05d636627057db8b395f9d38d76d9f884c634310d17f078d1ec86788d
actual bytes  : bdef02b05d636627057db8b395f9d38d76d9f884c634310d17f078d1ec86788d
=> MATCH
```

That last check mattered — restoring a manifest with a stale or wrong hash would have been worse than leaving the gap.

## Why keep these at all

They are reference copies; the authoritative manifests live in `microsoft/winget-pkgs`. Per `packaging/README.md`, this tree keeps one directory per submitted version so a generated PR can be diffed against what was actually shipped. That only works if the history is complete.

Found while verifying that #104–107 were safe to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)