### PR TITLE
Make the MCP server handle requests concurrently (A-01, C-09)

### DIFF
--- a/crates/netscli-mcp/src/server.rs
+++ b/crates/netscli-mcp/src/server.rs
@@ -7,10 +7,22 @@ mod protocol;
 mod schemas;
 mod tools;
 
+use std::sync::{Arc, Mutex};
+
 use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::sync::{mpsc, Semaphore};
 
 use dispatch::{handle_request, ServerState};
 use protocol::{JsonRpcRequest, JsonRpcResponse};
+
+/// Ceiling on requests executing at once.
+///
+/// Each in-flight request can itself fan out to `Ops`-level concurrency
+/// (which clamps to 1024 sockets), so this bounds how many of those fans a
+/// misbehaving or enthusiastic client can stack up. Requests beyond the
+/// limit queue rather than being rejected — ordering of *responses* is not
+/// guaranteed by JSON-RPC, but every request still gets answered.
+const MAX_CONCURRENT_REQUESTS: usize = 16;
 
 pub use tools::tools_list;
 
@@ -48,9 +60,41 @@ pub async fn run_server() -> anyhow::Result<()> {
     let stdin = io::stdin();
     let stdout = io::stdout();
     let mut reader = BufReader::new(stdin).lines();
-    let mut writer = BufWriter::new(stdout);
-    let mut state = ServerState::default();
-    let mut requests_handled: u64 = 0;
+    let state = Arc::new(Mutex::new(ServerState::default()));
+    let limiter = Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS));
+
+    // Responses are funnelled through one channel to a single writer task.
+    // Two concurrent handlers must never interleave bytes on stdout, and a
+    // dedicated writer is simpler to reason about than sharing a locked
+    // writer between tasks.
+    let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+    let writer_task = tokio::spawn(async move {
+        let mut writer = BufWriter::new(stdout);
+        let mut written: u64 = 0;
+        while let Some(line) = rx.recv().await {
+            if writer.write_all(line.as_bytes()).await.is_err()
+                || writer.write_all(b"\n").await.is_err()
+                || writer.flush().await.is_err()
+            {
+                // stdout is gone (client detached); nothing useful is left
+                // to do on this transport.
+                break;
+            }
+            written += 1;
+        }
+        written
+    });
+
+    // Serialising here rather than in each handler keeps the error path off
+    // the spawned tasks, which have no way to propagate a `?`.
+    let send = |tx: &mpsc::UnboundedSender<String>, response: &JsonRpcResponse| {
+        match serde_json::to_string(response) {
+            Ok(s) => {
+                let _ = tx.send(s);
+            }
+            Err(e) => tracing::error!(error = %e, "failed to serialize response"),
+        }
+    };
 
     while let Some(line) = reader.next_line().await? {
         if line.trim().is_empty() {
@@ -61,31 +105,51 @@ pub async fn run_server() -> anyhow::Result<()> {
             Ok(req) => req,
             Err(e) => {
                 tracing::warn!(error = %e, "json parse error");
-                let response = JsonRpcResponse::parse_error();
-                let response_str = serde_json::to_string(&response)?;
-                writer.write_all(response_str.as_bytes()).await?;
-                writer.write_all(b"\n").await?;
-                writer.flush().await?;
+                send(&tx, &JsonRpcResponse::parse_error());
                 continue;
             }
         };
 
-        // Notifications (no id) must not get a response.
+        // A *missing* id makes this a notification, which must not get a
+        // response. An explicit `"id": null` is a request and is handled
+        // below like any other.
         if request.id.is_none() {
             tracing::debug!(method = %request.method, "notification");
             if request.method == "notifications/initialized" {
-                state.initialized = true;
+                if let Ok(mut guard) = state.lock() {
+                    guard.initialized = true;
+                }
             }
             continue;
         }
 
-        let response = handle_request(&mut state, request).await;
-        let response_str = serde_json::to_string(&response)?;
-        writer.write_all(response_str.as_bytes()).await?;
-        writer.write_all(b"\n").await?;
-        writer.flush().await?;
-        requests_handled += 1;
+        // Read the next line immediately instead of awaiting the handler.
+        // This is the whole point: a slow `sweep_network` no longer blocks
+        // the requests queued behind it, including its own cancellation.
+        let state = Arc::clone(&state);
+        let limiter = Arc::clone(&limiter);
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            // `acquire_owned` on an Arc'd semaphore that is never closed
+            // only fails if the semaphore is closed, so this cannot error
+            // in practice; drop the permit-holding task if it ever does.
+            let Ok(_permit) = limiter.acquire_owned().await else {
+                return;
+            };
+            let response = handle_request(state, request).await;
+            match serde_json::to_string(&response) {
+                Ok(s) => {
+                    let _ = tx.send(s);
+                }
+                Err(e) => tracing::error!(error = %e, "failed to serialize response"),
+            }
+        });
     }
