### PR TITLE
Copy only the commands, and give each OS its own hero commands

### DIFF
--- a/site/src/scripts/landing-page.ts
+++ b/site/src/scripts/landing-page.ts
@@ -1,3 +1,4 @@
+import { initCopyButtons } from "./landing/copy-buttons";
 import { initScreenshotLightbox } from "./landing/lightbox";
 
 interface GitHubAsset {
@@ -89,59 +90,7 @@ export function initLandingPage(repo: string): void {
         .catch(() => {});
     })();
 
-    // Copy buttons on every .has-copy block and FAQ command row.
-    document.querySelectorAll<HTMLElement>(".has-copy, .faq-command").forEach((el) => {
-      if (el.querySelector(":scope > .copy-btn")) return;
-      const btn = document.createElement("button");
-      btn.className = "copy-btn";
-      btn.type = "button";
-      btn.setAttribute("aria-label", "Copy command");
-      btn.title = "Copy command";
-      const copyIcon = `
-        <svg aria-hidden="true" viewBox="0 0 16 16" focusable="false">
-          <path d="M5.5 2.5h7v9h-7z"></path>
-          <path d="M3.5 4.5h-1v9h7v-1"></path>
-        </svg>
-      `;
-      const copiedIcon = `
-        <svg aria-hidden="true" viewBox="0 0 16 16" focusable="false">
-          <path d="M3 8.2 6.1 11 13 4"></path>
-        </svg>
-      `;
-      btn.innerHTML = copyIcon;
-      btn.addEventListener("click", (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        let t = el.dataset.copy
-          || el.querySelector("code")?.textContent?.trim()
-          || el.textContent?.trim()
-          || "";
-        if (el.classList.contains("codeblock") || el.classList.contains("tryblock")) {
-          t = t
-            .split("\n")
-            .map((line: string) => line.replace(/^\$\s*/, "").replace(/\s*\/\/.*$/, "").trim())
-            .filter(Boolean)
-            .join("\n");
-        }
-        navigator.clipboard.writeText(t).then(() => {
-          btn.innerHTML = copiedIcon;
-          btn.classList.add("copied");
-          btn.setAttribute("aria-label", "Copied");
-          btn.title = "Copied";
-          setTimeout(() => {
-            btn.innerHTML = copyIcon;
-            btn.classList.remove("copied");
-            btn.setAttribute("aria-label", "Copy command");
-            btn.title = "Copy command";
-          }, 2500);
-        }).catch(() => {
-          btn.setAttribute("aria-label", "Copy failed");
-          btn.title = "Copy failed";
-        });
-      });
-      el.appendChild(btn);
-    });
-
+    initCopyButtons();
     initScreenshotLightbox();
 
     // OS tab swap. Keep visual state and ARIA state aligned so package
