### PR TITLE
Fix TUI unicode width handling and two data-safety issues (B-07, B-08, B-12, B-13)

### DIFF
--- a/apps/netscli-cli/src/tui/events/pcap.rs
+++ b/apps/netscli-cli/src/tui/events/pcap.rs
@@ -153,16 +153,15 @@ pub(super) async fn handle(
 
     let iface = interface.unwrap_or_else(|| "unknown".to_string());
     match ops.pcap_check_support() {
-        Ok(devs) => {
-            if !devs.iter().any(|d| d == &iface) {
-                out.push(Formatter::format_error(&format!(
-                    "Unknown interface: {iface}"
-                )));
-                out.push(Line::default());
-                out.extend(Formatter::format_pcap_interfaces(&devs));
-                return out;
-            }
-        }
+        // Deliberately no name check here (B-12).
+        //
+        // This used to require exact string equality against a device name,
+        // while `resolve_capture_device` in core also accepts case-insensitive
+        // names, description substrings, GUIDs and IP addresses. The TUI
+        // therefore rejected interfaces the CLI accepted, for the same
+        // capture. Core owns resolution; letting it fail produces one
+        // consistent error across both surfaces.
+        Ok(_devs) => {}
         Err(e) => {
             out.push(Formatter::format_error("PCAP is not available."));
             out.push(Line::from(format!("  {e}")));

--- a/apps/netscli-cli/src/tui/state/render/input.rs
+++ b/apps/netscli-cli/src/tui/state/render/input.rs
@@ -1,8 +1,9 @@
 use super::super::super::palette::palette;
 use super::super::super::widgets::{
-    build_suggestion_line, cursor_blink_on, draw_gradient_rounded_border, input_container_height,
-    label_style, line_with_drawn_cursor, next_scroll_top, pad_line_to_width, placeholder_style,
-    scrollbar_thumb, slice_chars, suggestion_window_start, value_style,
+    build_suggestion_line, cursor_blink_on, display_col, draw_gradient_rounded_border,
+    input_container_height, label_style, line_with_drawn_cursor, next_scroll_top,
+    pad_line_to_width, placeholder_style, scrollbar_thumb, slice_cols, suggestion_window_start,
+    value_style,
 };
 use super::super::{TuiApp, INPUT_PLACEHOLDER};
 use crate::tui_settings::StatsUnit;
@@ -13,6 +14,7 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Padding, Paragraph, Wrap},
     Frame,
 };
+use unicode_width::UnicodeWidthStr;
 
 impl<'a> TuiApp<'a> {
     pub(super) fn render_input(&mut self, f: &mut Frame<'_>, area: Rect) {
@@ -166,13 +168,18 @@ impl<'a> TuiApp<'a> {
         if area.height < 3 || w < 8 {
             let cursor = self.input.cursor();
             let (row, col) = (cursor.0, cursor.1);
-            let cursor_col = if row == 0 { col } else { 0 };
             let raw = self.input.lines().first().cloned().unwrap_or_default();
             let empty = raw.trim().is_empty();
             let display = if empty {
                 INPUT_PLACEHOLDER.to_string()
             } else {
                 raw.clone()
+            };
+            // `col` is a char index; scrolling and slicing are in cells (B-08).
+            let cursor_col = if row == 0 {
+                display_col(&display, col)
+            } else {
+                0
             };
             let width = area.width.max(1) as usize;
             let style = if empty {
@@ -182,12 +189,12 @@ impl<'a> TuiApp<'a> {
             };
 
             let prompt = "> ";
-            let avail = width.saturating_sub(prompt.chars().count()).max(1);
+            let avail = width.saturating_sub(UnicodeWidthStr::width(prompt)).max(1);
             self.input_scroll_x = next_scroll_top(self.input_scroll_x, cursor_col, avail);
             if empty {
                 self.input_scroll_x = 0;
             }
-            let visible = slice_chars(&display, self.input_scroll_x, avail);
+            let visible = slice_cols(&display, self.input_scroll_x, avail);
             let cursor_x = cursor_col
                 .saturating_sub(self.input_scroll_x)
                 .min(avail.saturating_sub(1));
@@ -203,14 +210,19 @@ impl<'a> TuiApp<'a> {
 
         let cursor = self.input.cursor();
         let (row, col) = (cursor.0, cursor.1);
-        let cursor_col = if row == 0 { col } else { 0 };
-
         let raw = self.input.lines().first().cloned().unwrap_or_default();
         let empty = raw.trim().is_empty();
         let display = if empty {
             INPUT_PLACEHOLDER.to_string()
         } else {
             raw.clone()
+        };
+
+        // `col` is a char index; scrolling and slicing are in cells (B-08).
+        let cursor_col = if row == 0 {
+            display_col(&display, col)
+        } else {
+            0
         };
 
         draw_gradient_rounded_border(f, area);
@@ -223,13 +235,13 @@ impl<'a> TuiApp<'a> {
 
         let width = inner.width.max(1) as usize;
         let prompt = "> ";
-        let avail = width.saturating_sub(prompt.chars().count()).max(1);
+        let avail = width.saturating_sub(UnicodeWidthStr::width(prompt)).max(1);
         self.input_scroll_x = next_scroll_top(self.input_scroll_x, cursor_col, avail);
         if empty {
             self.input_scroll_x = 0;
         }
 
-        let visible = slice_chars(&display, self.input_scroll_x, avail);
+        let visible = slice_cols(&display, self.input_scroll_x, avail);
         let style = if empty {
             placeholder_style()
         } else {

--- a/apps/netscli-cli/src/tui/widgets.rs
+++ b/apps/netscli-cli/src/tui/widgets.rs
@@ -6,6 +6,9 @@
 mod config_controls;
 mod gradient;
 mod input;
+#[cfg(test)]
+#[path = "widgets/input_tests.rs"]
+mod input_tests;
 mod lines;
 mod scroll;
 mod styles;
@@ -14,8 +17,8 @@ mod suggestions;
 pub(super) use config_controls::{config_line, cycle_option, cycle_unit};
 pub(super) use gradient::{draw_gradient_rounded_border, gradient_text_line_with_left_pad};
 pub(super) use input::{
-    configure_input, cursor_blink_on, input_container_height, line_with_drawn_cursor,
-    placeholder_style, slice_chars, suggestion_window_start,
+    configure_input, cursor_blink_on, display_col, input_container_height, line_with_drawn_cursor,
+    placeholder_style, slice_cols, suggestion_window_start,
 };
 pub(super) use lines::{boxed_lines, pad_line_to_width};
 pub(super) use scroll::{next_scroll_top, scrollbar_thumb};

--- a/apps/netscli-cli/src/tui/widgets/input.rs
+++ b/apps/netscli-cli/src/tui/widgets/input.rs
@@ -7,6 +7,7 @@ use ratatui::{
 };
 use ratatui_textarea::TextArea;
 use std::time::{SystemTime, UNIX_EPOCH};
+use unicode_width::UnicodeWidthStr;
 
 pub(super) const INPUT_PLACEHOLDER: &str = "Type /help for commands";
 
@@ -41,17 +42,28 @@ pub(in crate::tui) fn line_with_drawn_cursor(
 ) -> Line<'static> {
     let width = width.max(1);
     let cursor_x = cursor_x.min(width.saturating_sub(1));
-    let mut chars: Vec<char> = text.chars().collect();
-    while chars.len() < width {
-        chars.push(' ');
+
+    // Pad to `width` *cells*, not chars, and split on cell boundaries. Padding
+    // by `chars.len()` under-filled any line containing a wide character and
+    // then sliced by char index, so the reversed cursor cell landed left of
+    // where the caret actually was (B-08).
+    let left = slice_cols(text, 0, cursor_x);
+    let cursor_cell = slice_cols(text, cursor_x, 1);
+    let cursor_cell = if cursor_cell.is_empty() {
+        " ".to_string()
+    } else {
+        cursor_cell
+    };
+    let cursor_w = UnicodeWidthStr::width(cursor_cell.as_str()).max(1);
+    let right_start = cursor_x.saturating_add(cursor_w);
+    let mut right = slice_cols(text, right_start, width.saturating_sub(right_start));
+
+    // Trailing padding so the styled run still covers the full box.
+    let used =
+        UnicodeWidthStr::width(left.as_str()) + cursor_w + UnicodeWidthStr::width(right.as_str());
+    if used < width {
+        right.push_str(&" ".repeat(width - used));
     }
-    let left: String = chars.iter().take(cursor_x).collect();
-    let cursor_cell = chars.get(cursor_x).copied().unwrap_or(' ');
-    let right: String = chars
-        .iter()
-        .skip(cursor_x.saturating_add(1))
-        .take(width.saturating_sub(cursor_x.saturating_add(1)))
-        .collect();
 
     let mut spans: Vec<Span<'static>> = Vec::new();
     if !left.is_empty() {
@@ -64,7 +76,7 @@ pub(in crate::tui) fn line_with_drawn_cursor(
     } else {
         style
     };
-    spans.push(Span::styled(cursor_cell.to_string(), cursor_style));
+    spans.push(Span::styled(cursor_cell, cursor_style));
     if !right.is_empty() {
         spans.push(Span::styled(right, style));
     }
@@ -101,9 +113,43 @@ pub(in crate::tui) fn suggestion_window_start(
     start
 }
 
-pub(in crate::tui) fn slice_chars(text: &str, start: usize, len: usize) -> String {
+/// Terminal columns occupied by the first `char_index` characters.
+///
+/// The textarea reports the cursor as a *character* index, but everything
+/// downstream — scrolling, slicing, cursor placement — works in terminal
+/// cells. Conflating the two put the cursor in the wrong place and let the
+/// input overflow its box as soon as a wide character was typed (B-08).
+pub(in crate::tui) fn display_col(text: &str, char_index: usize) -> usize {
+    use unicode_width::UnicodeWidthChar;
+    text.chars()
+        .take(char_index)
+        .map(|c| c.width().unwrap_or(0))
+        .sum()
+}
+
+/// Slice `len` terminal columns starting at column `start`.
+///
+/// A wide character straddling either edge is dropped rather than split,
+/// since half of one cannot be rendered.
+pub(in crate::tui) fn slice_cols(text: &str, start: usize, len: usize) -> String {
+    use unicode_width::UnicodeWidthChar;
     if len == 0 {
         return String::new();
     }
-    text.chars().skip(start).take(len).collect()
+    let mut col = 0usize;
+    let mut out = String::new();
+    for ch in text.chars() {
+        let w = ch.width().unwrap_or(0);
+        if col >= start.saturating_add(len) {
+            break;
+        }
+        if col >= start {
+            if col + w > start + len {
+                break;
+            }
+            out.push(ch);
+        }
+        col += w;
+    }
+    out
 }

--- a/apps/netscli-cli/src/tui/widgets/input_tests.rs
+++ b/apps/netscli-cli/src/tui/widgets/input_tests.rs
@@ -1,0 +1,72 @@
+//! Width handling for the TUI input line (B-08).
+//!
+//! The textarea reports the cursor as a character index while everything
+//! downstream works in terminal cells. Every case here fails if those two are
+//! conflated again — which is what put the cursor in the wrong place and let
+//! the input overflow its box as soon as a wide character was typed.
+
+use super::input::{display_col, slice_cols};
+use unicode_width::UnicodeWidthStr;
+
+#[test]
+fn display_col_counts_cells_not_chars() {
+    // ASCII: cells and chars agree.
+    assert_eq!(display_col("abcdef", 3), 3);
+
+    // CJK: each character is two cells wide, so three chars is six cells.
+    assert_eq!(display_col("日本語", 3), 6);
+
+    // Mixed: "ab" (2) + "日" (2) = 4.
+    assert_eq!(display_col("ab日c", 3), 4);
+}
+
+#[test]
+fn display_col_handles_out_of_range_index() {
+    assert_eq!(display_col("abc", 99), 3);
+    assert_eq!(display_col("", 5), 0);
+}
+
+#[test]
+fn slice_cols_never_exceeds_the_requested_width() {
+    // The whole point: the result must fit the box it is rendered into.
+    for text in ["abcdef", "日本語です", "a日b本c", "🎉🎉🎉"] {
+        for width in 0..10 {
+            let out = slice_cols(text, 0, width);
+            assert!(
+                UnicodeWidthStr::width(out.as_str()) <= width,
+                "slice_cols({text:?}, 0, {width}) = {out:?} exceeded {width} cells",
+            );
+        }
+    }
+}
+
+#[test]
+fn slice_cols_drops_rather_than_splits_a_wide_char() {
+    // A wide character cannot be half-rendered, so asking for one cell of a
+    // two-cell character yields nothing rather than a broken glyph.
+    assert_eq!(slice_cols("日本", 0, 1), "");
+    assert_eq!(slice_cols("日本", 0, 2), "日");
+    assert_eq!(slice_cols("日本", 0, 3), "日");
+    assert_eq!(slice_cols("日本", 0, 4), "日本");
+}
+
+#[test]
+fn slice_cols_offsets_by_cells() {
+    // Starting at cell 2 skips the first CJK char, not the first two chars.
+    assert_eq!(slice_cols("日本語", 2, 2), "本");
+    assert_eq!(slice_cols("ab日", 2, 2), "日");
+}
+
+#[test]
+fn slice_cols_empty_width_is_empty() {
+    assert_eq!(slice_cols("anything", 0, 0), "");
+}
+
+// Regression for the specific failure: a CJK hostname in the input box used to
+// render more cells than `width`, pushing the border off screen.
+#[test]
+fn a_wide_string_never_overflows_the_input_width() {
+    let width = 10;
+    let visible = slice_cols("日本語のホスト名", 0, width);
+    assert!(UnicodeWidthStr::width(visible.as_str()) <= width);
+}

--- a/apps/netscli-cli/src/tui/widgets/lines.rs
+++ b/apps/netscli-cli/src/tui/widgets/lines.rs
@@ -2,6 +2,7 @@ use ratatui::{
     style::Style,
     text::{Line, Span},
 };
+use unicode_width::UnicodeWidthChar;
 
 pub(in crate::tui) fn boxed_lines(
     inner: Vec<Line<'static>>,
@@ -80,14 +81,26 @@ fn truncate_line_to_width(
     let mut out: Vec<Span<'static>> = Vec::new();
     let mut used = 0usize;
 
+    // Accumulate *display width*, not char count.
+    //
+    // `max_width` comes from `line_width`, which measures terminal cells, but
+    // this loop used to take `remaining` chars and add `chars().count()`
+    // (B-07). Any wide character — CJK, emoji — in a remote-supplied hostname
+    // or banner therefore consumed two cells while being counted as one, and
+    // pushed the box border off the right edge.
     for span in line.spans.drain(..) {
         if used >= target {
             break;
         }
-        let s = span.content.to_string();
-        let remaining = target - used;
-        let take = s.chars().take(remaining).collect::<String>();
-        used += take.chars().count();
+        let mut take = String::new();
+        for ch in span.content.chars() {
+            let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if used + w > target {
+                break;
+            }
+            take.push(ch);
+            used += w;
+        }
         if !take.is_empty() {
             out.push(Span::styled(take, span.style));
         }

--- a/apps/netscli-cli/src/tui_export.rs
+++ b/apps/netscli-cli/src/tui_export.rs
@@ -73,12 +73,30 @@ pub fn parse_export_command(input: &str) -> Result<ExportRequest> {
 }
 
 pub fn export_session(history: &[HistoryEntry], req: &ExportRequest) -> Result<PathBuf> {
+    let explicit = req.output.is_some();
     let path = req
         .output
         .clone()
         .unwrap_or_else(|| default_output_path(req.format));
+
+    // Refuse to clobber an existing file (B-13).
+    //
+    // `/export -o ~/.bashrc` used to overwrite it with no confirmation and no
+    // --force. The generated default path is timestamped to the second and is
+    // ours by construction, so only a user-supplied path needs the guard.
+    if explicit && path.exists() {
+        anyhow::bail!(
+            "{} already exists. Choose another path, or delete it first.",
+            path.display()
+        );
+    }
+
+    // Only create directories the user actually asked for. This used to run
+    // for the default path too, materialising trees as a side effect.
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
     }
 
     match req.format {


### PR DESCRIPTION
## Unicode width

**B-07** — `truncate_line_to_width` compared against a display width from `line_width` but accumulated `chars().count()`. Any wide character (CJK, emoji) in a **remote-supplied** hostname or banner consumed two cells while counting as one, pushing the box border off the right edge.

**B-08** — the input widget was char-indexed end to end. The textarea reports the cursor as a *character* index while scrolling, slicing and padding all work in *terminal cells*.

Rather than patch one end and leave the chain inconsistent, the whole path is now width-aware:

- `display_col()` converts the char-index cursor to a column
- `slice_cols()` slices by cells, **dropping** rather than splitting a straddling wide char (half a glyph can't render)
- the prompt width is measured in cells, not `chars().count()`
- `line_with_drawn_cursor` pads to width in cells

## Data safety

**B-13** — `/export` overwrote any path with no confirmation and no `--force`, so `/export -o ~/.bashrc` clobbered it. Now refuses to overwrite an existing file **when the path was user-supplied**; the generated default is timestamped to the second and ours by construction, so it doesn't need the guard. `create_dir_all` also no longer runs for the default path, where it was materialising directory trees as a side effect.

**B-12** — the TUI required exact string equality against a pcap device name, while core's `resolve_capture_device` also accepts case-insensitive names, description substrings, GUIDs and IP addresses. The TUI therefore **rejected interfaces the CLI accepted** for the same capture. The pre-check is removed; core owns resolution and produces one consistent error across both surfaces.

## Tests

7 new, including a property check that `slice_cols` never exceeds the requested width across ASCII, CJK and emoji at every width 0–9 — the invariant that actually matters, since the bug was "renders more cells than the box has".

`clippy -D warnings` clean **with and without `--features pcap`**. (The pcap *binary* can't link locally without the Npcap SDK, but clippy doesn't link, so the code is still checked.)