### PR TITLE
Scope the packet-capture claims to what is actually published

### DIFF
--- a/site/src/content/docs/docs/packet-capture.md
+++ b/site/src/content/docs/docs/packet-capture.md
@@ -5,8 +5,8 @@ description: NetsCLI packet capture support, runtime requirements, output format
 
 Packet capture is optional. It needs a build with packet-capture support and a system packet-capture library.
 
-:::caution[No published build has packet capture]
-It is a compile-time feature, and every published artifact — the desktop installers, the standard CLI release assets, and `cargo install netscli` — is built without it. Nothing on this page will work until you install a capture-capable build. See [Packet capture in the install guide](/docs/install/#packet-capture) for the three ways to get one.
+:::caution[The default builds have no packet capture]
+It is a compile-time feature. The desktop installers, the standard CLI release assets, and `cargo install netscli` are all built without it, so nothing on this page will work until you install a capture-capable build. The `-pcap` CLI assets on each release *are* built with it — see [Packet capture in the install guide](/docs/install/#packet-capture) for the three ways to get one.
 
 Run `netscli doctor` to check which build you have. It works on every build, unlike `netscli pcap --check` below.
 :::

--- a/site/src/data/site-content/hero.ts
+++ b/site/src/data/site-content/hero.ts
@@ -9,7 +9,14 @@ export const hero: Hero = {
   badge: 'Windows · Linux · macOS',
   heading: 'A modern network scanner',
   subhead:
-    'Discover LAN devices, scan TCP ports, query DNS, trace routes, inspect hosts, and capture packets from the desktop app, terminal UI, CLI, or MCP server. Each interface calls the same Rust core, so results stay consistent.',
+    // Packet capture is scoped deliberately. Listing it alongside the other
+    // operations claimed it works "from the desktop app, terminal UI, CLI, or
+    // MCP server", and no published desktop installer has capture compiled in
+    // at all -- a visitor could install from this page, go looking for it, and
+    // find nothing. The capture-enabled CLI assets are real and published, so
+    // the feature stays on the page; it just no longer implies the download
+    // above it includes it.
+    'Discover LAN devices, scan TCP ports, query DNS, trace routes, and inspect hosts from the desktop app, terminal UI, CLI, or MCP server — with packet capture in capture-enabled CLI builds. Each interface calls the same Rust core, so results stay consistent.',
   quickInstall:
     'curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash',
   installLinkLabel: 'More install options ↓',

--- a/site/src/data/site-content/meta.ts
+++ b/site/src/data/site-content/meta.ts
@@ -5,8 +5,12 @@ export const meta: Meta = {
   title: 'NetsCLI - Modern Network Scanner and Diagnostics Toolkit',
   description:
     'NetsCLI is a Rust-based network scanner for LAN discovery, TCP port scans, DNS, trace routes, host inspection, packet capture, and desktop, terminal, CLI, and MCP workflows.',
+  // Same scoping as the hero subhead: capture is not in any published desktop
+  // installer, so this must not imply it ships with the app. It is what search
+  // results and link previews show, which is where an inaccurate claim travels
+  // furthest.
   ogDescription:
-    'Discover LAN devices, scan TCP ports, query DNS, trace routes, inspect hosts, and capture packets from the desktop app, terminal UI, CLI, or MCP server backed by one Rust core.',
+    'Discover LAN devices, scan TCP ports, query DNS, trace routes, and inspect hosts from the desktop app, terminal UI, CLI, or MCP server backed by one Rust core. Packet capture in capture-enabled CLI builds.',
   keywords:
     'network scanner, rust, cli, tui, mcp server, model context protocol, port scan, host discovery, dns lookup, arp table, bonjour, mdns, packet capture, claude, cursor, ai agent, network tool, cross-platform',
   siteName: 'NetsCLI',


### PR DESCRIPTION
Two claims were wrong, **in opposite directions**.

## The landing page oversold it

The hero subhead and the Open Graph description both listed capture alongside the other operations — "from the desktop app, terminal UI, CLI, or MCP server".

No published desktop installer is built with `--features pcap` at all. A visitor could install from that page, go looking for packet capture, and find nothing. The acceptance pass followed exactly that path.

## The docs undersold it

`packet-capture.md` was headed **"No published build has packet capture"**, which isn't true. `release.yml` publishes capture-enabled assets on every release:

```
netscli-linux-x86_64-pcap
netscli-linux-aarch64-pcap
netscli-windows-x86_64-pcap.exe
netscli-macos-x86_64-pcap
```

The body of that same callout was already precise — "the desktop installers, the standard CLI release assets, and `cargo install netscli`" — so only the heading overstated. And it contradicted `install.md`, which documents the `-pcap` assets as one of the three ways to get capture.

## The fix

Capture stays on the landing page, because it's a real published capability. It's just scoped to where it actually exists.

**Hero subhead / `ogDescription`:**

> … and inspect hosts from the desktop app, terminal UI, CLI, or MCP server — **with packet capture in capture-enabled CLI builds.**

**`packet-capture.md`:** heading becomes "The default builds have no packet capture", and the body now names the `-pcap` assets as the ones that do.

## Deliberately unchanged

The `description` meta tag and the keyword list still mention packet capture unqualified. That's accurate — the product has the feature — and neither is a claim about what a given download contains.

## Verification

`astro check` clean, build passes, a11y gate 14 routes × both themes 0 violations, and the rendered hero checked on the deployed preview at 1280px.
