### PR TITLE
Keep Packet Capture visible, with setup guidance, on builds without it

### DIFF
--- a/apps/netscli-gui/src/hooks/useTauriRuntimeState.ts
+++ b/apps/netscli-gui/src/hooks/useTauriRuntimeState.ts
@@ -94,9 +94,25 @@ export function useTauriRuntimeState() {
     }
   }
 
+  // Packet Capture stays in the menu even on a build without the feature.
+  //
+  // It used to be filtered out, which is why the docs disagreed with each
+  // other: `docs/install.md` and `docs/RELEASE.md` both say the tool appears
+  // and presents setup guidance, while the app removed it entirely. Since no
+  // published installer is built with `--features pcap`, every real user got
+  // the hidden version — they went looking for packet capture, found no
+  // trace of it, and no explanation of why.
+  //
+  // Nothing else is needed to make this safe. The pane already renders
+  // `PcapUnavailableState` whenever the capability is unavailable, and
+  // `runDisabledReason` in App.tsx already disables Run for the same
+  // condition, so the tool is visible, explains itself, and stays
+  // non-runnable — which is what RELEASE.md specifies.
+  //
+  // mDNS keeps the capability check: it is on by default in every published
+  // build, so hiding it means the feature genuinely is not there.
   const toolCapabilities: ToolCapabilityMap = {
     mdns: mdnsCapability.compiled,
-    pcap: pcapCapability.compiled,
   };
 
   return {

--- a/apps/netscli-gui/src/tools/registry.test.ts
+++ b/apps/netscli-gui/src/tools/registry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { availableToolKinds, LOOKUP_TOOL_KINDS } from './registry';
+import type { ToolCapabilityMap } from './types';
+
+/**
+ * Packet Capture must stay reachable on builds without the feature.
+ *
+ * This is the behaviour three documents already specified and the app did
+ * not: `docs/RELEASE.md` says the GUI "may still show the Packet Capture
+ * tool, but it must present setup guidance and remain non-runnable", and the
+ * install docs say the same. The menu filtered it out instead, and because no
+ * published installer ships `--features pcap`, that was what every real user
+ * got — the feature simply absent, with nothing explaining why.
+ *
+ * The guidance pane and the disabled Run button are both keyed on the
+ * capability separately, so keeping the entry visible is safe. This test
+ * exists because the regression is silent: hiding a menu item again would
+ * break no other test and show up only as a missing feature.
+ */
+describe('availableToolKinds', () => {
+  it('keeps Packet Capture listed when the build has no pcap support', () => {
+    // What useTauriRuntimeState produces on a published build: mdns compiled,
+    // pcap absent from the map entirely.
+    const capabilities: ToolCapabilityMap = { mdns: true };
+    expect(availableToolKinds(LOOKUP_TOOL_KINDS, capabilities)).toContain('pcap');
+  });
+
+  it('still hides a tool that is explicitly unavailable', () => {
+    // The filter itself must keep working — mdns is the case that legitimately
+    // uses it, when a build genuinely lacks the feature.
+    const capabilities: ToolCapabilityMap = { mdns: false };
+    const kinds = availableToolKinds(LOOKUP_TOOL_KINDS, capabilities);
+    expect(kinds).not.toContain('mdns');
+    expect(kinds).toContain('pcap');
+  });
+
+  it('treats an unlisted tool as available', () => {
+    expect(availableToolKinds(LOOKUP_TOOL_KINDS, {})).toEqual(LOOKUP_TOOL_KINDS);
+  });
+});

--- a/site/src/content/docs/docs/interface-coverage.md
+++ b/site/src/content/docs/docs/interface-coverage.md
@@ -57,5 +57,5 @@ Most NetsCLI operations work in the standard published builds. A few capabilitie
 
 - Packet Capture appears only in builds that include packet-capture support. Capturing packets also needs Npcap on Windows or libpcap on Linux/macOS.
 - mDNS discovery is included in the published CLI, desktop app, and MCP server. Library consumers can still build `netscli-core` without the `mdns` feature if they need a leaner dependency set.
-- The desktop app hides tools that are not available in the current build.
+- The desktop app keeps Packet Capture visible even in builds without capture support, and shows setup guidance in place of results. Tools whose feature is genuinely absent from the build, such as mDNS discovery, are hidden.
 - If a runtime dependency is missing, NetsCLI keeps the rest of the app usable and explains what to install for that feature.

--- a/site/src/content/docs/docs/packet-capture.md
+++ b/site/src/content/docs/docs/packet-capture.md
@@ -21,7 +21,7 @@ Run `netscli doctor` to check which build you have. It works on every build, unl
 | Linux | libpcap installed and capture permissions granted. |
 | macOS | libpcap available and capture permissions granted where required. |
 
-If the desktop build does not include packet capture support, the Packet Capture tool is hidden. If support is included but the runtime library or permissions are missing, NetsCLI keeps the rest of the app usable and shows setup guidance for packet capture.
+The Packet Capture tool stays visible in the desktop app either way. If the build does not include packet capture support, or support is included but the runtime library or permissions are missing, the tool opens and shows setup guidance instead of running. The rest of the app is unaffected.
 
 ## CLI Capture
 


### PR DESCRIPTION
An acceptance pass found the docs contradicting each other: two pages said the desktop app **hides** the Packet Capture tool on builds without capture support, one said it **appears and shows setup guidance**.

They weren't really contradicting each other. Each was describing one of two different states as if it were universal — and the app implemented the wrong one for the case every user actually hits.

## The app was hiding it

```
toolCapabilities.pcap = pcapCapability.compiled   // false on published builds
availableToolKinds()  → filtered the tool out of the menu entirely
```

No published installer is built with `--features pcap`, so in practice the tool was **always** hidden. Someone looking for packet capture found no trace of it and no explanation of why.

`PcapUnavailableState` — the guidance screen — was only reachable for an already-open tab, which you could not open.

## RELEASE.md had specified the intent all along

> The GUI may still show the Packet Capture tool, but it must present setup guidance and remain non-runnable unless the backend is PCAP-capable…

The app now does that.

## The fix is to stop filtering, and nothing else

Both halves of the intended behaviour were already implemented and keyed on the capability separately:

- the pane renders `PcapUnavailableState` whenever the capability is unavailable
- `runDisabledReason` in `App.tsx` already disables Run on the same condition

So the tool is visible, explains itself, and stays non-runnable.

mDNS keeps its capability check — it's on by default in every published build, so hiding it means the feature genuinely isn't there.

## Docs

`packet-capture.md` and `interface-coverage.md` now describe the tool as visible with guidance, matching `install.md` and `RELEASE.md`. All four sources finally agree with the code.

## Test

`registry.test.ts` pins it, because this regression is silent — re-adding the filter would break no other test and would surface only as a missing feature. Confirmed it fails against the old capability map before keeping it:

```
× keeps Packet Capture listed when the build has no pcap support
  AssertionError: expected [ 'dns', 'reverse', 'mdns', …(2) ] to include 'pcap'
```

## Verification

97 GUI tests pass, lint 0 errors, `astro check` clean, site build passes, file-size guard clean.

Not verifiable here: the running desktop app. The Tauri render suite is schedule-only and can't pass on this host, so the visible-in-menu behaviour is covered by the unit test and by reading the two code paths that were already in place, not by launching the app.
