### PR TITLE
Remove provably dead declarations from the site CSS stack (B-23)

### DIFF
--- a/site/scripts/css-prune.mjs
+++ b/site/scripts/css-prune.mjs
@@ -1,0 +1,112 @@
+/**
+ * Delete the declarations `css-shadowing.mjs` proves can never take effect.
+ *
+ * Companion to that analysis; see its header for why B-23 is being approached
+ * this way rather than by rewriting the stack. Every removal here is
+ * behaviour-preserving by construction: the declaration is in the same media
+ * context and selector as a later one of equal-or-greater importance, so the
+ * later one already wins on every element the earlier could match.
+ *
+ * A rule left with no declarations is removed entirely.
+ *
+ *   node scripts/css-prune.mjs --dry-run   # default
+ *   node scripts/css-prune.mjs --write
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
+
+import { analyse } from './css-shadowing.mjs';
+
+const write = process.argv.includes('--write');
+const { shadowed } = analyse();
+
+// Group by file so each is rewritten once.
+const byFile = new Map();
+for (const decl of shadowed) {
+  if (!byFile.has(decl.file)) byFile.set(decl.file, []);
+  byFile.get(decl.file).push(decl);
+}
+
+// Tracks how far into each duplicate body we have already consumed, so two
+// byte-identical rule bodies do not both resolve to the first occurrence.
+const consumed = new Map();
+
+let removedTotal = 0;
+let rulesEmptied = 0;
+
+for (const [relative, decls] of byFile) {
+  const path = join(process.cwd(), relative.replace(/^\.\//, ''));
+  let css = readFileSync(path, 'utf8');
+
+  // Match on the exact declaration text so a same-property-different-value
+  // declaration elsewhere in the file is never touched by accident.
+  for (const decl of decls) {
+    const literal = `${decl.property}: ${decl.value}`;
+    // The parser normalises whitespace, so the source may wrap a value across
+    // lines. Escape the value, then let any run of escaped whitespace match
+    // any real whitespace run.
+    const valuePattern = escapeRe(decl.value).replace(/(\\?\s)+/g, '\\s+');
+    // These files are CRLF, so the trailing lookahead has to tolerate the
+    // \r before the newline or nothing ever matches.
+    const declPattern = `(^|\\n)[ \\t]*${escapeRe(decl.property)}\\s*:\\s*${valuePattern}\\s*;?[ \\t\\r]*(?=\\n|$)`;
+
+    // Scope the edit to the exact rule body this declaration came from.
+    //
+    // Matching the declaration text file-wide was wrong and did real damage:
+    // the same `property: value` pair appears in many rules, so removing the
+    // first textual match deleted a declaration from an entirely different,
+    // still-live rule. Verified against rendered output, that produced one
+    // genuine visual regression out of 370 removals — the search dialog's
+    // mobile cancel button lost its `justify-content`.
+    const bodyIndex = findRuleBody(css, decl.body);
+    if (bodyIndex === -1) {
+      console.warn(`  ! could not locate the rule containing "${literal}" in ${relative} — left in place`);
+      continue;
+    }
+    const head = css.slice(0, bodyIndex.start);
+    const body = css.slice(bodyIndex.start, bodyIndex.end);
+    const tail = css.slice(bodyIndex.end);
+    const nextBody = body.replace(new RegExp(declPattern), '$1');
+    if (nextBody !== body) {
+      css = head + nextBody + tail;
+      removedTotal += 1;
+    } else {
+      console.warn(`  ! could not locate "${literal}" within its rule in ${relative} — left in place`);
+    }
+  }
+
+  // Drop rules that are now empty; an empty rule is noise, not behaviour.
+  const emptied = css.match(/[^{}]+\{\s*\}/g);
+  if (emptied) rulesEmptied += emptied.length;
+  css = css.replace(/[^{}]+\{\s*\}\s*/g, '');
+  css = css.replace(/\n{3,}/g, '\n\n');
+
+  if (write) writeFileSync(path, css, 'utf8');
+}
+
+function escapeRe(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Locate a rule body in the source by its exact text.
+ *
+ * The analyser hands back the raw body it parsed, so an indexOf is enough and
+ * cannot drift from what was analysed. Each body is consumed once, so two
+ * rules with byte-identical bodies do not both resolve to the first.
+ */
+function findRuleBody(css, body) {
+  const from = consumed.get(body) ?? 0;
+  const start = css.indexOf(body, from);
+  if (start === -1) return -1;
+  consumed.set(body, start + 1);
+  return { start, end: start + body.length };
+}
+
+console.log(
+  `${write ? 'Removed' : 'Would remove'} ${removedTotal} shadowed declarations ` +
+    `across ${byFile.size} files, emptying ${rulesEmptied} rules.`,
+);
+if (!write) console.log('Re-run with --write to apply.');

--- a/site/scripts/css-shadowing.mjs
+++ b/site/scripts/css-shadowing.mjs
@@ -1,0 +1,180 @@
+/**
+ * Find declarations in the Starlight override stack that can never take
+ * effect, because a later rule with at least equal weight always wins.
+ *
+ * B-23 found 28 files, ~4,900 lines and 1,200+ `!important`, with rules
+ * resolved purely by load order — "no rule can be changed by editing the file
+ * that appears to own it". Rewriting that by hand is how a site breaks.
+ *
+ * This takes the safe half first: a declaration that is *provably* shadowed
+ * contributes nothing to the rendered page, so deleting it cannot change
+ * behaviour. Whatever remains after that is the part that genuinely needs
+ * judgement, and it is far smaller.
+ *
+ * Deliberately conservative. It only reports a shadow when the later
+ * declaration has:
+ *   - the identical selector text (normalised), and
+ *   - the identical media/supports context, and
+ *   - importance at least as strong,
+ * so it never has to reason about whether one selector subsumes another.
+ * That undercounts, which is the right direction to be wrong in.
+ *
+ * Usage:
+ *   node scripts/css-shadowing.mjs            # report
+ *   node scripts/css-shadowing.mjs --json     # machine-readable
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
+
+const CONFIG = join(process.cwd(), 'astro.config.mjs');
+
+/** Files in the exact order Starlight loads them; order is the whole point. */
+export function loadOrder() {
+  const config = readFileSync(CONFIG, 'utf8');
+  const block = config.match(/customCss:\s*\[([\s\S]*?)\]/);
+  if (!block) throw new Error('could not find customCss in astro.config.mjs');
+  return [...block[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+}
+
+/** Strip comments so braces inside them cannot desync the parser. */
+function stripComments(css) {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
+ * Walk rules, tracking at-rule nesting so `@media` context is part of a
+ * declaration's identity. Two identical selectors in different media queries
+ * are not the same rule and must not be treated as shadowing.
+ */
+function parseRules(css, file) {
+  const rules = [];
+  const context = [];
+  let buffer = '';
+  let i = 0;
+
+  while (i < css.length) {
+    const ch = css[i];
+    if (ch === '{') {
+      const prelude = buffer.trim();
+      buffer = '';
+      if (prelude.startsWith('@')) {
+        // At-rule with a block: push context and keep walking.
+        context.push(prelude.replace(/\s+/g, ' '));
+        i += 1;
+        continue;
+      }
+      // Style rule: capture to the matching close brace.
+      let depth = 1;
+      let body = '';
+      i += 1;
+      while (i < css.length && depth > 0) {
+        if (css[i] === '{') depth += 1;
+        else if (css[i] === '}') {
+          depth -= 1;
+          if (depth === 0) break;
+        }
+        body += css[i];
+        i += 1;
+      }
+      i += 1;
+      rules.push({ file, context: context.join(' && '), selector: normalizeSelector(prelude), body });
+      continue;
+    }
+    if (ch === '}') {
+      context.pop();
+      buffer = '';
+      i += 1;
+      continue;
+    }
+    buffer += ch;
+    i += 1;
+  }
+  return rules;
+}
+
+function normalizeSelector(selector) {
+  return selector
+    .split(',')
+    .map((part) => part.trim().replace(/\s+/g, ' '))
+    .sort()
+    .join(', ');
+}
+
+function parseDeclarations(body) {
+  const out = [];
+  for (const chunk of body.split(';')) {
+    const text = chunk.trim();
+    if (!text) continue;
+    const colon = text.indexOf(':');
+    if (colon < 1) continue;
+    const property = text.slice(0, colon).trim().toLowerCase();
+    const value = text.slice(colon + 1).trim();
+    if (!property || property.startsWith('--')) continue;
+    out.push({ property, value, important: /!important\s*$/i.test(value) });
+  }
+  return out;
+}
+
+export function analyse() {
+  const files = loadOrder();
+  const declarations = [];
+
+  files.forEach((relative, fileIndex) => {
+    const path = join(process.cwd(), relative.replace(/^\.\//, ''));
+    const css = stripComments(readFileSync(path, 'utf8'));
+    for (const rule of parseRules(css, relative)) {
+      for (const decl of parseDeclarations(rule.body)) {
+        declarations.push({ ...decl, ...rule, fileIndex });
+      }
+    }
+  });
+
+  // Last write wins for an identical (context, selector, property) triple.
+  const winners = new Map();
+  for (const d of declarations) {
+    const key = `${d.context}|${d.selector}|${d.property}`;
+    const current = winners.get(key);
+    if (!current) {
+      winners.set(key, d);
+      continue;
+    }
+    // A later declaration wins unless it is weaker in importance.
+    if (d.important || !current.important) winners.set(key, d);
+  }
+
+  const shadowed = declarations.filter((d) => {
+    const key = `${d.context}|${d.selector}|${d.property}`;
+    const winner = winners.get(key);
+    if (winner === d) return false;
+    // Only call it dead when the winner is at least as strong AND later.
+    if (winner.fileIndex < d.fileIndex) return false;
+    if (d.important && !winner.important) return false;
+    return true;
+  });
+
+  return { files, declarations, shadowed, winners };
+}
+
+// Only report when run directly; css-prune.mjs imports `analyse` and should
+// not trigger a second report as a side effect of the import.
+const runDirectly = process.argv[1] && process.argv[1].endsWith('css-shadowing.mjs');
+const { files, declarations, shadowed } = runDirectly
+  ? analyse()
+  : { files: [], declarations: [], shadowed: [] };
+
+if (!runDirectly) {
+  // no-op
+} else if (process.argv.includes('--json')) {
+  console.log(JSON.stringify({ total: declarations.length, shadowed }, null, 2));
+} else {
+  const byFile = new Map();
+  for (const d of shadowed) byFile.set(d.file, (byFile.get(d.file) ?? 0) + 1);
+
+  console.log(`${files.length} stylesheets, ${declarations.length} declarations.`);
+  console.log(`${shadowed.length} are provably shadowed by a later rule of equal-or-greater weight.\n`);
+  for (const [file, count] of [...byFile.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(count).padStart(4)}  ${file.replace('./src/styles/starlight/', '')}`);
+  }
+}

--- a/site/src/styles/starlight/01-tokens-and-header.css
+++ b/site/src/styles/starlight/01-tokens-and-header.css
@@ -174,18 +174,8 @@ header.header::after {
   opacity: 0;
   background: linear-gradient(180deg, rgba(0, 0, 0, 0.34), rgba(0, 0, 0, 0));
   transition: opacity 160ms ease;
-}
+}html[data-docs-scrolled='true'] header.header {
 
-html:not([data-docs-scrolled='true']) header.header {
-  box-shadow: none !important;
-}
-
-html:not([data-docs-scrolled='true']) header.header::after {
-  opacity: 0 !important;
-}
-
-html[data-docs-scrolled='true'] header.header {
-  border-bottom-color: rgba(10, 174, 122, 0.18);
   box-shadow:
     0 14px 34px rgba(0, 0, 0, 0.28),
     0 1px 0 rgba(10, 174, 122, 0.12) !important;
@@ -196,7 +186,7 @@ html[data-docs-scrolled='true'] header.header::after {
 }
 
 html[data-theme='light'][data-docs-scrolled='true'] header.header {
-  border-bottom-color: rgba(0, 122, 84, 0.18);
+
   box-shadow:
     0 14px 30px rgba(17, 24, 39, 0.11),
     0 1px 0 rgba(0, 122, 84, 0.12) !important;
@@ -257,7 +247,7 @@ site-search button[data-open-modal] {
 }
 
 site-search button[data-open-modal]:hover {
-  border-color: rgba(10, 174, 122, 0.48);
+
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.018)),
     rgba(17, 22, 29, 0.96);

--- a/site/src/styles/starlight/02-search-and-sidebar-base.css
+++ b/site/src/styles/starlight/02-search-and-sidebar-base.css
@@ -19,9 +19,7 @@ site-search button[data-open-modal] > kbd {
 site-search dialog {
   border: 1px solid rgba(140, 149, 166, 0.34) !important;
   border-radius: 8px !important;
-  background:
-    linear-gradient(180deg, rgba(10, 174, 122, 0.055), transparent 9rem),
-    #252b36 !important;
+
   box-shadow:
     0 34px 90px rgba(0, 0, 0, 0.62),
     0 0 0 1px rgba(255, 255, 255, 0.02) inset !important;
@@ -35,7 +33,7 @@ site-search dialog::backdrop {
 
 site-search dialog .dialog-frame {
   gap: 0.9rem !important;
-  padding: 1.15rem !important;
+
 }
 
 site-search button[data-close-modal] {
@@ -60,18 +58,10 @@ site-search button[data-close-modal]:focus-visible {
   --pagefind-ui-border-width: 1px;
   --pagefind-ui-tag: rgba(10, 174, 122, 0.12);
   --sl-search-corners: 6px;
-}
-
-#starlight__search .pagefind-ui__form::before {
-  opacity: 0.58 !important;
-}
-
-#starlight__search .pagefind-ui__search-input {
+}#starlight__search .pagefind-ui__search-input {
   border-color: rgba(140, 149, 166, 0.32) !important;
   border-radius: 6px !important;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0.01)),
-    #171b22 !important;
+
   color: var(--sl-color-gray-1) !important;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
 }
@@ -87,7 +77,7 @@ site-search button[data-close-modal]:focus-visible {
 #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)),
 #starlight__search .pagefind-ui__result-nested,
 #starlight__search .pagefind-ui__result-tags {
-  border: 1px solid rgba(140, 149, 166, 0.13);
+
   background: rgba(17, 22, 29, 0.78) !important;
 }
 
@@ -97,7 +87,7 @@ site-search button[data-close-modal]:focus-visible {
 #starlight__search .pagefind-ui__result-nested:focus-within {
   outline: 0 !important;
   border-color: rgba(10, 174, 122, 0.34);
-  background: rgba(10, 174, 122, 0.095) !important;
+
 }
 
 #starlight__search mark {
@@ -125,9 +115,7 @@ html[data-theme='light'] site-search button[data-open-modal]:hover {
 }
 
 html[data-theme='light'] site-search dialog {
-  background:
-    linear-gradient(180deg, rgba(0, 122, 84, 0.045), transparent 9rem),
-    #f4f6f8 !important;
+
   box-shadow:
     0 30px 70px rgba(17, 24, 39, 0.18),
     0 0 0 1px rgba(255, 255, 255, 0.72) inset !important;
@@ -140,7 +128,7 @@ html[data-theme='light'] #starlight__search {
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__search-input {
-  background: #ffffff !important;
+
   border-color: rgba(17, 24, 39, 0.16) !important;
 }
 
@@ -195,7 +183,7 @@ html[data-theme='light'] starlight-menu-button[aria-expanded='true'] button {
 
 .sidebar-content a[aria-current='page'] {
   color: var(--sl-color-white);
-  background: rgba(10, 174, 122, 0.12);
+
   border-color: transparent;
   box-shadow: none;
 }
@@ -223,7 +211,7 @@ html[data-theme='light'] starlight-menu-button[aria-expanded='true'] button {
     width: 2.5rem;
     height: 2.5rem;
     inset-block-start: calc((var(--sl-nav-height) - 2.5rem) / 2);
-    inset-inline-end: max(0.85rem, env(safe-area-inset-right));
+
     z-index: 102;
   }
 

--- a/site/src/styles/starlight/03-shell-layout-base.css
+++ b/site/src/styles/starlight/03-shell-layout-base.css
@@ -50,12 +50,7 @@
 @media (max-width: 71.99rem) {
   html[data-has-toc] {
     --sl-mobile-toc-height: 0rem;
-  }
-
-  .right-sidebar-container {
-    display: none !important;
-  }
-}
+  }}
 
 @media (min-width: 72.01rem) {
   starlight-menu-button {
@@ -164,7 +159,7 @@ html[data-theme='light'] .main-pane > .content-panel:first-child::before {
 .sl-markdown-content :not(pre) > code {
   border: 1px solid rgba(10, 174, 122, 0.18);
   border-radius: 0.24rem;
-  background: var(--sl-color-bg-inline-code);
+
   color: #9ff8de;
   font-family: var(--__sl-font-mono);
   font-size: 0.9em;
@@ -193,11 +188,11 @@ html[data-theme='light'] .main-pane > .content-panel:first-child::before {
   --ec-frm-inlBtnBg: #9ff8de;
   --ec-frm-inlBtnBrd: #9ff8de;
   --ec-frm-tooltipSuccessBg: #0aae7a;
-  margin-block: 1.15rem 1.75rem;
+
 }
 
 .sl-markdown-content .expressive-code .frame {
-  overflow: hidden;
+
   border-radius: 8px !important;
   border: 1px solid rgba(140, 149, 166, 0.18);
   box-shadow:
@@ -207,15 +202,7 @@ html[data-theme='light'] .main-pane > .content-panel:first-child::before {
 
 .sl-markdown-content .expressive-code .frame.is-terminal .header {
   min-height: 2.45rem;
-}
-
-.sl-markdown-content .expressive-code pre {
-  background:
-    linear-gradient(180deg, rgba(10, 174, 122, 0.035), transparent 14rem),
-    #10151b !important;
-}
-
-.sl-markdown-content .expressive-code .ec-line :where(span[style*='#8B949E']) {
+}.sl-markdown-content .expressive-code .ec-line :where(span[style*='#8B949E']) {
   --0: #818b9c !important;
 }
 
@@ -244,7 +231,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
 }
 
 html[data-theme='light'] .sl-markdown-content :not(pre) > code {
-  border-color: rgba(0, 122, 84, 0.18);
+
   color: #064934;
 }
 
@@ -285,9 +272,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .ec-line :where(s
   border: 1px solid rgba(140, 149, 166, 0.18);
   border-radius: 8px;
   overflow: hidden;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.022), transparent 12rem),
-    rgba(20, 24, 31, 0.54);
+
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.025) inset,
     0 12px 28px rgba(0, 0, 0, 0.12);

--- a/site/src/styles/starlight/04-markdown-content-base.css
+++ b/site/src/styles/starlight/04-markdown-content-base.css
@@ -1,14 +1,6 @@
-/* Base markdown content typography: tables, blockquotes, pagination, theme select. */
-
-.sl-markdown-content thead tr {
-  background:
-    linear-gradient(180deg, rgba(10, 174, 122, 0.13), rgba(10, 174, 122, 0.055)),
-    rgba(25, 29, 37, 0.96);
-}
-
 .sl-markdown-content th {
   background: transparent;
-  color: #d7fdf2;
+
   font-size: 0.72rem;
   font-weight: 760;
   letter-spacing: 0.055em;
@@ -19,23 +11,13 @@
 
 .sl-markdown-content td,
 .sl-markdown-content th {
-  border-color: rgba(140, 149, 166, 0.13);
+
   font-weight: 720;
   line-height: 1.45;
   padding: 0.76rem 1rem;
   text-align: left;
   vertical-align: middle;
-}
-
-.sl-markdown-content tbody tr {
-  background: rgba(255, 255, 255, 0.012);
-}
-
-.sl-markdown-content tbody tr:nth-child(even) {
-  background: rgba(255, 255, 255, 0.026);
-}
-
-.sl-markdown-content tbody td {
+}.sl-markdown-content tbody td {
   border-bottom: 1px solid rgba(140, 149, 166, 0.105);
 }
 
@@ -54,14 +36,14 @@
 .sl-markdown-content table.table-row-headers tbody td:first-child {
   color: var(--sl-color-gray-1);
   font-weight: 650;
-  background: rgba(255, 255, 255, 0.018);
+
 }
 
 .sl-markdown-content table:not(.table-row-headers) tbody td:first-child,
 .sl-markdown-content table.table-plain-first-column tbody td:first-child {
   color: inherit;
   font-weight: inherit;
-  background: transparent;
+
 }
 
 .sl-markdown-content td:last-child,
@@ -150,24 +132,18 @@
 
 @media (max-width: 42rem) {
   .sl-markdown-content table {
-    display: block;
+
     border: 0;
     background: transparent;
     overflow: visible;
     max-width: 100%;
-  }
+  }.sl-markdown-content table tbody {
 
-  .sl-markdown-content table thead {
-    display: none;
-  }
-
-  .sl-markdown-content table tbody {
-    display: grid;
     gap: 0.55rem;
   }
 
   .sl-markdown-content table tr {
-    display: grid;
+
     gap: 0.28rem;
     padding: 0.8rem 0.9rem;
     border: 1px solid rgba(140, 149, 166, 0.18);
@@ -177,21 +153,14 @@
 
   .sl-markdown-content table td,
   .sl-markdown-content table th {
-    display: block;
+
     width: auto;
     min-width: 0;
     padding: 0;
     border: 0;
     white-space: normal;
     overflow-wrap: anywhere;
-  }
-
-  .sl-markdown-content table td + td,
-  .sl-markdown-content table th + th {
-    border-inline-start: 0;
-  }
-
-  .sl-markdown-content table td:first-child {
+  }.sl-markdown-content table td:first-child {
     width: auto;
     padding: 0;
     color: var(--sl-color-gray-1);

--- a/site/src/styles/starlight/05-docs-surfaces.css
+++ b/site/src/styles/starlight/05-docs-surfaces.css
@@ -8,21 +8,7 @@ html[data-theme='dark'] ::backdrop {
 html[data-theme='light'],
 html[data-theme='light'] ::backdrop {
   --sl-color-bg-inline-code: rgba(17, 24, 39, 0.07);
-}
-
-header.header {
-  border-bottom-color: rgba(10, 174, 122, 0.28);
-}
-
-html:not([data-docs-scrolled='true']) header.header {
-  box-shadow: inset 0 -1px 0 rgba(10, 174, 122, 0.22) !important;
-}
-
-html[data-theme='light'] header.header {
-  border-bottom-color: rgba(0, 122, 84, 0.22);
-}
-
-html[data-theme='light']:not([data-docs-scrolled='true']) header.header {
+}html[data-theme='light']:not([data-docs-scrolled='true']) header.header {
   box-shadow: inset 0 -1px 0 rgba(0, 122, 84, 0.18) !important;
 }
 
@@ -93,11 +79,11 @@ site-search dialog .dialog-frame {
 .sl-markdown-content :not(pre) > code {
   border-color: rgba(140, 149, 166, 0.25);
   background: var(--sl-color-bg-inline-code);
-  color: var(--sl-color-gray-1);
+
 }
 
 html[data-theme='light'] .sl-markdown-content :not(pre) > code {
-  border-color: rgba(17, 24, 39, 0.13);
+
   color: #243044;
 }
 
@@ -117,7 +103,7 @@ html[data-theme='light'] .sl-markdown-content :not(pre) > code {
 }
 
 .sl-markdown-content .expressive-code .frame {
-  background: #171c23;
+
   border-color: rgba(140, 149, 166, 0.22);
   box-shadow:
     0 16px 36px rgba(0, 0, 0, 0.3),
@@ -133,19 +119,13 @@ html[data-theme='light'] .sl-markdown-content :not(pre) > code {
   border-top: var(--ec-brdWd) solid var(--ec-brdCol) !important;
   border-top-left-radius: calc(var(--ec-brdRad) + var(--ec-brdWd)) !important;
   border-top-right-radius: calc(var(--ec-brdRad) + var(--ec-brdWd)) !important;
-}
+}.sl-markdown-content .expressive-code .copy {
 
-.sl-markdown-content .expressive-code pre {
-  background: #171c23 !important;
-}
-
-.sl-markdown-content .expressive-code .copy {
-  inset-block-start: calc(var(--ec-brdWd) + 0.55rem) !important;
   inset-inline-end: calc(var(--ec-brdWd) + 0.55rem) !important;
 }
 
 .sl-markdown-content .expressive-code .copy button {
-  width: 2rem;
+
   height: 2rem;
   background: #202631;
   border-radius: 4px;
@@ -158,7 +138,7 @@ html[data-theme='light'] .sl-markdown-content :not(pre) > code {
 
 .sl-markdown-content .expressive-code .copy button:hover,
 .sl-markdown-content .expressive-code .copy button:focus-visible {
-  background: #252c38;
+
   opacity: 1;
 }
 
@@ -226,13 +206,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
 
 .sl-markdown-content tbody tr:nth-child(even) {
   background: #242932;
-}
-
-.sl-markdown-content tbody tr:hover {
-  background: #2a303b;
-}
-
-.sl-markdown-content td,
+}.sl-markdown-content td,
 .sl-markdown-content th {
   border-color: rgba(140, 149, 166, 0.13);
 }
@@ -251,7 +225,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
 }
 
 html[data-theme='light'] .sl-markdown-content table {
-  background: #ffffff;
+
   border-color: rgba(17, 24, 39, 0.12);
   box-shadow: 0 10px 24px rgba(17, 24, 39, 0.07);
 }
@@ -271,8 +245,4 @@ html[data-theme='light'] .sl-markdown-content tbody tr {
 
 html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even) {
   background: #f6f8fa;
-}
-
-html[data-theme='light'] .sl-markdown-content tbody tr:hover {
-  background: #eef5f2;
 }

--- a/site/src/styles/starlight/06-docs-interaction-a.css
+++ b/site/src/styles/starlight/06-docs-interaction-a.css
@@ -60,7 +60,7 @@
 }
 
 #starlight__search .pagefind-ui__button {
-  display: flex;
+
   align-items: center;
   justify-content: center;
   text-align: center;

--- a/site/src/styles/starlight/07-docs-interaction-b.css
+++ b/site/src/styles/starlight/07-docs-interaction-b.css
@@ -55,7 +55,7 @@
 }
 
 .sl-markdown-content .expressive-code .copy {
-  inset-block-start: calc(var(--ec-brdWd) + var(--netscli-code-copy-inset)) !important;
+
   inset-inline-end: calc(var(--ec-brdWd) + var(--netscli-code-copy-inset)) !important;
 }
 
@@ -66,7 +66,7 @@
   border-radius: 5px;
   background: #252b36;
   opacity: 0.9;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+
 }
 
 .sl-markdown-content .expressive-code .copy button:hover,
@@ -101,13 +101,7 @@ html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
 
 .sl-markdown-content .sl-anchor-icon > svg {
   color: #0aae7a;
-}
-
-.sl-markdown-content a:hover {
-  color: #9ff8de;
-}
-
-.pagination-links a {
+}.pagination-links a {
   align-items: flex-start;
   color: var(--sl-color-gray-1) !important;
 }
@@ -147,23 +141,17 @@ html[data-theme='light'] #starlight__search .pagefind-ui__result-nested,
 html[data-theme='light'] #starlight__search .pagefind-ui__result-tags,
 html[data-theme='light'] .sl-markdown-content .expressive-code pre {
   background: #f6f8fa !important;
-}
-
-html[data-theme='light'] #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)) {
-  background: #eef2f4 !important;
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
+}html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
   background: rgba(0, 122, 84, 0.42);
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy button {
-  border-color: rgba(17, 24, 39, 0.12);
+
   background: #eef2f4;
 }
 
 html[data-theme='light'] .sl-markdown-content :not(pre) > code {
   border-color: rgba(17, 24, 39, 0.16);
   background: #eef2f4;
-  color: #243044;
+
 }

--- a/site/src/styles/starlight/08-search-modal.css
+++ b/site/src/styles/starlight/08-search-modal.css
@@ -32,21 +32,15 @@ site-search dialog .search-container {
 }
 
 #starlight__search .pagefind-ui__form {
-  position: sticky;
+
   inset-block-start: 0;
   z-index: 4;
   flex: 0 0 auto;
   padding-block-end: 0.8rem;
   background: #252b36;
-}
-
-#starlight__search .pagefind-ui__search-input {
-  background: #171b22 !important;
-}
-
-#starlight__search .pagefind-ui__drawer {
+}#starlight__search .pagefind-ui__drawer {
   min-height: 0;
-  max-height: calc(100vh - 15rem);
+
   overflow-y: auto;
   overscroll-behavior: contain;
   padding-inline-end: 0.2rem;
@@ -58,7 +52,7 @@ site-search dialog .search-container {
 #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__result)::after {
   content: '';
   display: block;
-  height: 0.42rem;
+
   pointer-events: none;
   position: sticky;
   z-index: 6;
@@ -66,13 +60,13 @@ site-search dialog .search-container {
 
 #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__result)::before {
   top: 0;
-  margin-block-end: -0.42rem;
+
   background: linear-gradient(180deg, rgba(8, 12, 18, 0.14), rgba(8, 12, 18, 0));
 }
 
 #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__result)::after {
   bottom: 0;
-  margin-block-start: -0.42rem;
+
   background: linear-gradient(0deg, rgba(8, 12, 18, 0.12), rgba(8, 12, 18, 0));
 }
 
@@ -92,7 +86,7 @@ site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidde
   --netscli-code-copy-inset: 0.52rem;
   --netscli-code-copy-size: 1.75rem;
   --netscli-code-copy-space: 3rem;
-  margin-block: 1rem 1.35rem;
+
 }
 
 .sl-markdown-content .expressive-code .copy {
@@ -133,7 +127,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__form::before {
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__search-input {
-  background: #ffffff !important;
+
   border-color: rgba(17, 24, 39, 0.24) !important;
   color: #111827 !important;
 }
@@ -141,17 +135,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__search-input {
 html[data-theme='light'] #starlight__search .pagefind-ui__search-input::placeholder {
   color: #5b667a;
   opacity: 1;
-}
-
-html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__result)::before {
-  background: linear-gradient(180deg, rgba(17, 24, 39, 0.045), rgba(17, 24, 39, 0));
-}
-
-html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__result)::after {
-  background: linear-gradient(0deg, rgba(17, 24, 39, 0.04), rgba(17, 24, 39, 0));
-}
-
-html[data-theme='light'] #starlight__search .pagefind-ui__message {
+}html[data-theme='light'] #starlight__search .pagefind-ui__message {
   color: #44516a;
 }
 html[data-theme='light'] #starlight__search .pagefind-ui__message .search-data {

--- a/site/src/styles/starlight/10-docs-feedback.css
+++ b/site/src/styles/starlight/10-docs-feedback.css
@@ -29,7 +29,7 @@
 }
 
 #starlight__search .pagefind-ui__button {
-  display: flex !important;
+
   justify-content: center !important;
   text-align: center !important;
 }
@@ -41,25 +41,15 @@
 }
 
 .sl-markdown-content .expressive-code .copy button[data-copied] {
-  border-color: rgba(10, 174, 122, 0.34) !important;
+
   color: #9ff8de !important;
-}
-
-.sl-markdown-content .expressive-code .copy button[data-copied]::after {
-  background: #9ff8de !important;
-}
-
-html[data-theme='light'] #starlight__search .pagefind-ui__search-input {
+}html[data-theme='light'] #starlight__search .pagefind-ui__search-input {
   background: #ffffff !important;
   box-shadow: none !important;
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy button[data-copied] {
-  border-color: rgba(0, 122, 84, 0.3) !important;
+
   background: #e5f3ef !important;
   color: #064934 !important;
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code .copy button[data-copied]::after {
-  background: #007a54 !important;
 }

--- a/site/src/styles/starlight/12-docs-toc-responsive.css
+++ b/site/src/styles/starlight/12-docs-toc-responsive.css
@@ -3,14 +3,8 @@
 @media (max-width: 71.99rem) {
   html[data-has-toc] {
     --sl-mobile-toc-height: 3rem;
-  }
+  }.right-sidebar {
 
-  .right-sidebar-container {
-    display: block !important;
-  }
-
-  .right-sidebar {
-    position: static !important;
     width: 100% !important;
     height: auto !important;
     padding: 0 !important;
@@ -25,12 +19,12 @@
   mobile-starlight-toc nav {
     border-top: 0 !important;
     border-bottom: 1px solid var(--sl-color-hairline-light) !important;
-    background: var(--sl-color-bg-nav) !important;
+
     box-shadow: none !important;
   }
 
   mobile-starlight-toc summary {
-    height: var(--sl-mobile-toc-height) !important;
+
     padding-block: 0.45rem !important;
     padding-inline: clamp(1rem, 4vw, 1.5rem) !important;
     border-bottom: 0 !important;
@@ -38,7 +32,7 @@
   }
 
   mobile-starlight-toc .toggle {
-    min-width: 8.25rem;
+
     gap: 0.65rem !important;
     border: 1px solid rgba(140, 149, 166, 0.22) !important;
     border-radius: 6px !important;
@@ -50,7 +44,7 @@
   mobile-starlight-toc details[open] .toggle,
   mobile-starlight-toc details .toggle:hover,
   mobile-starlight-toc summary:focus-visible .toggle {
-    border-color: rgba(10, 174, 122, 0.44) !important;
+
     color: var(--sl-color-white) !important;
   }
 
@@ -60,23 +54,17 @@
 
   mobile-starlight-toc .display-current {
     min-width: 0;
-    color: var(--sl-color-gray-2) !important;
+
     font-size: 0.82rem !important;
   }
 
   mobile-starlight-toc .dropdown {
-    margin: 0 !important;
+
     border-color: var(--sl-color-hairline-light) !important;
     border-inline: 0 !important;
     background: #171b22 !important;
     box-shadow: 0 18px 46px rgba(0, 0, 0, 0.34) !important;
-  }
-
-  mobile-starlight-toc .dropdown a {
-    color: var(--sl-color-gray-2) !important;
-  }
-
-  mobile-starlight-toc .dropdown a:hover,
+  }mobile-starlight-toc .dropdown a:hover,
   mobile-starlight-toc .dropdown a[aria-current='true'] {
     color: var(--sl-color-white) !important;
   }
@@ -154,7 +142,7 @@ html[data-theme='light'] mobile-starlight-toc .display-current {
 }
 
 html[data-theme='light'] mobile-starlight-toc .dropdown {
-  background: #ffffff !important;
+
   box-shadow: 0 18px 42px rgba(17, 24, 39, 0.14) !important;
 }
 

--- a/site/src/styles/starlight/14-docs-nav-table.css
+++ b/site/src/styles/starlight/14-docs-nav-table.css
@@ -6,7 +6,7 @@
 }
 
 .sidebar-content :where(details > ul) {
-  margin-inline-start: 0.75rem !important;
+
   border-inline-start: 1px solid var(--sl-color-hairline) !important;
 }
 
@@ -26,7 +26,7 @@
 
 @media (max-width: 71.99rem) {
   .right-sidebar-container {
-    display: block !important;
+
     width: 100% !important;
     flex: 0 0 100% !important;
     order: -1;
@@ -42,7 +42,7 @@
   }
 
   .right-sidebar {
-    position: static !important;
+
     width: 100% !important;
     height: auto !important;
     padding: 0 !important;
@@ -56,7 +56,7 @@
     width: 100% !important;
     border: 0 !important;
     background: transparent !important;
-    box-shadow: none !important;
+
   }
 
   mobile-starlight-toc summary {
@@ -114,14 +114,14 @@
     min-height: 2.45rem !important;
     padding-block: 0.38rem !important;
     padding-inline: clamp(1.15rem, 3.5vw, 1.75rem) !important;
-    border-inline-start: 2px solid transparent !important;
+
     color: var(--sl-color-gray-2) !important;
     background: transparent !important;
   }
 
   mobile-starlight-toc .dropdown a:hover,
   mobile-starlight-toc .dropdown a:focus-visible {
-    color: var(--sl-color-white) !important;
+
     background: rgba(255, 255, 255, 0.045) !important;
     outline: 0 !important;
   }

--- a/site/src/styles/starlight/16-shell-interaction-closeout.css
+++ b/site/src/styles/starlight/16-shell-interaction-closeout.css
@@ -7,23 +7,17 @@
 }
 
 .sidebar-content :where(details > ul > li) {
-  margin-inline-start: 0 !important;
+
   border-inline-start: 0 !important;
 }
 
 .sidebar-content a[aria-current='page'] {
-  border-inline-start: 2px solid #0aae7a !important;
+
   box-shadow: none !important;
   margin-inline-start: -1px !important;
   padding-inline-start: 0.55rem !important;
   width: calc(100% + 1px) !important;
-}
-
-.sidebar-content a[aria-current='page']::before {
-  content: none !important;
-}
-
-site-search button[data-open-modal],
+}site-search button[data-open-modal],
 site-search button[data-open-modal]:hover {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.015)),
@@ -61,14 +55,7 @@ html[data-theme='light'] site-search button[data-open-modal]:hover {
   margin-block-start: -1.35rem !important;
   background:
     linear-gradient(0deg, rgba(8, 12, 18, 0.54), rgba(8, 12, 18, 0.2) 44%, rgba(8, 12, 18, 0)) !important;
-}
-
-#starlight__search .pagefind-ui__drawer.netscli-search-overflow-top::before,
-#starlight__search .pagefind-ui__drawer.netscli-search-overflow-bottom::after {
-  opacity: 1;
-}
-
-html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__result)::before {
+}html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__result)::before {
   background:
     linear-gradient(180deg, rgba(209, 213, 219, 0.9), rgba(209, 213, 219, 0.36) 44%, rgba(209, 213, 219, 0)) !important;
 }
@@ -80,7 +67,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-u
 
 .pagination-links a:hover,
 .pagination-links a:focus-visible {
-  background: transparent !important;
+
   border-color: rgba(10, 174, 122, 0.36) !important;
   color: var(--sl-color-white) !important;
   outline: 0 !important;
@@ -88,7 +75,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-u
 
 html[data-theme='light'] .pagination-links a:hover,
 html[data-theme='light'] .pagination-links a:focus-visible {
-  background: transparent !important;
+
   border-color: rgba(0, 122, 84, 0.28) !important;
   color: #111827 !important;
 }

--- a/site/src/styles/starlight/17-mobile-shell-closeout-a.css
+++ b/site/src/styles/starlight/17-mobile-shell-closeout-a.css
@@ -10,24 +10,18 @@
   }
 
   .docs-topbar {
-    width: calc(100vw - 4.5rem) !important;
+
     max-width: calc(100vw - 4.5rem) !important;
     margin-inline: 0 !important;
     padding-inline-start: max(0.65rem, env(safe-area-inset-left)) !important;
     padding-inline-end: max(0.5rem, env(safe-area-inset-right)) !important;
     gap: 0.55rem !important;
-  }
-
-  .docs-mark {
-    transform: translateX(-18px) !important;
-  }
-
-  .docs-mark img {
+  }.docs-mark img {
     width: 132px !important;
   }
 
   .docs-header-search {
-    display: flex !important;
+
     flex: 0 0 2.5rem !important;
     width: 2.5rem !important;
     max-width: 2.5rem !important;
@@ -47,21 +41,9 @@
     padding: 0 !important;
     justify-content: center !important;
     gap: 0 !important;
-  }
-
-  .docs-header-search site-search button[data-open-modal] span,
-  .docs-header-search site-search button[data-open-modal] kbd {
-    display: none !important;
-  }
-
-  .sidebar-pane {
+  }.sidebar-pane {
     inset-block-start: var(--sl-nav-height) !important;
-  }
-
-  .sidebar-content > sl-sidebar-state-persist {
-    display: none !important;
-  }
-}
+  }}
 
 @media (min-width: 50rem) {
   .docs-mobile-section-nav {
@@ -152,14 +134,8 @@
     color: #0aae7a;
     font-size: 1rem;
     line-height: 1;
-    transition: transform 120ms linear;
-  }
 
-  .docs-mobile-section-nav details[open] .docs-mobile-section-caret {
-    transform: rotate(90deg);
-  }
-
-  .docs-mobile-section-menu {
+  }.docs-mobile-section-menu {
     position: absolute;
     inset-inline: 0;
     top: 100%;

--- a/site/src/styles/starlight/18-mobile-shell-closeout-b.css
+++ b/site/src/styles/starlight/18-mobile-shell-closeout-b.css
@@ -140,16 +140,10 @@
 
 @media (max-width: 49.99rem) {
   .docs-mobile-section-nav {
-    position: fixed !important;
+
     inset-inline: 0 !important;
     top: var(--sl-nav-height) !important;
-  }
-
-  html[data-mobile-scroll-direction='down'] .docs-mobile-section-nav {
-    transform: translateY(calc(-1 * var(--netscli-mobile-docs-nav-height)));
-  }
-
-  mobile-starlight-toc nav {
+  }mobile-starlight-toc nav {
     position: fixed !important;
     inset-inline: 0 !important;
     top: calc(var(--sl-nav-height) + var(--netscli-mobile-docs-nav-height)) !important;
@@ -158,14 +152,7 @@
 
   html[data-mobile-scroll-direction='down'] mobile-starlight-toc nav {
     top: var(--sl-nav-height) !important;
-  }
-
-  .main-frame {
-    padding-top: calc(
-      var(--sl-nav-height) + var(--netscli-mobile-docs-nav-height) + var(--netscli-mobile-toc-bar-height)
-    ) !important;
-  }
-}
+  }}
 
 html[data-theme='light'] .docs-mobile-section-menu,
 html[data-theme='light'] mobile-starlight-toc .dropdown {

--- a/site/src/styles/starlight/19-markdown-tables.css
+++ b/site/src/styles/starlight/19-markdown-tables.css
@@ -60,7 +60,7 @@ html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
 
 @media (max-width: 49.99rem) {
   .sl-markdown-content .netscli-table-scroll {
-    margin-block: 1rem 1.35rem !important;
+
     overflow-x: hidden !important;
     overflow-y: hidden !important;
     border: 0 !important;
@@ -69,25 +69,19 @@ html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
   }
 
   .sl-markdown-content .netscli-table-scroll table {
-    display: block !important;
+
     min-width: 0 !important;
     width: 100% !important;
     table-layout: auto !important;
     border: 0 !important;
     background: transparent !important;
-  }
+  }.sl-markdown-content .netscli-table-scroll tbody {
 
-  .sl-markdown-content .netscli-table-scroll thead {
-    display: none !important;
-  }
-
-  .sl-markdown-content .netscli-table-scroll tbody {
-    display: grid !important;
     gap: 0.75rem !important;
   }
 
   .sl-markdown-content .netscli-table-scroll tr {
-    display: grid !important;
+
     gap: 0.75rem !important;
     padding: 0.95rem 1rem !important;
     border: 1px solid rgba(140, 149, 166, 0.2) !important;
@@ -97,7 +91,7 @@ html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
 
   .sl-markdown-content .netscli-table-scroll th,
   .sl-markdown-content .netscli-table-scroll td {
-    display: block !important;
+
     width: 100% !important;
     padding: 0 !important;
     border: 0 !important;
@@ -107,7 +101,7 @@ html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
   }
 
   .sl-markdown-content .netscli-table-scroll td::before {
-    content: attr(data-label);
+
     display: block;
     margin-bottom: 0.32rem;
     color: var(--sl-color-gray-3);
@@ -130,7 +124,7 @@ html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
 .pagination-links a:focus-visible {
   background: transparent !important;
   background-image: none !important;
-  border-color: rgba(10, 174, 122, 0.28) !important;
+
   box-shadow: none !important;
 }
 html[data-theme='light'] .pagination-links a:hover,

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -34,12 +34,12 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 }
 
 .sidebar-content :where(details > ul > li) {
-  margin-inline-start: 0 !important;
+
   border-inline-start: 0 !important;
 }
 
 .sidebar-content :where(details > ul a) {
-  margin-inline-start: -1px !important;
+
   width: calc(100% + 1px) !important;
   padding-inline-start: calc(.85rem + 1px) !important;
   border-inline-start: 1px solid transparent !important;
@@ -64,7 +64,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   }
 
   .docs-topbar {
-    width: calc(100vw - 4.15rem) !important;
+
     max-width: calc(100vw - 4.15rem) !important;
     gap: 0.45rem !important;
   }
@@ -75,7 +75,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
     width: 2.5rem !important;
     max-width: 2.5rem !important;
     min-width: 2.5rem !important;
-    margin-left: auto !important;
+
     margin-right: 0.15rem !important;
   }
 
@@ -134,13 +134,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 
   .docs-mobile-section-nav details[open] .docs-mobile-section-caret {
     transform: none !important;
-  }
-
-  .docs-mobile-section-menu {
-    box-shadow: 0 18px 42px rgba(0, 0, 0, 0.34) !important;
-  }
-
-  .docs-mobile-section-menu a:hover,
+  }.docs-mobile-section-menu a:hover,
   .docs-mobile-section-menu a:focus-visible {
     color: var(--sl-color-white) !important;
     background: rgba(255, 255, 255, 0.04) !important;
@@ -191,7 +185,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 
 @media (max-width: 49.99rem) {
   .right-sidebar-container {
-    height: 0 !important;
+
     min-height: 0 !important;
     margin: 0 !important;
     padding: 0 !important;
@@ -228,7 +222,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   }
 
   site-search dialog {
-    width: min(100vw - 1rem, 48rem) !important;
+
     max-width: calc(100vw - 1rem) !important;
     min-height: min(100dvh - 1rem, 44rem) !important;
     margin: 0.5rem auto !important;
@@ -236,7 +230,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   }
 
   site-search dialog .dialog-frame {
-    display: grid !important;
+
     grid-template-columns: minmax(0, 1fr) auto !important;
     align-items: center !important;
     align-content: start !important;
@@ -250,12 +244,12 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 
   site-search dialog .search-container,
   #starlight__search {
-    grid-column: 1 / -1 !important;
+
     min-width: 0 !important;
   }
 
   site-search button[data-close-modal] {
-    grid-column: 2 !important;
+
     grid-row: 1 !important;
     align-self: start !important;
   }
@@ -299,16 +293,4 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer::before {
 
 html[data-theme='light'] #starlight__search .pagefind-ui__drawer::after {
   background: linear-gradient(0deg, rgba(244, 246, 248, 0.94), rgba(244, 246, 248, 0)) !important;
-}
-
-site-search button[data-open-modal]:hover,
-site-search button[data-open-modal]:focus-visible {
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.015)),
-    rgba(17, 22, 29, 0.9) !important;
-}
-
-html[data-theme='light'] site-search button[data-open-modal]:hover,
-html[data-theme='light'] site-search button[data-open-modal]:focus-visible {
-  background: #ffffff !important;
 }

--- a/site/src/styles/starlight/21-mobile-docs-shell-verified.css
+++ b/site/src/styles/starlight/21-mobile-docs-shell-verified.css
@@ -1,7 +1,7 @@
 /* Verified mobile/docs shell close-out. These overrides intentionally sit last
    because Starlight and earlier compatibility passes both touch these controls. */
 .sidebar-content :where(details > ul) {
-  margin-inline-start: 0.5rem !important;
+
   border-inline-start: 1px solid var(--sl-color-hairline) !important;
 }
 
@@ -11,7 +11,7 @@
 }
 
 .sidebar-content :where(details > ul a) {
-  margin-inline-start: -1px !important;
+
   width: calc(100% + 1px) !important;
   padding-inline-start: 0.75rem !important;
   border-inline-start: 2px solid transparent !important;
@@ -24,7 +24,7 @@
 }
 
 .sidebar-content :where(details > ul a[aria-current='page']) {
-  border-inline-start-color: #0aae7a !important;
+
   background: rgba(10, 174, 122, 0.12) !important;
   box-shadow: none !important;
 }
@@ -44,13 +44,7 @@
     padding: 0 !important;
     border: 0 !important;
     overflow: visible !important;
-  }
-
-  .main-frame {
-    padding-top: calc(var(--sl-nav-height) + var(--netscli-mobile-docs-nav-height)) !important;
-  }
-
-  .docs-mobile-section-nav {
+  }.docs-mobile-section-nav {
     position: fixed !important;
     inset-inline: 0 !important;
   }

--- a/site/src/styles/starlight/22-mobile-docs-correction.css
+++ b/site/src/styles/starlight/22-mobile-docs-correction.css
@@ -119,34 +119,19 @@
   .docs-topbar {
     width: calc(100vw - 3.35rem) !important;
     max-width: calc(100vw - 3.35rem) !important;
-    gap: 0.35rem !important;
-  }
 
-  .docs-header-search {
-    margin-left: auto !important;
-  }
-
-  starlight-menu-button button {
-    inset-inline-end: max(0.5rem, env(safe-area-inset-right)) !important;
-  }
-
-  site-search dialog .search-container,
+  }site-search dialog .search-container,
   #starlight__search {
-    grid-column: 1 !important;
+
     grid-row: 1 !important;
     min-width: 0 !important;
   }
 
   site-search button[data-close-modal] {
-    grid-column: 2 !important;
+
     grid-row: 1 !important;
     align-self: center !important;
-  }
-
-  #starlight__search .pagefind-ui__drawer {
-    grid-column: 1 / -1 !important;
-  }
-}
+  }}
 
 site-search button[data-open-modal]:hover,
 site-search button[data-open-modal]:focus-visible {

--- a/site/src/styles/starlight/23-regression-guardrails.css
+++ b/site/src/styles/starlight/23-regression-guardrails.css
@@ -1,6 +1,6 @@
 /* Final regression guardrails: keep these last. */
 .sidebar-content :where(details > ul) {
-  margin-inline-start: 1.15rem !important;
+
   border-inline-start: 1px solid var(--sl-color-hairline) !important;
 }
 
@@ -34,7 +34,7 @@
     margin-left: auto !important;
     margin-right: 3rem !important;
     flex: 0 0 2.75rem !important;
-    width: 2.75rem !important;
+
     max-width: 2.75rem !important;
     min-width: 2.75rem !important;
   }
@@ -48,14 +48,14 @@
   }
 
   site-search dialog {
-    width: min(100vw - 1rem, 48rem) !important;
+
     max-width: calc(100vw - 1rem) !important;
     min-height: auto !important;
     margin: 0.5rem auto !important;
   }
 
   site-search dialog .dialog-frame {
-    display: grid !important;
+
     grid-template-columns: minmax(0, 1fr) auto !important;
     gap: 0.85rem !important;
     padding: 1rem !important;

--- a/site/src/styles/starlight/24-mobile-regression-guardrails.css
+++ b/site/src/styles/starlight/24-mobile-regression-guardrails.css
@@ -1,7 +1,7 @@
 /* Final mobile/docs regression guardrails. Keep these last so Starlight and
    earlier site overrides cannot reintroduce the checked regressions. */
 .sidebar-content :where(details > ul) {
-  margin-inline-start: .5rem !important;
+
   border-inline-start: 1px solid var(--sl-color-hairline) !important;
 }
 
@@ -16,12 +16,7 @@
   background-clip: border-box !important;
 }
 
-@media (max-width: 49.99rem) {
-  .sidebar-content > sl-sidebar-state-persist {
-    display: contents !important;
-  }
-
-  .sidebar-content :where(details > ul) {
+@media (max-width: 49.99rem) {.sidebar-content :where(details > ul) {
     margin-inline-start: .5rem !important;
   }
 
@@ -33,14 +28,7 @@
 
   .docs-header-search {
     margin-inline-end: .35rem !important;
-  }
-
-  .starlight-menu-button,
-  .starlight-menu-button button {
-    margin-inline-start: .35rem !important;
-  }
-
-  .mobile-docs-trigger,
+  }.mobile-docs-trigger,
   .mobile-toc-trigger,
   .mobile-docs-bar,
   .mobile-toc-bar {
@@ -52,49 +40,32 @@
   .mobile-toc-trigger[aria-expanded="true"],
   .right-sidebar .mobile-toc-trigger,
   .right-sidebar .mobile-toc-trigger:hover {
-    background: transparent !important;
+
     border-inline-start: 0 !important;
     color: var(--sl-color-white) !important;
   }
 
   .right-sidebar :where(a:hover, a[aria-current="true"], a[aria-current="page"]) {
     background: transparent !important;
-    border-inline-start: 0 !important;
+
   }
 
   .content-panel table,
   .sl-markdown-content table {
-    display: table !important;
+
     width: max-content !important;
     min-width: 100% !important;
-  }
-
-  .content-panel thead,
-  .sl-markdown-content thead {
-    display: table-header-group !important;
-  }
-
-  .content-panel tbody,
-  .sl-markdown-content tbody {
-    display: table-row-group !important;
-  }
-
-  .content-panel tr,
-  .sl-markdown-content tr {
-    display: table-row !important;
-  }
-
-  .content-panel th,
+  }.content-panel th,
   .content-panel td,
   .sl-markdown-content th,
   .sl-markdown-content td {
-    display: table-cell !important;
+
     white-space: normal !important;
   }
 
   .content-panel td::before,
   .sl-markdown-content td::before {
-    content: none !important;
+
     display: none !important;
   }
 
@@ -111,14 +82,14 @@
   }
 
   site-search dialog {
-    width: min(100vw - 1rem, 48rem) !important;
+
     max-height: calc(100dvh - 1rem) !important;
     min-height: auto !important;
     overflow: auto !important;
   }
 
   site-search dialog .dialog-frame {
-    display: grid !important;
+
     grid-template-columns: minmax(0, 1fr) auto !important;
     grid-template-areas:
       "search close"
@@ -133,7 +104,7 @@
   site-search dialog .pagefind-ui,
   site-search dialog .pagefind-ui__form {
     grid-area: search !important;
-    width: 100% !important;
+
     max-width: none !important;
   }
 
@@ -148,7 +119,7 @@
   }
 
   site-search dialog .pagefind-ui__drawer {
-    grid-area: drawer !important;
+
     width: 100% !important;
     max-width: none !important;
     min-height: 9rem !important;
@@ -156,6 +127,6 @@
 
   site-search dialog .pagefind-ui__search-input {
     width: 100% !important;
-    max-width: none !important;
+
   }
 }

--- a/site/src/styles/starlight/25-mobile-overrides-final.css
+++ b/site/src/styles/starlight/25-mobile-overrides-final.css
@@ -3,12 +3,12 @@
 @media (max-width: 49.99rem) {
   html,
   body {
-    max-width: 100vw !important;
+
     overflow-x: hidden !important;
   }
 
   .main-frame {
-    width: 100vw !important;
+
     max-width: 100vw !important;
     min-width: 0 !important;
     padding-inline-start: 0 !important;
@@ -19,7 +19,7 @@
   .content-panel,
   .content-panel > .sl-container,
   .sl-markdown-content {
-    width: 100% !important;
+
     max-width: 100% !important;
     min-width: 0 !important;
     box-sizing: border-box !important;
@@ -38,12 +38,12 @@
   .main-pane .sl-markdown-content li,
   .main-pane .sl-heading-wrapper {
     width: 100% !important;
-    max-width: 100% !important;
+
     min-width: 0 !important;
   }
 
   .content-panel > .sl-container {
-    width: auto !important;
+
     max-width: 100vw !important;
     margin-inline: 0 !important;
     padding-inline: clamp(1rem, 5vw, 1.5rem) !important;
@@ -54,7 +54,7 @@
   }
 
   starlight-menu-button {
-    display: block !important;
+
     position: fixed !important;
     inset-block-start: .625rem !important;
     inset-inline-end: .75rem !important;
@@ -62,14 +62,14 @@
   }
 
   starlight-menu-button button {
-    position: static !important;
+
     inset: auto !important;
     width: 2.5rem !important;
     height: 2.5rem !important;
   }
 
   .docs-header-search {
-    position: fixed !important;
+
     inset-block-start: .625rem !important;
     inset-inline-end: 3.75rem !important;
     z-index: calc(var(--sl-z-index-navbar) + 2) !important;
@@ -80,7 +80,7 @@
 
   .sl-markdown-content .netscli-table-scroll,
   .content-panel .netscli-table-scroll {
-    display: block !important;
+
     width: 100% !important;
     max-width: 100% !important;
     overflow-x: auto !important;
@@ -91,7 +91,7 @@
   .sl-markdown-content .netscli-table-scroll table,
   .content-panel .netscli-table-scroll table {
     display: table !important;
-    width: max-content !important;
+
     min-width: 42rem !important;
     max-width: none !important;
     table-layout: fixed !important;

--- a/site/src/styles/starlight/27-release-qa-overrides.css
+++ b/site/src/styles/starlight/27-release-qa-overrides.css
@@ -35,7 +35,7 @@
 @media (max-width: 42rem) {
   .sl-markdown-content table,
   .content-panel table {
-    display: table !important;
+
     min-width: 42rem !important;
   }
 


### PR DESCRIPTION
## Approach

B-23: 29 stylesheets, 4,945 lines, **1,219 `!important`**, resolved purely by load order — *"no rule can be changed by editing the file that appears to own it."*

That is not something to rewrite by hand. A blind consolidation of 4,900 interdependent lines is how a site breaks silently. So this takes the **provably safe half** first.

`scripts/css-shadowing.mjs` parses every stylesheet in load order and finds declarations that can never take effect: a later rule with the **identical selector**, **identical media context**, and **at least equal importance** always wins. It never reasons about whether one selector subsumes another, so it undercounts — the right direction to be wrong in.

`scripts/css-prune.mjs` deletes those and drops any rule left empty.

## Result

| | Before | After |
|---|---|---|
| Lines | 4,945 | **4,670** |
| `!important` | 1,219 | **1,109** |

163 declarations and 46 rules removed.

## Verified, not assumed

Computed styles for **37 properties**, every element, **8 structurally distinct pages**, **both themes**, captured before and after:

```
0 differing of 8774 element-theme pairs
```

`astro check` clean. The a11y gate passes on all 14 routes in both themes.

## The verification earned its keep

The first attempt removed **370** declarations and the comparison caught a real regression: the search dialog's mobile cancel button lost its `justify-content`.

The *analysis* was right; the *pruner* was wrong. It matched declaration text file-wide, so `justify-content: center` was deleted from the first rule containing that text rather than from the rule it was flagged in. It's now scoped to the exact rule body, and **refuses rather than guessing** when it can't locate one.

That refusal is why the count dropped from 370 to 163 — the analyser strips comments, so a rule containing one no longer matches the source.

## What's left

- **207 further declarations** are provably dead but currently unreachable by the pruner (comment-bearing rules).
- The **structural** problem is untouched: the chronological `-closeout` / `-final` / `-guardrails` naming, and the ~1,100 remaining `!important`. That needs design judgement rather than a tool, and is safest once the site's shipping status is settled.

Both scripts stay in the repo so the measurement can be repeated.