+
+    // Dropping the last sender ends the writer loop; the clones held by
+    // still-running handlers keep it alive until they finish.
+    drop(tx);
+    let requests_handled = writer_task.await.unwrap_or(0);
 
     tracing::info!(requests_handled, "netscli MCP server shutting down");
     Ok(())

--- a/crates/netscli-mcp/src/server/dispatch.rs
+++ b/crates/netscli-mcp/src/server/dispatch.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use serde::Deserialize;
 use serde_json::{json, Value};
 
@@ -29,11 +31,23 @@ pub(super) struct ServerState {
     pub(super) next_pcap_job_id: u64,
 }
 
-pub(super) async fn handle_request(
-    state: &mut ServerState,
-    req: JsonRpcRequest,
-) -> JsonRpcResponse {
-    let id = req.id.clone();
+/// Shared server state.
+///
+/// A `std::sync::Mutex` is deliberate: every critical section below is
+/// synchronous and short (a bool read, a job-map insert). Nothing holds this
+/// guard across an `.await`, which is what keeps the handler futures `Send`
+/// and keeps slow tool calls — the whole reason this is concurrent — outside
+/// the lock entirely.
+pub(super) type SharedState = Arc<Mutex<ServerState>>;
+
+fn lock(state: &SharedState) -> Result<std::sync::MutexGuard<'_, ServerState>, RpcError> {
+    state
+        .lock()
+        .map_err(|_| RpcError::Internal("server state lock poisoned".to_string()))
+}
+
+pub(super) async fn handle_request(state: SharedState, req: JsonRpcRequest) -> JsonRpcResponse {
+    let id = req.id.clone().flatten();
     let method = req.method.clone();
     // For tools/call the caller-visible operation is the tool name; surface it
     // so log consumers can grep a single tool without regex-parsing params.
@@ -55,7 +69,7 @@ pub(super) async fn handle_request(
         id,
     };
 
-    match handle_request_inner(state, &req).await {
+    match handle_request_inner(&state, &req).await {
         Ok(val) => {
             response.result = Some(val);
         }
@@ -89,7 +103,7 @@ pub(super) async fn handle_request(
 }
 
 async fn handle_request_inner(
-    state: &mut ServerState,
+    state: &SharedState,
     req: &JsonRpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
     if req.jsonrpc != "2.0" {
@@ -99,8 +113,9 @@ async fn handle_request_inner(
         )));
     }
 
-    // Enforce MCP init lifecycle for requests.
-    if !state.initialized && req.method != "initialize" && req.method != "tools/list" {
+    // Enforce MCP init lifecycle for requests. Read and release — the guard
+    // must not survive into the tool dispatch below.
+    if !lock(state)?.initialized && req.method != "initialize" && req.method != "tools/list" {
         return Err(RpcError::NotInitialized);
     }
 
@@ -113,7 +128,7 @@ async fn handle_request_inner(
             let protocol = p
                 .protocol_version
                 .unwrap_or_else(|| "2024-11-05".to_string());
-            state.initialized = true;
+            lock(state)?.initialized = true;
             Ok(json!({
                 "protocolVersion": protocol,
                 "capabilities": { "tools": {} },
@@ -128,11 +143,11 @@ async fn handle_request_inner(
         // `jobs.rs`), so they stay separate from `dispatch_tool`'s
         // stateless tool table below.
         #[cfg(feature = "pcap")]
-        "start_pcap_capture" => start_pcap_capture_job(state, params).await,
+        "start_pcap_capture" => start_pcap_capture_job(&mut lock(state)?, params),
         #[cfg(feature = "pcap")]
-        "get_pcap_capture_status" => pcap_job_status(state, params),
+        "get_pcap_capture_status" => pcap_job_status(&lock(state)?, params),
         #[cfg(feature = "pcap")]
-        "get_pcap_capture_result" => pcap_job_result(state, params),
+        "get_pcap_capture_result" => pcap_job_result(&lock(state)?, params),
 
         // Every other backwards-compatible direct method name maps 1:1 onto
         // a `tools/call` tool of the same name; share that table instead of
@@ -198,7 +213,7 @@ async fn dispatch_tool(name: &str, params: Value) -> Result<Value, RpcError> {
 }
 
 async fn handle_tools_call(
-    state: &mut ServerState,
+    state: &SharedState,
     params: Value,
 ) -> Result<serde_json::Value, RpcError> {
     #[cfg(not(feature = "pcap"))]
@@ -222,15 +237,16 @@ async fn handle_tools_call(
     {
         match p.name.as_str() {
             "start_pcap_capture" => {
-                return Ok(mcp_tool_result_text(
-                    start_pcap_capture_job(state, args).await?,
-                ))
+                return Ok(mcp_tool_result_text(start_pcap_capture_job(
+                    &mut lock(state)?,
+                    args,
+                )?))
             }
             "get_pcap_capture_status" => {
-                return Ok(mcp_tool_result_text(pcap_job_status(state, args)?))
+                return Ok(mcp_tool_result_text(pcap_job_status(&lock(state)?, args)?))
             }
             "get_pcap_capture_result" => {
-                return Ok(mcp_tool_result_text(pcap_job_result(state, args)?))
+                return Ok(mcp_tool_result_text(pcap_job_result(&lock(state)?, args)?))
             }
             _ => {}
         }

--- a/crates/netscli-mcp/src/server/dispatch.rs
+++ b/crates/netscli-mcp/src/server/dispatch.rs
@@ -142,12 +142,25 @@ async fn handle_request_inner(
         // lifecycle. These are stateful (server-held job handles, in
         // `jobs.rs`), so they stay separate from `dispatch_tool`'s
         // stateless tool table below.
+        // The guard is bound to a local rather than inlined as
+        // `&mut lock(state)?`: a guard built inside the argument list is a
+        // temporary, and the reborrow through it does not coerce to
+        // `&mut ServerState` there.
         #[cfg(feature = "pcap")]
-        "start_pcap_capture" => start_pcap_capture_job(&mut lock(state)?, params),
+        "start_pcap_capture" => {
+            let mut guard = lock(state)?;
+            start_pcap_capture_job(&mut guard, params)
+        }
         #[cfg(feature = "pcap")]
-        "get_pcap_capture_status" => pcap_job_status(&lock(state)?, params),
+        "get_pcap_capture_status" => {
+            let guard = lock(state)?;
+            pcap_job_status(&guard, params)
+        }
         #[cfg(feature = "pcap")]
-        "get_pcap_capture_result" => pcap_job_result(&lock(state)?, params),
+        "get_pcap_capture_result" => {
+            let guard = lock(state)?;
+            pcap_job_result(&guard, params)
+        }
 
         // Every other backwards-compatible direct method name maps 1:1 onto
         // a `tools/call` tool of the same name; share that table instead of
@@ -237,16 +250,18 @@ async fn handle_tools_call(
     {
         match p.name.as_str() {
             "start_pcap_capture" => {
+                let mut guard = lock(state)?;
                 return Ok(mcp_tool_result_text(start_pcap_capture_job(
-                    &mut lock(state)?,
-                    args,
-                )?))
+                    &mut guard, args,
+                )?));
             }
             "get_pcap_capture_status" => {
-                return Ok(mcp_tool_result_text(pcap_job_status(&lock(state)?, args)?))
+                let guard = lock(state)?;
+                return Ok(mcp_tool_result_text(pcap_job_status(&guard, args)?));
             }
             "get_pcap_capture_result" => {
-                return Ok(mcp_tool_result_text(pcap_job_result(&lock(state)?, args)?))
+                let guard = lock(state)?;
+                return Ok(mcp_tool_result_text(pcap_job_result(&guard, args)?));
             }
             _ => {}
         }

--- a/crates/netscli-mcp/src/server/dispatch/tests.rs
+++ b/crates/netscli-mcp/src/server/dispatch/tests.rs
@@ -8,22 +8,26 @@ fn request(method: &str, params: Option<Value>, id: i64) -> JsonRpcRequest {
         jsonrpc: "2.0".to_string(),
         method: method.to_string(),
         params,
-        id: Some(json!(id)),
+        id: Some(Some(json!(id))),
     }
 }
 
-async fn initialized_state() -> ServerState {
-    let mut state = ServerState::default();
-    let resp = handle_request(&mut state, request("initialize", Some(json!({})), 0)).await;
+fn new_state() -> SharedState {
+    Arc::new(Mutex::new(ServerState::default()))
+}
+
+async fn initialized_state() -> SharedState {
+    let state = new_state();
+    let resp = handle_request(state.clone(), request("initialize", Some(json!({})), 0)).await;
     assert!(resp.error.is_none(), "initialize failed: {:?}", resp.error);
     state
 }
 
 #[tokio::test]
 async fn methods_before_initialize_are_rejected() {
-    let mut state = ServerState::default();
+    let state = new_state();
     let resp = handle_request(
-        &mut state,
+        state.clone(),
         request(
             "tools/call",
             Some(json!({"name": "list_network_interfaces", "arguments": {}})),
@@ -37,20 +41,20 @@ async fn methods_before_initialize_are_rejected() {
 
 #[tokio::test]
 async fn tools_list_and_initialize_are_allowed_before_initialize() {
-    let mut state = ServerState::default();
-    let resp = handle_request(&mut state, request("tools/list", None, 1)).await;
+    let state = new_state();
+    let resp = handle_request(state.clone(), request("tools/list", None, 1)).await;
     assert!(resp.error.is_none(), "tools/list failed: {:?}", resp.error);
 
-    let resp = handle_request(&mut state, request("initialize", Some(json!({})), 2)).await;
+    let resp = handle_request(state.clone(), request("initialize", Some(json!({})), 2)).await;
     assert!(resp.error.is_none(), "initialize failed: {:?}", resp.error);
 }
 
 #[tokio::test]
 async fn invalid_params_return_invalid_params_code() {
-    let mut state = initialized_state().await;
+    let state = initialized_state().await;
     // scan_ports requires "host"; omit it to trigger a deserialize failure.
     let resp = handle_request(
-        &mut state,
+        state.clone(),
         request(
             "tools/call",
             Some(json!({"name": "scan_ports", "arguments": {}})),
@@ -64,9 +68,9 @@ async fn invalid_params_return_invalid_params_code() {
 
 #[tokio::test]
 async fn unknown_tool_name_is_invalid_params() {
-    let mut state = initialized_state().await;
+    let state = initialized_state().await;
     let resp = handle_request(
-        &mut state,
+        state.clone(),
         request(
             "tools/call",
             Some(json!({"name": "does_not_exist", "arguments": {}})),
@@ -85,17 +89,17 @@ async fn unknown_tool_name_is_invalid_params() {
 
 #[tokio::test]
 async fn unknown_method_is_method_not_found() {
-    let mut state = initialized_state().await;
-    let resp = handle_request(&mut state, request("does_not_exist", None, 5)).await;
+    let state = initialized_state().await;
+    let resp = handle_request(state.clone(), request("does_not_exist", None, 5)).await;
     let err = resp.error.expect("expected method-not-found error");
     assert_eq!(err.code, -32601);
 }
 
 #[tokio::test]
 async fn oversized_subnet_is_rejected() {
-    let mut state = initialized_state().await;
+    let state = initialized_state().await;
     let resp = handle_request(
-        &mut state,
+        state.clone(),
         request(
             "tools/call",
             Some(json!({"name": "discover_network", "arguments": {"subnet": "10.0.0.0/8"}})),
@@ -114,10 +118,10 @@ async fn oversized_subnet_is_rejected() {
 
 #[tokio::test]
 async fn too_many_ports_is_rejected() {
-    let mut state = initialized_state().await;
+    let state = initialized_state().await;
     let ports: Vec<u16> = (1u16..=(netscli_core::MAX_PORTS_PER_SCAN as u16 + 1)).collect();
     let resp = handle_request(
-        &mut state,
+        state.clone(),
         request(
             "tools/call",
             Some(json!({"name": "scan_ports", "arguments": {"host": "127.0.0.1", "ports": ports}})),
@@ -134,20 +138,76 @@ async fn too_many_ports_is_rejected() {
     );
 }
 
+// A-01 regression. Before this, `run_server` awaited each handler inline, so
+// a slow tool call held up every request behind it — measured at 9.3 s for a
+// `tools/list` queued behind one `ping_host`.
+//
+// Asserting on wall-clock would be flaky on a loaded CI box, so instead this
+// pins the property that made the fix possible: the handler future is `Send`
+// and `'static`, which is exactly what lets `run_server` spawn it instead of
+// awaiting it. A regression to `&mut ServerState` fails to compile here.
+#[tokio::test]
+async fn handlers_can_run_concurrently_on_shared_state() {
+    let state = initialized_state().await;
+
+    let handles: Vec<_> = (0..8)
+        .map(|i| {
+            let state = state.clone();
+            tokio::spawn(async move { handle_request(state, request("tools/list", None, i)).await })
+        })
+        .collect();
+
+    for handle in handles {
+        let resp = handle.await.expect("handler task panicked");
+        assert!(resp.error.is_none(), "tools/list failed: {:?}", resp.error);
+    }
+}
+
+// C-09 regression: an explicit `"id": null` is a *request* under JSON-RPC 2.0
+// and must be answered. It was previously indistinguishable from an absent id
+// and silently dropped, leaving the caller waiting forever.
+#[tokio::test]
+async fn explicit_null_id_is_answered() {
+    let state = initialized_state().await;
+    let req = JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        method: "tools/list".to_string(),
+        params: None,
+        id: Some(Some(Value::Null)),
+    };
+    assert!(req.id.is_some(), "explicit null id must not read as absent");
+
+    let resp = handle_request(state, req).await;
+    assert!(resp.error.is_none(), "tools/list failed: {:?}", resp.error);
+    assert_eq!(resp.id, Some(Value::Null), "response must echo the null id");
+}
+
+// A missing `jsonrpc` field is an Invalid Request (-32600), not a Parse Error
+// (-32700) — the message is well-formed JSON, it just isn't valid JSON-RPC.
+#[tokio::test]
+async fn missing_jsonrpc_version_is_invalid_request() {
+    let state = initialized_state().await;
+    let req: JsonRpcRequest =
+        serde_json::from_str(r#"{"method":"tools/list","id":1}"#).expect("should still parse");
+    let resp = handle_request(state, req).await;
+    let err = resp.error.expect("expected invalid-request error");
+    assert_eq!(err.code, -32600);
+}
+
 // The pcap job tools only exist in `--features pcap` builds; verify they're
 // unreachable (not a silent no-op) when the feature is off, since they share
 // `dispatch_tool`'s catch-all with every other unknown tool name.
 #[cfg(not(feature = "pcap"))]
 #[tokio::test]
 async fn pcap_job_tools_are_unknown_without_pcap_feature() {
-    let mut state = initialized_state().await;
+    let state = initialized_state().await;
     for tool in [
         "start_pcap_capture",
         "get_pcap_capture_status",
         "get_pcap_capture_result",
     ] {
         let resp = handle_request(
-            &mut state,
+            state.clone(),
             request(
                 "tools/call",
                 Some(json!({"name": tool, "arguments": {}})),
@@ -165,10 +225,10 @@ async fn pcap_job_tools_are_unknown_without_pcap_feature() {
 #[cfg(feature = "pcap")]
 #[tokio::test]
 async fn pcap_job_lifecycle_start_status_result() {
-    let mut state = initialized_state().await;
+    let state = initialized_state().await;
 
     let start = handle_request(
-        &mut state,
+        state.clone(),
         request(
             "tools/call",
             Some(
@@ -182,7 +242,7 @@ async fn pcap_job_lifecycle_start_status_result() {
     let job_id = extract_job_id(&start).expect("start response should include a jobId");
 
     let status = handle_request(
-        &mut state,
+        state.clone(),
         request(
             "tools/call",
             Some(json!({"name": "get_pcap_capture_status", "arguments": {"jobId": job_id}})),
@@ -193,7 +253,7 @@ async fn pcap_job_lifecycle_start_status_result() {
     assert!(status.error.is_none(), "status failed: {:?}", status.error);
 
     let result = handle_request(
-        &mut state,
+        state.clone(),
         request(
             "tools/call",
             Some(json!({"name": "get_pcap_capture_result", "arguments": {"jobId": job_id}})),
@@ -207,9 +267,9 @@ async fn pcap_job_lifecycle_start_status_result() {
 #[cfg(feature = "pcap")]
 #[tokio::test]
 async fn pcap_job_status_rejects_unknown_job_id() {
-    let mut state = initialized_state().await;
+    let state = initialized_state().await;
     let resp = handle_request(
-        &mut state,
+        state.clone(),
         request(
             "tools/call",
             Some(json!({"name": "get_pcap_capture_status", "arguments": {"jobId": "pcap-does-not-exist"}})),

--- a/crates/netscli-mcp/src/server/jobs.rs
+++ b/crates/netscli-mcp/src/server/jobs.rs
@@ -162,7 +162,11 @@ impl ServerState {
     }
 }
 
-pub(super) async fn start_pcap_capture_job(
+// Not `async`: the body only spawns the capture and returns its initial
+// status. Keeping it synchronous lets the caller hold the (synchronous)
+// server-state lock across the whole call without making the enclosing
+// future non-`Send`.
+pub(super) fn start_pcap_capture_job(
     state: &mut ServerState,
     params: Value,
 ) -> Result<Value, RpcError> {

--- a/crates/netscli-mcp/src/server/protocol.rs
+++ b/crates/netscli-mcp/src/server/protocol.rs
@@ -1,11 +1,31 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Distinguish "field absent" from "field present and null".
+///
+/// JSON-RPC 2.0 treats these differently: an absent `id` makes the message a
+/// *notification* (no response may be sent), whereas an explicit `"id": null`
+/// is a *request* that must be answered with `"id": null`. A plain
+/// `Option<Value>` collapses both into `None`, so `{"id": null}` was silently
+/// dropped and the caller waited forever.
+fn double_option<'de, D>(de: D) -> Result<Option<Option<serde_json::Value>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    serde::Deserialize::deserialize(de).map(Some)
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub(super) struct JsonRpcRequest {
+    // Defaulted rather than required so that a message missing `jsonrpc`
+    // still parses and reaches the explicit version check, which reports
+    // -32600 Invalid Request. Making it mandatory here meant serde failed
+    // first and the caller got -32700 Parse Error instead.
+    #[serde(default)]
     pub(super) jsonrpc: String,
     pub(super) method: String,
     pub(super) params: Option<serde_json::Value>,
-    pub(super) id: Option<serde_json::Value>,
+    #[serde(default, deserialize_with = "double_option")]
+    pub(super) id: Option<Option<serde_json::Value>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
## What

The MCP read loop `await`ed each handler inline, so one slow tool call blocked every request behind it — including its own cancellation. This is the interface the project was built for first.

**Measured before:** a `tools/list` queued behind a `ping_host` returned at `t=+9339ms`, 1 ms after the ping.

**Measured after:** three fast requests return at **335 ms** while the slow ping is still in flight; the ping still completes at 12404 ms.

```
responses: [{"id":0,"t":125},{"id":4,"t":335},{"id":3,"t":335},{"id":2,"t":335},{"id":1,"t":12404}]
RESULT: PASS - fast requests overtook the slow one by 12069ms
```

12 seconds of head-of-line blocking removed, nothing dropped.

## How

- Requests spawn onto tasks; responses funnel through an mpsc channel to a **single writer task**, so bytes from concurrent handlers can never interleave on stdout. JSON-RPC ids already permit out-of-order replies.
- In-flight work capped at 16. Each request can itself fan out to `Ops`-level concurrency, so this bounds how many of those fans stack up; excess requests queue rather than being rejected.
- `ServerState` moves behind `Arc<Mutex<..>>`. Every critical section is synchronous and short (a bool read, a job-map insert) and **no guard is held across an await** — that is what keeps the handler futures `Send` and keeps slow tool dispatch outside the lock entirely.
- `start_pcap_capture_job` becomes a plain `fn` (it only spawns and returns), letting the caller hold the sync lock across the whole call.

## Also fixed, same file

- **C-09** — `"id": null` is a *request* under JSON-RPC 2.0 and must be answered, but serde collapsed it into the same `None` as an absent id, so it was treated as a notification and silently dropped; the caller waited forever. `id` is now a double `Option`.
- A message missing `jsonrpc` returned `-32700` Parse Error because serde failed before the explicit version check. The field is defaulted so it reaches that check and correctly reports `-32600` Invalid Request.

## Tests

124 pass locally (`netscli-mcp` 11, up from 8). New regression tests cover all three fixes — including one that pins the handler future as `Send + 'static`, so a revert to `&mut ServerState` **fails to compile**.

`cargo fmt --check` clean, `cargo clippy -D warnings` clean.