### PR TITLE
Make the GUI keyboard-accessible and fix result-grid ARIA (H-3, B-20..B-22, C-13)

### DIFF
--- a/apps/netscli-gui/src/components/results/DetailPane.tsx
+++ b/apps/netscli-gui/src/components/results/DetailPane.tsx
@@ -103,9 +103,25 @@ export function DetailPane({
         onKeyDown={(event) => handleDetailResizeKeyDown(event, height, setHeight, setMode)}
         onPointerDown={(event) => startDetailResize(event, setHeight, setMode)}
       />
-      <div className="detail-tabs">
+      {/*
+        C-13: these looked like tabs and behaved like tabs but carried no tab
+        semantics, so assistive tech announced a row of unrelated buttons with
+        no indication which was current. They are real buttons already, so
+        they are keyboard-reachable — this adds the missing relationship.
+        The landing page already does this correctly.
+      */}
+      <div className="detail-tabs" role="tablist" aria-label="Detail view">
         {tabSet.map((tab) => (
-          <button className={activeDetail === tab ? 'active' : ''} key={tab} onClick={() => onSetDetailTab(tab)}>
+          <button
+            className={activeDetail === tab ? 'active' : ''}
+            key={tab}
+            role="tab"
+            aria-selected={activeDetail === tab}
+            aria-controls="detail-panel"
+            id={`detail-tab-${tab}`}
+            type="button"
+            onClick={() => onSetDetailTab(tab)}
+          >
             {tab}
           </button>
         ))}
@@ -148,6 +164,12 @@ export function DetailPane({
             overflow.left ? 'has-left-overflow' : '',
           ].filter(Boolean).join(' ')}
           ref={detailBodyRef}
+          // Completes the tablist relationship above (C-13): the buttons
+          // point here via aria-controls, and this names the tab it belongs
+          // to so the panel is announced with its own label.
+          id="detail-panel"
+          role="tabpanel"
+          aria-labelledby={`detail-tab-${activeDetail}`}
           tabIndex={0}
           onContextMenu={onContentContextMenu}
           onKeyDown={selectDetailBodyOnShortcut}

--- a/apps/netscli-gui/src/components/results/ResultTable.tsx
+++ b/apps/netscli-gui/src/components/results/ResultTable.tsx
@@ -100,14 +100,26 @@ export function ResultTable({
       ].filter(Boolean).join(' ')}
       data-testid="result-table"
       ref={tableShellRef}
-      role="grid"
-      aria-multiselectable="true"
-      tabIndex={0}
       onScroll={() => updateOverflowState(tableShellRef.current, setOverflow)}
       onContextMenu={onContentContextMenu}
-      onKeyDown={(event) => handleTableKeyDown(event, activeTab.selectedIndex, rows.length, onSelectAllRows, onSelectRow)}
     >
-      <table className="result-table">
+      {/*
+        The grid role lives on the <table>, not on the scroll container
+        (B-20). A `role="grid"` div whose only child is a table breaks row
+        ownership: the rows belong to the table, so assistive tech saw a grid
+        with no rows. Focus and key handling move here with it, since
+        `aria-activedescendant` must sit on the focused element.
+      */}
+      <table
+        className="result-table"
+        role="grid"
+        aria-multiselectable="true"
+        aria-activedescendant={rows.length > 0 ? `result-row-${activeTab.selectedIndex}` : undefined}
+        tabIndex={0}
+        onKeyDown={(event) =>
+          handleTableKeyDown(event, activeTab.selectedIndex, rows.length, onSelectAllRows, onSelectRow)
+        }
+      >
         <colgroup>
           {effectiveColumns.map((column) => (
             <col key={column.key} style={column.width ? { width: `${column.width}px` } : undefined} />
@@ -116,7 +128,19 @@ export function ResultTable({
         <thead>
           <tr>
             {effectiveColumns.map((column) => (
-              <th className={column.grow ? 'grow' : ''} key={column.key}>
+              <th
+                className={column.grow ? 'grow' : ''}
+                key={column.key}
+                // Without this the sort state was visible only as a caret
+                // glyph, which screen readers do not convey (B-20).
+                aria-sort={
+                  activeTab.sortKey === column.key
+                    ? activeTab.sortDir === 'asc'
+                      ? 'ascending'
+                      : 'descending'
+                    : 'none'
+                }
+              >
                 <button onClick={() => onSort(column)}>
                   <span>{column.label}</span>
                   {activeTab.sortKey === column.key && (
@@ -151,6 +175,10 @@ export function ResultTable({
                 aria-selected={selected}
                 className={[selected ? 'selected' : '', focused ? 'focused' : ''].filter(Boolean).join(' ')}
                 data-testid={`result-row-${row.data.port ?? row.id}`}
+                // Referenced by the grid's aria-activedescendant so arrow-key
+                // navigation is announced. Keyed by index, not row id,
+                // because the selection is an index.
+                id={`result-row-${index}`}
                 key={row.id}
                 tabIndex={-1}
                 onClick={(event) => onSelectRow(index, selectionModeForPointer(event))}

--- a/apps/netscli-gui/src/components/shell/TabStrip.a11y.test.tsx
+++ b/apps/netscli-gui/src/components/shell/TabStrip.a11y.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+//
+// H-3 regression: the workspace tabs were plain divs with an onClick — no
+// role, no tabIndex, and no tab-switching shortcut anywhere in the app — so
+// they could not be reached or operated by keyboard at all.
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TabStrip } from './TabStrip';
+import { createTab } from '../../tools/registry';
+
+function renderStrip(activeIndex = 0) {
+  const tabs = [createTab('scan'), createTab('arp'), createTab('dns')];
+  const onSelectTab = vi.fn();
+  const onCloseTab = vi.fn();
+  render(
+    <TabStrip
+      tabs={tabs}
+      activeTabId={tabs[activeIndex].id}
+      openMenu={null}
+      toolCapabilities={{} as never}
+      onAddScanTab={vi.fn()}
+      onAddToolTab={vi.fn()}
+      onCloseTab={onCloseTab}
+      onSelectTab={onSelectTab}
+      setOpenMenu={vi.fn()}
+    />,
+  );
+  return { tabs, onSelectTab, onCloseTab };
+}
+
+describe('tab strip keyboard access', () => {
+  it('exposes the tabs as a tablist', () => {
+    renderStrip();
+    expect(screen.getByRole('tablist')).toBeTruthy();
+    expect(screen.getAllByRole('tab')).toHaveLength(3);
+  });
+
+  it('marks exactly one tab selected', () => {
+    renderStrip(1);
+    const selected = screen.getAllByRole('tab').filter((el) => el.getAttribute('aria-selected') === 'true');
+    expect(selected).toHaveLength(1);
+  });
+
+  // Roving tabindex: the strip is a single tab stop, and arrows move within.
+  it('puts only the active tab in the tab order', () => {
+    renderStrip(1);
+    const tabIndexes = screen.getAllByRole('tab').map((el) => el.getAttribute('tabindex'));
+    expect(tabIndexes).toEqual(['-1', '0', '-1']);
+  });
+
+  it('moves to the next tab on ArrowRight and wraps at the end', () => {
+    const { tabs, onSelectTab } = renderStrip(2);
+    const active = screen.getAllByRole('tab')[2];
+    active.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(onSelectTab).toHaveBeenCalledWith(tabs[0].id);
+  });
+
+  it('moves to the previous tab on ArrowLeft and wraps at the start', () => {
+    const { tabs, onSelectTab } = renderStrip(0);
+    screen.getAllByRole('tab')[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    expect(onSelectTab).toHaveBeenCalledWith(tabs[2].id);
+  });
+
+  it('jumps to the ends with Home and End', () => {
+    const { tabs, onSelectTab } = renderStrip(1);
+    const active = screen.getAllByRole('tab')[1];
+    active.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    expect(onSelectTab).toHaveBeenCalledWith(tabs[0].id);
+    active.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    expect(onSelectTab).toHaveBeenCalledWith(tabs[2].id);
+  });
+
+  it('closes the focused tab with Delete', () => {
+    const { tabs, onCloseTab } = renderStrip(1);
+    screen.getAllByRole('tab')[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }));
+    expect(onCloseTab).toHaveBeenCalledWith(tabs[1].id);
+  });
+
+  // A div does not activate on Enter/Space the way a button does, so this
+  // needs an explicit handler rather than coming for free.
+  it('activates a tab with Enter and Space', () => {
+    const { tabs, onSelectTab } = renderStrip(0);
+    const first = screen.getAllByRole('tab')[0];
+    first.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    first.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(onSelectTab).toHaveBeenCalledTimes(2);
+    expect(onSelectTab).toHaveBeenCalledWith(tabs[0].id);
+  });
+});

--- a/apps/netscli-gui/src/components/shell/TabStrip.tsx
+++ b/apps/netscli-gui/src/components/shell/TabStrip.tsx
@@ -5,6 +5,8 @@ import { TOOL_CONFIG } from '../../tools/registry';
 import { tabIdentity } from '../../tools/presentation';
 import type { ToolCapabilityMap, ToolKind, WorkspaceTab } from '../../tools/types';
 import { computePopoverPosition } from '../primitives/overlay';
+import { handleTabStripKeyDown } from './tabStripKeyboard';
+import { useTabStripDrag } from './useTabStripDrag';
 import { tabDisplayFor } from './tabDisplay';
 import { TabToolMenu } from './TabToolMenu';
 
@@ -35,15 +37,10 @@ export function TabStrip({
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const activeTabRef = useRef<HTMLDivElement | null>(null);
   const chevronRef = useRef<HTMLButtonElement | null>(null);
-  const dragState = useRef({
-    active: false,
-    captured: false,
-    startX: 0,
-    scrollLeft: 0,
-    moved: false,
-    pointerId: 0,
+  const { dragHandlers, suppressNextClick } = useTabStripDrag(scrollRef, () => {
+    updateOverflowState();
+    updateToolMenuPosition();
   });
-  const suppressNextClick = useRef(false);
   const [toolMenuPosition, setToolMenuPosition] = useState({ left: 0, maxHeight: 360, top: 0 });
   const [overflowState, setOverflowState] = useState({
     overflow: false,
@@ -118,92 +115,14 @@ export function TabStrip({
       <div
         className="tab-scroll"
         ref={scrollRef}
-        onWheel={(event) => {
-          const scroll = scrollRef.current;
-          if (!scroll) return;
-          if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
-          const unit =
-            event.deltaMode === WheelEvent.DOM_DELTA_LINE
-              ? 16
-              : event.deltaMode === WheelEvent.DOM_DELTA_PAGE
-                ? scroll.clientWidth
-                : 1;
-          scroll.scrollBy({ left: event.deltaY * unit, behavior: 'smooth' });
-          event.preventDefault();
-          window.requestAnimationFrame(() => {
-            updateOverflowState();
-            updateToolMenuPosition();
-          });
-        }}
-        onPointerDown={(event) => {
-          if (event.button !== 0 || (event.target as HTMLElement).closest('button')) return;
-          const scroll = scrollRef.current;
-          if (!scroll || scroll.scrollWidth <= scroll.clientWidth + 1) return;
-          dragState.current = {
-            active: true,
-            captured: false,
-            startX: event.clientX,
-            scrollLeft: scroll.scrollLeft,
-            moved: false,
-            pointerId: event.pointerId,
-          };
-        }}
-        onPointerMove={(event) => {
-          const state = dragState.current;
-          const scroll = scrollRef.current;
-          if (!state.active || !scroll) return;
-          const delta = event.clientX - state.startX;
-          if (Math.abs(delta) <= 6 && !state.moved) return;
-          state.moved = true;
-          if (!state.captured) {
-            scroll.setPointerCapture(event.pointerId);
-            state.captured = true;
-          }
-          scroll.scrollLeft = state.scrollLeft - delta;
-          event.preventDefault();
-          updateOverflowState();
-          updateToolMenuPosition();
-        }}
-        onPointerUp={(event) => {
-          const state = dragState.current;
-          const moved = state.active && state.moved;
-          if (state.captured && scrollRef.current?.hasPointerCapture(event.pointerId)) {
-            scrollRef.current.releasePointerCapture(event.pointerId);
-          }
-          dragState.current = {
-            active: false,
-            captured: false,
-            startX: 0,
-            scrollLeft: 0,
-            moved: false,
-            pointerId: 0,
-          };
-          if (moved) {
-            suppressNextClick.current = true;
-            window.setTimeout(() => {
-              suppressNextClick.current = false;
-            }, 0);
-          }
-        }}
-        onPointerCancel={(event) => {
-          if (dragState.current.captured && scrollRef.current?.hasPointerCapture(event.pointerId)) {
-            scrollRef.current.releasePointerCapture(event.pointerId);
-          }
-          dragState.current = {
-            active: false,
-            captured: false,
-            startX: 0,
-            scrollLeft: 0,
-            moved: false,
-            pointerId: 0,
-          };
-        }}
+        {...dragHandlers}
         onScroll={() => {
           updateOverflowState();
           updateToolMenuPosition();
         }}
       >
-        <div className="tab-list">
+        {/* Tablist semantics and roving tabindex — see tabStripKeyboard.ts. */}
+        <div className="tab-list" role="tablist" aria-label="Open tools">
           {tabs.map((tab, index) => {
             const config = TOOL_CONFIG[tab.kind];
             const Icon = config.Icon;
@@ -218,7 +137,10 @@ export function TabStrip({
                 ].filter(Boolean).join(' ')}
                 key={tab.id}
                 ref={tab.id === activeTabId ? activeTabRef : undefined}
+                role="tab"
+                aria-selected={tab.id === activeTabId}
                 aria-label={tooltip}
+                tabIndex={tab.id === activeTabId ? 0 : -1}
                 data-tooltip={tooltip}
                 data-tooltip-placement="bottom"
                 onClick={(event) => {
@@ -229,6 +151,7 @@ export function TabStrip({
                   }
                   onSelectTab(tab.id);
                 }}
+                onKeyDown={(event) => handleTabStripKeyDown(event, index, tabs, onSelectTab, onCloseTab)}
               >
                 <Icon size={14} />
                 <span className="tab-identity">

--- a/apps/netscli-gui/src/components/shell/ToastHost.tsx
+++ b/apps/netscli-gui/src/components/shell/ToastHost.tsx
@@ -8,10 +8,40 @@ interface ToastHostProps {
 }
 
 export function ToastHost({ dismissToast, setActiveTabId, toast }: ToastHostProps) {
-  if (!toast) return null;
+  const actionLabel = toast?.actionUrl ? 'View release' : toast?.tabId ? 'Open tab' : null;
 
-  const actionLabel = toast.actionUrl ? 'View release' : toast.tabId ? 'Open tab' : null;
+  // The live region is rendered unconditionally, even with no toast (B-21).
+  //
+  // Screen readers only announce changes *within* a region that already
+  // existed; inserting an element that itself carries `aria-live` is
+  // unreliable. Previously this component returned null with no toast, so
+  // operation-complete and operation-*failed* notices were silent.
+  //
+  // `.toast` is `position: absolute`, and a static wrapper does not create a
+  // containing block, so this does not move it.
+  return (
+    <div role="status" aria-live="polite" aria-atomic="true">
+      {toast && <ToastButton
+        actionLabel={actionLabel}
+        dismissToast={dismissToast}
+        setActiveTabId={setActiveTabId}
+        toast={toast}
+      />}
+    </div>
+  );
+}
 
+function ToastButton({
+  actionLabel,
+  dismissToast,
+  setActiveTabId,
+  toast,
+}: {
+  actionLabel: string | null;
+  dismissToast: () => void;
+  setActiveTabId: (tabId: string) => void;
+  toast: WorkspaceToast;
+}) {
   return (
     <button
       className={[

--- a/apps/netscli-gui/src/components/shell/tabStripKeyboard.ts
+++ b/apps/netscli-gui/src/components/shell/tabStripKeyboard.ts
@@ -1,0 +1,62 @@
+import type { KeyboardEvent } from 'react';
+
+import type { WorkspaceTab } from '../../tools/types';
+
+/**
+ * Keyboard behaviour for the workspace tab strip.
+ *
+ * H-3: the tabs were plain divs with an onClick — no role, no tabIndex, and
+ * no tab-switching shortcut anywhere in the app — so they could not be
+ * reached or operated by keyboard at all. `TabStrip` now renders them as a
+ * tablist with a roving tabindex (only the active tab is in the tab order),
+ * and this module supplies the movement.
+ *
+ * Split out of `TabStrip.tsx` to keep that file under the maintainability
+ * cap. Lives next to it rather than in `hooks/` because it is specific to
+ * this strip's roving-tabindex markup.
+ *
+ * Standard tablist pattern: arrows move between tabs and wrap at the ends,
+ * Home/End jump to the ends, Delete closes, Enter/Space activate. The last
+ * is needed because the tabs are divs, which — unlike buttons — do not fire
+ * a click on Enter or Space.
+ */
+export function handleTabStripKeyDown(
+  event: KeyboardEvent<HTMLDivElement>,
+  index: number,
+  tabs: WorkspaceTab[],
+  onSelectTab: (tabId: string) => void,
+  onCloseTab: (tabId: string) => void,
+) {
+  const tab = tabs[index];
+  if (!tab) return;
+  const last = tabs.length - 1;
+
+  if (event.key === 'Delete') {
+    event.preventDefault();
+    onCloseTab(tab.id);
+    return;
+  }
+
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    onSelectTab(tab.id);
+    return;
+  }
+
+  let target: number | null = null;
+  if (event.key === 'ArrowRight') target = index === last ? 0 : index + 1;
+  else if (event.key === 'ArrowLeft') target = index === 0 ? last : index - 1;
+  else if (event.key === 'Home') target = 0;
+  else if (event.key === 'End') target = last;
+  if (target === null) return;
+
+  event.preventDefault();
+  const next = tabs[target];
+  if (!next) return;
+  onSelectTab(next.id);
+
+  // Selecting alone only moves the tabindex; focus would stay on the now
+  // untabbable previous tab. DOM order matches `tabs`.
+  const sibling = event.currentTarget.parentElement?.children[target];
+  if (sibling instanceof HTMLElement) sibling.focus();
+}

--- a/apps/netscli-gui/src/components/shell/useTabStripDrag.ts
+++ b/apps/netscli-gui/src/components/shell/useTabStripDrag.ts
@@ -1,0 +1,101 @@
+import { useRef } from 'react';
+import type { PointerEvent as ReactPointerEvent, WheelEvent as ReactWheelEvent } from 'react';
+
+const IDLE = {
+  active: false,
+  captured: false,
+  startX: 0,
+  scrollLeft: 0,
+  moved: false,
+  pointerId: 0,
+};
+
+/**
+ * Drag-to-scroll and wheel-to-scroll for the tab strip.
+ *
+ * Extracted from `TabStrip.tsx` to keep it under the maintainability cap.
+ * It is a clean seam: nothing here touches tab state, only the scroll
+ * container's position.
+ *
+ * `suppressNextClick` exists because a drag ends with a click on whichever
+ * tab is under the cursor; the strip checks it to avoid switching tabs when
+ * the user was only scrolling.
+ */
+export function useTabStripDrag(
+  scrollRef: React.RefObject<HTMLDivElement | null>,
+  onScrollChange: () => void,
+) {
+  const dragState = useRef({ ...IDLE });
+  const suppressNextClick = useRef(false);
+
+  function onWheel(event: ReactWheelEvent<HTMLDivElement>) {
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
+    const unit =
+      event.deltaMode === WheelEvent.DOM_DELTA_LINE
+        ? 16
+        : event.deltaMode === WheelEvent.DOM_DELTA_PAGE
+          ? scroll.clientWidth
+          : 1;
+    scroll.scrollBy({ left: event.deltaY * unit, behavior: 'smooth' });
+    event.preventDefault();
+    window.requestAnimationFrame(onScrollChange);
+  }
+
+  function onPointerDown(event: ReactPointerEvent<HTMLDivElement>) {
+    if (event.button !== 0 || (event.target as HTMLElement).closest('button')) return;
+    const scroll = scrollRef.current;
+    if (!scroll || scroll.scrollWidth <= scroll.clientWidth + 1) return;
+    dragState.current = {
+      ...IDLE,
+      active: true,
+      startX: event.clientX,
+      scrollLeft: scroll.scrollLeft,
+      pointerId: event.pointerId,
+    };
+  }
+
+  function onPointerMove(event: ReactPointerEvent<HTMLDivElement>) {
+    const state = dragState.current;
+    const scroll = scrollRef.current;
+    if (!state.active || !scroll) return;
+    const delta = event.clientX - state.startX;
+    if (Math.abs(delta) <= 6 && !state.moved) return;
+    state.moved = true;
+    if (!state.captured) {
+      scroll.setPointerCapture(event.pointerId);
+      state.captured = true;
+    }
+    scroll.scrollLeft = state.scrollLeft - delta;
+    event.preventDefault();
+    onScrollChange();
+  }
+
+  function releaseCapture(pointerId: number) {
+    if (dragState.current.captured && scrollRef.current?.hasPointerCapture(pointerId)) {
+      scrollRef.current.releasePointerCapture(pointerId);
+    }
+  }
+
+  function onPointerUp(event: ReactPointerEvent<HTMLDivElement>) {
+    const moved = dragState.current.active && dragState.current.moved;
+    releaseCapture(event.pointerId);
+    dragState.current = { ...IDLE };
+    if (!moved) return;
+    suppressNextClick.current = true;
+    window.setTimeout(() => {
+      suppressNextClick.current = false;
+    }, 0);
+  }
+
+  function onPointerCancel(event: ReactPointerEvent<HTMLDivElement>) {
+    releaseCapture(event.pointerId);
+    dragState.current = { ...IDLE };
+  }
+
+  return {
+    suppressNextClick,
+    dragHandlers: { onWheel, onPointerDown, onPointerMove, onPointerUp, onPointerCancel },
+  };
+}

--- a/apps/netscli-gui/src/hooks/usePopoverDismissal.ts
+++ b/apps/netscli-gui/src/hooks/usePopoverDismissal.ts
@@ -12,7 +12,21 @@ export function usePopoverDismissal({
   setOpenMenu: (menu: string | null) => void;
 }) {
   useEffect(() => {
+    // Suppressing the webview's native menu everywhere also killed it inside
+    // text fields (B-22). The app's own context menu only covers result
+    // surfaces, so right-clicking a form input produced nothing at all and
+    // users lost their only mouse-driven cut/copy/paste affordance.
+    //
+    // Editable targets keep the native menu; everything else is still
+    // suppressed so the app can draw its own.
     function suppressWebviewContextMenu(event: Event) {
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        target.closest('input, textarea, [contenteditable="true"]')
+      ) {
+        return;
+      }
       event.preventDefault();
     }
 


### PR DESCRIPTION
## H-3 — the workspace tabs could not be used by keyboard at all

Plain `<div>`s with an `onClick`: no `role`, no `tabIndex`, and no tab-switching shortcut anywhere in the app. Now a proper tablist with a roving tabindex — arrows move and wrap, Home/End jump to the ends, Delete closes, Enter/Space activate (a div doesn't activate on Enter the way a button does). Arrow selection also **moves focus**, which the roving tabindex otherwise strands on the old tab.

## Also fixed

| # | Bug |
|---|---|
| **B-20** | `role="grid"` sat on the scroll container whose only child was a `<table>` — that breaks row ownership, so AT saw a grid with **no rows**. Role, focus and key handling move onto the table (`aria-activedescendant` must sit on the focused element). Headers gain `aria-sort`, previously conveyed only by a caret glyph. |
| **B-21** | Toasts were **never announced** — no `role`, no `aria-live` anywhere in the GUI, so operation-complete and operation-**failed** notices were silent. The live region now renders unconditionally: screen readers only announce changes *within* a region that already existed. |
| **B-22** | Native context menu suppressed document-wide **including text inputs**, while the app's own menu only covers result surfaces — right-clicking any form field yielded nothing, losing the only mouse-driven cut/copy/paste. |
| **C-13** | Detail-pane "tabs" had no tab semantics — announced as unrelated buttons with no current-item indication. |

## Verified live, not just in tests

Driven through the running GUI via browser tooling:

```
tablistPresent: true   gridOnTable: true   liveRegion: true
gridActiveDescendant: "result-row-0"
ariaSortValues: ["ascending","none","none","none","none","none"]

ArrowLeft: selectedIdx 2 -> 1, tabIndexes ["-1","0","-1"],
           focusedIsSelected: true

clickSelectsTab: true          wheelMovedScroll: true
contextMenuAllowedInInput: true  contextMenuSuppressedOnBody: true
```

The last two lines matter because I extracted drag-to-scroll mechanically — click-select and wheel-scroll are confirmed still working, not assumed.

## Note on the file-size gate

`TabStrip` crossed the cap. I started shaving comments to squeeze under it, realised that was the wrong fix, and extracted keyboard handling and drag-to-scroll into their own modules instead.

**80 tests pass, up from 72** — 8 new ones covering tablist semantics, roving tabindex, wrap-around, Home/End, Delete and Enter/Space.