### PR TITLE
Show phones the right OS, and truncate long commands instead of wrapping

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -464,25 +464,17 @@ const { hero, social, version } = site;
   .hero .quick-install span{white-space:normal;overflow:visible;text-overflow:clip;word-break:break-all}
 }
 
-/* Narrow screens: wrap the hero command instead of clipping it.
+/* Narrow screens: the hero command stays on one line and ellipsises.
  *
- * `.hero-command code` is `nowrap` + `text-overflow:ellipsis`, which at
- * 375px meant 251px of box for 631px of text -- more than half of the
- * `curl ... | bash` one-liner a first-time visitor is being asked to run was
- * simply not visible. The copy button still copied all of it, which makes it
- * worse rather than better: you cannot see what you are about to paste into
- * a shell.
+ * Deliberate: the `curl … | bash` URL is long enough to wrap to four lines
+ * at 375px, which turns the hero's tightest element into its tallest. The
+ * copy button carries the full string, so nothing is lost — and unlike the
+ * install boxes below, this one never had text hidden under the button,
+ * because `.hero-command` is not a scroller. Its `padding-right:58px` means
+ * the ellipsis lands clear of the button.
  *
- * Here rather than in global.css for the cascade reason noted in
- * Install.astro.
+ * Worth stating the tradeoff, since this is a shell one-liner: a truncated
+ * command means copying something you have not fully read. The copy button
+ * is the intended path and the full command is in the install guide.
  */