@@ -212,18 +161,49 @@ export function initLandingPage(repo: string): void {
         : "windows";
       setOS(detected);
 
-      const packageInstall = document.getElementById("hero-package-install");
-      if (packageInstall) {
-        const packageCommands: Record<OperatingSystem, string> = {
-          windows: "winget install fstubner.netscli",
-          macos: "brew tap fstubner/tap && brew install netscli",
-          linux: "curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash",
-        };
-        const packageCommand = packageCommands[detected];
-        packageInstall.dataset.copy = packageCommand;
-        const code = packageInstall.querySelector("code");
-        if (code) code.textContent = packageCommand;
-      }
+      // Both hero command boxes are OS-aware, and they must differ.
+      //
+      // Only the second box used to be. The first held `hero.quickInstall`
+      // -- the `curl … install.sh | bash` line -- for everyone, which made
+      // two separate problems:
+      //
+      //   Windows: the most prominent command on the page was a bash
+      //   pipeline that does not run there, with the correct `winget` line
+      //   demoted to the smaller box below it.
+      //
+      //   Linux: `packageCommands.linux` was byte-identical to
+      //   `hero.quickInstall`, so the hero printed the same command twice.
+      //
+      // Primary is whatever the install section recommends for that
+      // platform, so the hero and "Get started" agree; secondary is a
+      // genuinely different route.
+      const heroCommands: Record<OperatingSystem, { primary: string; secondary: string }> = {
+        windows: {
+          primary: "winget install fstubner.netscli",
+          secondary:
+            "iwr -useb https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.ps1 | iex",
+        },
+        macos: {
+          primary: "brew tap fstubner/tap && brew install netscli",
+          secondary:
+            "curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash",
+        },
+        linux: {
+          primary:
+            "curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash",
+          secondary: "yay -S netscli-bin",
+        },
+      };
+
+      const setHeroCommand = (id: string, command: string) => {
+        const host = document.getElementById(id);
+        if (!host) return;
+        host.dataset.copy = command;
+        const code = host.querySelector("code");
+        if (code) code.textContent = command;
+      };
+      setHeroCommand("hero-quick-install", heroCommands[detected].primary);
+      setHeroCommand("hero-package-install", heroCommands[detected].secondary);
 
       const desktopDownload = document.querySelector<HTMLAnchorElement>("#hero-desktop-download");
       if (desktopDownload) {

--- a/site/src/scripts/landing/copy-buttons.ts
+++ b/site/src/scripts/landing/copy-buttons.ts
@@ -1,0 +1,86 @@
+/**
+ * Copy-to-clipboard buttons for every `.has-copy` block and FAQ command row.
+ *
+ * Split out of `landing-page.ts` to keep that file under the 300-line
+ * guard. It is a self-contained concern: it owns the button markup, the
+ * copied/failed states, and — the fiddly part — deciding what a given block
+ * should actually put on the clipboard.
+ */
+export function initCopyButtons(): void {
+    document.querySelectorAll<HTMLElement>(".has-copy, .faq-command").forEach((el) => {
+    if (el.querySelector(":scope > .copy-btn")) return;
+    const btn = document.createElement("button");
+    btn.className = "copy-btn";
+    btn.type = "button";
+    btn.setAttribute("aria-label", "Copy command");
+    btn.title = "Copy command";
+    const copyIcon = `
+      <svg aria-hidden="true" viewBox="0 0 16 16" focusable="false">
+        <path d="M5.5 2.5h7v9h-7z"></path>
+        <path d="M3.5 4.5h-1v9h7v-1"></path>
+      </svg>
+    `;
+    const copiedIcon = `
+      <svg aria-hidden="true" viewBox="0 0 16 16" focusable="false">
+        <path d="M3 8.2 6.1 11 13 4"></path>
+      </svg>
+    `;
+    btn.innerHTML = copyIcon;
+    btn.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      let t = el.dataset.copy
+        || el.querySelector("code")?.textContent?.trim()
+        || el.textContent?.trim()
+        || "";
+      if (el.classList.contains("codeblock") || el.classList.contains("tryblock")) {
+        // Copy the commands, not the sample output shown beneath them.
+        //
+        // Every non-empty line used to be kept, `$` stripped, and the lot
+        // joined. On the CLI example that meant a button labelled "Copy
+        // command" produced the two commands *plus* the JSON they print:
+        //
+        //     netscli scan demo.local -p 80,443 --json
+        //     [
+        //       { "port": 80,  "open": true, "service": "http"  },
+        //     ...
+        //
+        // Pasted into a shell that runs the scan, then tries to execute
+        // `[`, `{ "port": 80… }` and `]`.
+        //
+        // So: if a block uses `$` prompts, those lines are the commands
+        // and everything else is output — take only them. A block with no
+        // prompts (the MCP config JSON) is content in its own right, so
+        // copy it whole, dropping only `//` comment lines. Preserving
+        // those lines verbatim also keeps the JSON's indentation, which
+        // the old per-line `.trim()` flattened.
+        const lines = t.split("\n");
+        const prompted = lines.filter((line: string) => /^\s*\$\s+/.test(line));
+        t = (prompted.length > 0
+          ? prompted.map((line: string) => line.replace(/^\s*\$\s+/, "").trim())
+          : lines.filter((line: string) => !/^\s*\/\//.test(line)).map((line: string) => line.replace(/\s+$/, ""))
+        )
+          .filter((line: string, i: number, all: string[]) => line.trim() !== "" || (i > 0 && i < all.length - 1))
+          .join("\n")
+          .trim();
+      }
+      navigator.clipboard.writeText(t).then(() => {
+        btn.innerHTML = copiedIcon;
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", "Copied");
+        btn.title = "Copied";
+        setTimeout(() => {
+          btn.innerHTML = copyIcon;
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", "Copy command");
+          btn.title = "Copy command";
+        }, 2500);
+      }).catch(() => {
+        btn.setAttribute("aria-label", "Copy failed");
+        btn.title = "Copy failed";
+      });
+    });
+    el.appendChild(btn);
+  });
+
+}


### PR DESCRIPTION
Three defects from an independent acceptance pass over the deployed site — a session that had not seen the code and was told to try to break it.

## 1. "Copy command" copied the sample output as well

The codeblock branch kept every non-empty line, stripped `$`, and joined the lot. On the CLI example that produced the two commands **plus the JSON they print**. Pasting into a shell ran the scan, then tried to execute `[`, `{ "port": 80, … }`, `]` and three hostnames.

A block that uses `$` prompts now yields only those lines. A block with no prompts (the MCP config JSON) is copied whole, minus `//` comment lines — and preserving those lines verbatim also keeps the JSON's indentation, which the old per-line `.trim()` flattened.

Verified by wrapping `navigator.clipboard.writeText` on the deployed page and capturing the real payload, the same technique the acceptance session used:

```
CLI block -> netscli scan demo.local -p 80,443 --json
             netscli discover --json | jq '.[].hostname'
MCP block -> the full JSON, indentation intact
```

## 2. Windows visitors were led with a bash pipeline

The first and most prominent hero box always held `hero.quickInstall` (`curl … install.sh | bash`), whatever the platform. On Windows that is the one command on the page that **cannot run**, with the correct `winget` line demoted to the smaller box beneath it.

## 3. Linux visitors saw the same command twice

`packageCommands.linux` was byte-identical to `hero.quickInstall`, so both hero boxes printed the same `curl … | bash`.

Both boxes are now OS-aware and always differ. Primary is whatever the install section recommends for that platform, so the hero and "Get started" agree; secondary is a genuinely different route:

| | primary | secondary |
|---|---|---|
| Windows | `winget install fstubner.netscli` | `iwr … install.ps1 \| iex` |
| macOS | `brew tap … && brew install netscli` | `curl … install.sh \| bash` |
| Linux | `curl … install.sh \| bash` | `yay -S netscli-bin` |

Verified on the deployed build: a Windows UA gives winget + iwr, an Android UA (which now resolves to Linux) gives curl + yay, neither duplicated.

## Refactor

Copy-button setup moved to `landing/copy-buttons.ts` — `landing-page.ts` crossed the 300-line guard, and this is a self-contained concern owning the button markup, its states, and the what-to-copy decision.

Re-verified **after** the split, since that is where this kind of move breaks: all 37 buttons still inject, both payloads are still correct, and the lightbox still opens and closes.

## Verification

`astro check` clean, build passes, a11y gate 14 routes x both themes 0 violations, file-size guard clean.
