### PR TITLE
Stop the ARP read blocking the runtime, and the release check refiring

### DIFF
--- a/apps/netscli-cli/src/cli_dispatch.rs
+++ b/apps/netscli-cli/src/cli_dispatch.rs
@@ -97,7 +97,7 @@ pub(crate) async fn run_command(command: &Commands, ctx: CommandContext<'_>) -> 
             json,
             yaml,
         } => {
-            arp::run(ctx, *add, *delete, *clear, ip, mac, *json, *yaml)?;
+            arp::run(ctx, *add, *delete, *clear, ip, mac, *json, *yaml).await?;
         }
         #[cfg(feature = "pcap")]
         Commands::Pcap {

--- a/apps/netscli-cli/src/cli_dispatch/arp.rs
+++ b/apps/netscli-cli/src/cli_dispatch/arp.rs
@@ -8,7 +8,7 @@ use std::net::IpAddr;
 use std::str::FromStr;
 
 #[allow(clippy::too_many_arguments)]
-pub(super) fn run(
+pub(super) async fn run(
     ctx: CommandContext<'_>,
     add: bool,
     delete: bool,
@@ -91,7 +91,7 @@ pub(super) fn run(
         return Ok(());
     }
 
-    let entries = ctx.ops.get_arp_table()?;
+    let entries = ctx.ops.get_arp_table().await?;
     match format {
         OutputFormat::Json | OutputFormat::Yaml => print_structured(format, &entries)?,
         OutputFormat::Text => {

--- a/apps/netscli-cli/src/tui/events/network.rs
+++ b/apps/netscli-cli/src/tui/events/network.rs
@@ -41,7 +41,7 @@ pub(super) async fn handle_arp(parts: &[&str], ops: &Ops) -> Vec<Line<'static>> 
             Ok(_) => out.push(Line::from("Cleared ARP table")),
             Err(e) => out.push(Formatter::format_error(&format!("Error: {}", e))),
         },
-        _ => match ops.get_arp_table() {
+        _ => match ops.get_arp_table().await {
             Ok(entries) => {
                 out.extend(Formatter::format_arp_table(&entries));
             }

--- a/apps/netscli-gui/src-tauri/src/commands/operations/lookup.rs
+++ b/apps/netscli-gui/src-tauri/src/commands/operations/lookup.rs
@@ -113,7 +113,7 @@ pub(crate) async fn get_arp_table(
 ) -> JsonResult {
     run_json_operation(op_id, manager, None, move || async move {
         let ops = Ops::default();
-        let entries = ops.get_arp_table().map_err(|e| e.to_string())?;
+        let entries = ops.get_arp_table().await.map_err(|e| e.to_string())?;
         serde_json::to_value(entries).map_err(|e| e.to_string())
     })
     .await

--- a/apps/netscli-gui/src/hooks/useReleaseNotifications.test.tsx
+++ b/apps/netscli-gui/src/hooks/useReleaseNotifications.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+//
+// Needs a DOM because renderHook mounts a component tree; the default
+// environment here is node, opted out per-file.
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useReleaseNotifications } from './useReleaseNotifications';
+
+vi.mock('../services/releases', () => ({
+  fetchLatestRelease: vi.fn(() => new Promise(() => {})), // never settles; we only count calls
+  isNewerVersion: () => false,
+}));
+
+const { fetchLatestRelease } = await import('../services/releases');
+
+/**
+ * The release check must fire once, not once per render.
+ *
+ * `showUpdateToast` and `dismissToast` are plain functions from
+ * `useWorkspaceToast`, so every render gives them new identities. While they
+ * were effect dependencies, each render aborted the in-flight request and
+ * started another — roughly one request to api.github.com per progress event
+ * during a scan, against an unauthenticated limit of 60 an hour.
+ *
+ * A re-render is exactly what this asserts, because the bug is invisible
+ * otherwise: the feature works, it just quietly exhausts the rate limit.
+ */
+describe('useReleaseNotifications', () => {
+  beforeEach(() => {
+    vi.mocked(fetchLatestRelease).mockClear();
+  });
+
+  const options = (overrides: Partial<Parameters<typeof useReleaseNotifications>[0]> = {}) => ({
+    appVersion: '0.3.0',
+    enabled: true,
+    dismissToast: () => {},
+    // A fresh function identity each call, as the real hook produces.
+    showUpdateToast: (_version: string, _url: string) => {},
+    toast: null,
+    ...overrides,
+  });
+
+  it('checks once across many re-renders with new callback identities', () => {
+    const { rerender } = renderHook(() => useReleaseNotifications(options()));
+    expect(fetchLatestRelease).toHaveBeenCalledTimes(1);
+
+    for (let i = 0; i < 12; i += 1) rerender();
+
+    expect(fetchLatestRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not check at all when release notifications are disabled', () => {
+    renderHook(() => useReleaseNotifications(options({ enabled: false })));
+    expect(fetchLatestRelease).not.toHaveBeenCalled();
+  });
+
+  it('re-checks when the app version changes', () => {
+    let version = '0.3.0';
+    const { rerender } = renderHook(() => useReleaseNotifications(options({ appVersion: version })));
+    expect(fetchLatestRelease).toHaveBeenCalledTimes(1);
+
+    version = '0.4.0';
+    rerender();
+    expect(fetchLatestRelease).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/netscli-gui/src/hooks/useReleaseNotifications.ts
+++ b/apps/netscli-gui/src/hooks/useReleaseNotifications.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { fetchLatestRelease, isNewerVersion } from '../services/releases';
 import type { WorkspaceToast } from '../workspace/types';
@@ -18,11 +18,31 @@ export function useReleaseNotifications({
   showUpdateToast,
   toast,
 }: ReleaseNotificationOptions) {
+  // The callbacks live in a ref so they cannot re-trigger the effects below.
+  //
+  // Both are plain functions declared in `useWorkspaceToast`'s body, so each
+  // render produces new identities. Listing them as dependencies meant the
+  // release check re-ran on *every* render: it aborted the in-flight request
+  // and issued another one. During a scan that is roughly one request to
+  // api.github.com per progress event — per probed port — and the
+  // unauthenticated limit is 60 an hour, so the app rate-limited itself out
+  // of update checks within seconds of normal use. Even idle it refired every
+  // 30s, because the interface poll sets state with freshly deserialized
+  // values each time.
+  //
+  // Same shape as the handler ref in useKeyboardShortcuts: assign in an
+  // effect with no dependency array, so it runs after every render and only
+  // ever writes a ref.
+  const callbacks = useRef({ dismissToast, showUpdateToast });
+  useEffect(() => {
+    callbacks.current = { dismissToast, showUpdateToast };
+  });
+
   useEffect(() => {
     if (!enabled && toast?.kind === 'update') {
-      dismissToast();
+      callbacks.current.dismissToast();
     }
-  }, [dismissToast, enabled, toast?.kind]);
+  }, [enabled, toast?.kind]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -32,7 +52,7 @@ export function useReleaseNotifications({
       .then((release) => {
         const dismissed = window.localStorage.getItem('netscli-dismissed-release-version');
         if (dismissed === release.version || !isNewerVersion(release.version, appVersion)) return;
-        showUpdateToast(release.version, release.url);
+        callbacks.current.showUpdateToast(release.version, release.url);
       })
       .catch((error) => {
         if (controller.signal.aborted) return;
@@ -40,6 +60,5 @@ export function useReleaseNotifications({
       });
 
     return () => controller.abort();
-  }, [appVersion, enabled, showUpdateToast]);
+  }, [appVersion, enabled]);
 }
-

--- a/crates/netscli-core/src/discover.rs
+++ b/crates/netscli-core/src/discover.rs
@@ -124,11 +124,18 @@ impl DiscoverEngine {
             ping_results.into_iter().filter(|r| r.alive).collect();
 
         // 2) Load ARP/neighbor table once and reuse it.
-        let arp_map: HashMap<IpAddr, crate::arp::ArpEntry> = NetworkManager::get_arp_table()
-            .unwrap_or_default()
-            .into_iter()
-            .map(|e| (e.ip, e))
-            .collect();
+        //
+        // On a blocking thread: this shells out to `arp` on Windows and
+        // macOS, and running it inline parked a runtime worker on the child
+        // process for every discover and sweep.
+        let arp_map: HashMap<IpAddr, crate::arp::ArpEntry> =
+            tokio::task::spawn_blocking(NetworkManager::get_arp_table)
+                .await
+                .unwrap_or_else(|_| Ok(Vec::new()))
+                .unwrap_or_default()
+                .into_iter()
+                .map(|e| (e.ip, e))
+                .collect();
 
         // 3) Optionally reverse-DNS alive hosts using a single resolver.
         let hostname_map: HashMap<IpAddr, Option<String>> = if resolve {

--- a/crates/netscli-core/src/ops/network.rs
+++ b/crates/netscli-core/src/ops/network.rs
@@ -26,7 +26,24 @@ impl Ops {
         }
     }
 
-    pub fn get_arp_table(&self) -> Result<Vec<ArpEntry>> {
-        NetworkManager::get_arp_table()
+    /// Read the local ARP/neighbour table.
+    ///
+    /// Async, and it moves the read to a blocking thread, because on Windows
+    /// and macOS this shells out to `arp` and waits on the child process.
+    /// Every other method on `Ops` is async, so a sync one here invited
+    /// exactly the bug it produced: three separate callers — the MCP tool
+    /// dispatcher, the Tauri command, and `DiscoverEngine` — all invoked it
+    /// straight from an async context and parked a runtime worker on
+    /// `waitpid` for the life of the subprocess.
+    ///
+    /// The MCP case was the sharp one. Its handlers are capped at 16
+    /// concurrent, and the read loop is itself a task on the same pool, so
+    /// sixteen `get_arp_table` calls could stall every worker — including
+    /// the one reading stdin. No further request would even be parsed, and
+    /// a cancellation could not get through.
+    pub async fn get_arp_table(&self) -> Result<Vec<ArpEntry>> {
+        tokio::task::spawn_blocking(NetworkManager::get_arp_table)
+            .await
+            .map_err(|e| crate::error::Error::Other(format!("ARP read task failed: {e}")))?
     }
 }

--- a/crates/netscli-mcp/src/server/dispatch.rs
+++ b/crates/netscli-mcp/src/server/dispatch.rs
@@ -195,9 +195,8 @@ async fn dispatch_tool(name: &str, params: Value) -> Result<Value, RpcError> {
             let res = op_dns_lookup(p).await?;
             serde_json::to_value(res).map_err(|e| RpcError::Internal(e.to_string()))
         }
-        "get_arp_table" => {
-            serde_json::to_value(op_get_arp_table()?).map_err(|e| RpcError::Internal(e.to_string()))
-        }
+        "get_arp_table" => serde_json::to_value(op_get_arp_table().await?)
+            .map_err(|e| RpcError::Internal(e.to_string())),
         "inspect_host" => {
             let p: ScanParams = parse_params(params)?;
             let res = op_inspect_host(p).await?;

--- a/crates/netscli-mcp/src/server/operations.rs
+++ b/crates/netscli-mcp/src/server/operations.rs
@@ -125,9 +125,10 @@ pub(super) async fn op_dns_lookup(
         .map_err(|e| RpcError::ToolError(e.to_string()))
 }
 
-pub(super) fn op_get_arp_table() -> Result<Vec<netscli_core::ArpEntry>, RpcError> {
+pub(super) async fn op_get_arp_table() -> Result<Vec<netscli_core::ArpEntry>, RpcError> {
     let ops = netscli_core::Ops::default();
     ops.get_arp_table()
+        .await
         .map_err(|e| RpcError::ToolError(e.to_string()))
 }
 


### PR DESCRIPTION
Two defects the independent reviews found. Both degrade the product in normal use, and neither is visible from a passing test suite.

## 1. Reading the ARP table blocked tokio workers

On Windows and macOS it shells out to `arp` and waits on the child process.

`Ops::get_arp_table` was **the one sync method on an otherwise async facade**, which invited exactly the bug it produced — three separate callers all invoked it straight from an async context:

| caller | effect |
|---|---|
| MCP tool dispatcher | blocks a runtime worker per call |
| Tauri command | blocks a runtime worker per call |
| `DiscoverEngine` | blocks a worker on **every** discover and sweep |

**The MCP case is the sharp one.** Handlers are capped at 16 concurrent and the stdin read loop is itself a task on the same pool, so sixteen `get_arp_table` calls could park every worker. No further request would be parsed — **including a cancellation**. That's the same class of defect the concurrency rewrite fixed, at a call site it missed.

Fixed at the source rather than per caller: `Ops::get_arp_table` is now async and moves the read to `spawn_blocking`, so every consumer benefits and the next one can't repeat it. `DiscoverEngine` calls `NetworkManager::get_arp_table` directly, so that one is wrapped in place.

**Breaking change, deliberately.** `Ops::get_arp_table` becoming async breaks netscli-core consumers. It lands in the unreleased 0.3.0, and `Ops` is the async facade — the sync signature was the anomaly.

## 2. The desktop app rate-limited itself out of update checks

`useReleaseNotifications` listed `showUpdateToast` as an effect dependency. It's a plain function from `useWorkspaceToast`, so every render gives it a new identity and the effect re-ran on every render: abort the in-flight request, issue another.

During a scan that's roughly **one request to api.github.com per progress event — per probed port** — against an unauthenticated limit of 60 an hour. Idle, it still refired every 30s, because the interface poll sets state with freshly deserialized values.

The callbacks now live in a ref updated by a no-dependency effect — the same shape as the handler ref in `useKeyboardShortcuts` — so the check runs once per `(appVersion, enabled)` change.

## Tests

Both were confirmed to fail against the previous behaviour before being kept:

```
× checks once across many re-renders with new callback identities
  expected 13 to be 1
```

## Verification

`cargo fmt`, clippy with and without `pcap`, 147 Rust tests, 100 GUI tests, lint 0 errors, GUI build, file-size guard — all pass.

Not verifiable here: the blocking fix is structural (the call moves to a blocking pool) and is covered by the type system and review, not by a test that measures runtime stall. Reproducing the original wedge needs a live MCP session with 16 concurrent ARP calls on a Windows or macOS host.