-@media(max-width:700px){
-  .hero-command code{
-    white-space:pre-wrap;
-    overflow:visible;
-    text-overflow:clip;
-    overflow-wrap:anywhere;
-  }
-  .hero-command .copy-btn{top:7px;transform:none}
-}
 </style>

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -276,34 +276,33 @@ a.install-download:hover{color:#23d198;background:rgba(10,174,122,.08)}
 }
 .surface-download-btn:hover .dl-hint{color:#9a9a9a}
 
-/* Narrow screens: wrap commands instead of scrolling them sideways.
+/* Narrow screens: truncate long commands, do not scroll them sideways.
  *
- * `.cmd` is itself the horizontal scroller (`overflow-x:auto;
- * white-space:pre`) and the copy button is absolutely positioned inside it.
- * Overflowing inline content paints straight across a scroll container's
- * right padding, so the `padding-right:74px` above reserved nothing --
- * measured at 375px wide, 38px of `winget install fstubner.netscli.gui`
- * rendered underneath an opaque button, with a scrollbar beneath it.
+ * The bug being fixed is the sideways scroll, not the truncation. `.cmd` was
+ * itself the horizontal scroller (`overflow-x:auto; white-space:pre`) with
+ * the copy button absolutely positioned inside it, and overflowing inline
+ * content paints straight across a scroll container's right padding -- so
+ * the `padding-right:74px` above reserved nothing. Measured at 375px, 38px
+ * of `winget install fstubner.netscli.gui` rendered underneath an opaque
+ * button, with a scrollbar beneath it.
  *
- * Wrapping fixes it without moving the button: once the text no longer
- * overflows it respects padding-right normally. It also makes the whole
- * command readable, which sideways scrolling in a 279px box never did, and
- * it matches what the Scoop and PowerShell rows already do.
+ * `overflow:hidden` + `text-overflow:ellipsis` clips at the *content* box
+ * instead, so the ellipsis lands before the padding and the button sits in
+ * clear space. No scrollbar, nothing hidden underneath, and the layout stays
+ * one line per command -- matching the hero.
  *
- * This lives here rather than in global.css because global.css is imported
- * before component styles, so an override there loses the cascade tie to
- * the `.cmd` rules above and silently does nothing.
+ * The copy button carries the full command either way.
+ *
+ * Lives here rather than in global.css: global.css is imported before
+ * component styles, so an override there loses the cascade tie to the `.cmd`
+ * rules above and silently does nothing.
  */
 @media(max-width:700px){
   .cmd,
   .cmd.big{
-    white-space:pre-wrap;
-    overflow-x:visible;
-    overflow-wrap:anywhere;
-    word-break:normal;
+    white-space:nowrap;
+    overflow:hidden;
+    text-overflow:ellipsis;
   }
-  /* Centred is right for a one-line box; on a wrapped box the button has to
-     sit at the top so it never lands mid-command. */
-  .cmd.has-copy .copy-btn{top:7px;transform:none}
 }
 </style>

--- a/site/src/scripts/landing-page.ts
+++ b/site/src/scripts/landing-page.ts
@@ -190,10 +190,26 @@ export function initLandingPage(repo: string): void {
         navigatorWithUaData.userAgentData?.platform ||
         navigator.userAgent ||
         "";
+      // Mobile and Chrome OS have to be matched explicitly.
+      //
+      // UA-CH reports `platform` as one of a small fixed set: "Windows",
+      // "macOS", "Linux", "Android", "Chrome OS", "iOS". The previous three
+      // tests covered only the first three, so Android, iOS and Chrome OS
+      // all fell through to the `"macos"` default -- every phone visitor was
+      // shown the macOS install tab and offered a .dmg from the hero button.
+      // Confirmed on a Pixel 8 UA, where `platform` is exactly "Android".
+      //
+      // Apple's mobile platforms group with macOS, and Android/Chrome OS
+      // with Linux. Neither can actually run NetsCLI, so the goal is only to
+      // show the least wrong thing to someone browsing on a phone and to
+      // stop claiming a Mac is involved when it is not.
+      //
+      // `cros` is matched before `linux` deliberately: Chrome OS is
+      // Linux-based and some UA strings contain both.
       const detected: OperatingSystem = /win/i.test(ua) ? "windows"
-        : /mac/i.test(ua) ? "macos"
-        : /linux/i.test(ua) ? "linux"
-        : "macos";
+        : /mac|ios|iphone|ipad/i.test(ua) ? "macos"
+        : /android|cros|chrome\s?os|linux/i.test(ua) ? "linux"
+        : "windows";
       setOS(detected);
 
       const packageInstall = document.getElementById("hero-package-install");


### PR DESCRIPTION
Two findings from a touch-emulation pass. The earlier mobile testing ran at 375px wide but with `isMobile:false, hasTouch:false` — a narrow desktop browser, not a device — so `hover:none` rules never applied and UA-CH reported a desktop platform. **Neither of these is visible without real device emulation.**

## 1. Every phone visitor was shown macOS

UA-CH reports `navigator.userAgentData.platform` from a fixed set. The detection tested three of the six:

| platform reports | before | after |
|---|---|---|
| Windows / macOS / Linux | correct | correct |
| **Android** | **macOS** | Linux |
| **Chrome OS** | **macOS** | Linux |
| **iOS** | **macOS** | macOS (now explicit) |
| unknown | macOS | Windows |

Confirmed on a Pixel 8, where `platform` is exactly `"Android"`: the install panel opened on the **macOS tab** and the hero button offered `netscli-gui-macos-x86_64.dmg`. After the fix, same UA gives the Linux tab and an `.AppImage`.

Apple's mobile platforms group with macOS, Android and Chrome OS with Linux. Neither can actually run NetsCLI, so the goal is to show the least wrong thing and stop claiming a Mac is involved. The unknown fallback moves to Windows — it should be the most likely desktop, not the least.

## 2. Long commands truncate again instead of wrapping

The previous PR made them wrap. That was the wrong call, and it's worth being precise about why: **the hero ellipsis was deliberate design, not a defect.** Wrapping turned the hero's tightest element into its tallest — the `curl` one-liner ran to four lines at 375px.

The actual bug was never the truncation. `.cmd` is itself a horizontal scroller (`overflow-x:auto; white-space:pre`) with the copy button absolutely positioned inside it, and overflowing content paints across a scroll container's right padding — so text rendered *underneath* an opaque button, with a scrollbar beneath it.

`overflow:hidden` + `text-overflow:ellipsis` fixes that without wrapping: the ellipsis is placed at the **content** box, so it lands before the padding and clear of the button.

Measured on the deployed build, every command box:

| | ellipsis clear of button by |
|---|---|
| hero boxes | 18px |
| install boxes | 37px |

No scrollbar, nothing under the button, one line per command.

**Tradeoff, stated plainly:** a truncated `curl … | bash` means copying something not fully read. The copy button carries the full string and the install guide has it in full.

## Verification

`astro check` clean · build passes · a11y gate 14 routes × both themes, 0 violations · file-size guard clean · verified on the deployed preview under Pixel 8 emulation.
