### PR TITLE
Make the Tauri render suite schedule-only, and stop gating releases on it

### DIFF
--- a/.github/workflows/gui-render.yml
+++ b/.github/workflows/gui-render.yml
@@ -1,18 +1,37 @@
 name: GUI Render
 
+# Schedule and manual only — deliberately NOT on pull_request.
+#
+# This suite cannot currently pass. WebView2 Runtime 150+ ignores
+# WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS on an elevated host, which is by
+# design per Microsoft, so tauri-driver can never hand msedgedriver the
+# remote-debugging port it needs. Tracked upstream at wry#1782; there is no
+# change on our side that fixes it.
+#
+# Run per-PR it cost ~13 minutes on every PR touching the GUI or core — nine
+# of the last ten runs failed, all at the same step, for that same reason.
+# A check that cannot pass teaches everyone to ignore a red X, which is worse
+# than not running it: the next genuine failure looks identical to the noise.
+#
+# The weekly run is what tells us the day upstream fixes it, and
+# workflow_dispatch covers investigating it on demand. No coverage is lost by
+# dropping the PR trigger, because there was no passing signal to lose.
+#
+# To restore per-PR runs: confirm a green scheduled run first, then re-add
+#
+#   pull_request:
+#     branches: [main]
+#     paths:
+#       - 'apps/netscli-gui/**'
+#       - 'crates/netscli-core/**'
+#       - 'Cargo.lock'
+#       - 'Cargo.toml'
+#       - 'rust-toolchain.toml'
+#       - '.github/workflows/gui-render.yml'
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 7 * * 2'  # Tuesdays 07:00 UTC
-  pull_request:
-    branches: [main]
-    paths:
-      - 'apps/netscli-gui/**'
-      - 'crates/netscli-core/**'
-      - 'Cargo.lock'
-      - 'Cargo.toml'
-      - 'rust-toolchain.toml'
-      - '.github/workflows/gui-render.yml'
 
 concurrency:
   group: gui-render-${{ github.ref }}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -35,8 +35,16 @@ Before the first automated release runs, add these secrets at
    cargo clippy --all-targets -- -D warnings
    cargo clippy --all-targets --features pcap -- -D warnings
    cargo audit
-   cd apps/netscli-gui && npm run test:unit && npm run test:maintainability && npm run build && npm run test:tauri-render
+   cd apps/netscli-gui && npm run lint && npm run test:unit && npm run test:maintainability && npm run build
    ```
+   > **`npm run test:tauri-render` is not part of this gate right now, and a
+   > release must not block on it.** WebView2 Runtime 150+ ignores
+   > `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` on an elevated host, by design
+   > per Microsoft, so tauri-driver cannot hand msedgedriver its
+   > remote-debugging port. Tracked at wry#1782; nothing on our side fixes
+   > it. `gui-render.yml` is schedule-only for the same reason. Desktop
+   > coverage is manual until a scheduled run goes green — see the installer
+   > smoke below, which is a real check and still required.
    On Windows, PCAP-enabled source builds also need the Npcap SDK import
    library on `LIB` (for x64 MSVC, the directory containing `wpcap.lib` is
    usually `<Npcap SDK>\Lib\x64`) and `C:\Windows\System32\Npcap` on `PATH`
@@ -48,6 +56,10 @@ Before the first automated release runs, add these secrets at
 
    # Installed-binary render smoke. The render harness skips its own
    # Tauri build when TAURI_APP_PATH is set.
+   #
+   # Expected to fail today for the WebView2/wry#1782 reason noted above.
+   # Run it to see whether that has changed, but do not gate the release on
+   # it -- launch the installed app by hand instead and confirm it renders.
    $env:TAURI_APP_PATH = "C:\Program Files\NetsCLI\netscli-gui.exe"
    npm run test:tauri-render
    Remove-Item Env:\TAURI_APP_PATH


### PR DESCRIPTION
## Measured

| | |
|---|---|
| Last 10 GUI Render runs | **9 failed**, 1 cancelled |
| Time per run | **12–13 min** |
| Failing step | `Run Tauri render test` — the same one every time |

It triggered on any PR touching `apps/netscli-gui/**`, `crates/netscli-core/**` or `Cargo.*` — nearly every PR.

## Why it can't pass

WebView2 Runtime 150+ ignores `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` on an elevated host — **by design per Microsoft** — so `tauri-driver` can never hand `msedgedriver` the remote-debugging port it needs. Tracked at wry#1782. There is no change on our side that fixes it.

## Why removing it is not a loss of coverage

A check that cannot pass is worse than one that doesn't run. It puts a permanent red X on every PR and trains everyone to ignore it, so the next *genuine* failure looks identical to the noise. There was no passing signal to lose.

Kept: the weekly `cron` (tells us the day upstream fixes it) and `workflow_dispatch` (investigate on demand). The workflow header records the exact block to restore and that **a scheduled run must go green first**.

## The same bug, somewhere worse

`docs/RELEASE.md` step 3 told maintainers to run `npm run test:tauri-render` as part of the release gate — so following the documented process would **block a release on a known-broken check**. That matters right now, with v0.3.0 still uncut.

- Removed from the gate, reason inline.
- The installed-app render smoke now says to launch the app by hand instead.
- The **installer smoke stays required** — it's a real check and unaffected.
- Added the missing `npm run lint` (ESLint only landed yesterday).

Verified the full documented command line runs end to end.

## Not changed, deliberately

Worth recording what I looked at and left alone: `Swatinem/rust-cache` is already on all three Rust jobs with correctly distinct `shared-key`s per job and OS; every workflow has `concurrency` + `cancel-in-progress`; npm caching is keyed on the lockfile; release builds are already matrix-reduced to ubuntu-only on PRs; and the `changes` job path-gates everything.

The 3-OS test matrix stays — this is a cross-platform network tool and platform code is where the bugs are (B-37 was Windows-only). The separate pcap clippy run stays too; it caught a real break in #169.