### PR TITLE
Fix two layout defects found by sweeping every route across six widths

### DIFF
--- a/site/src/styles/starlight/04-markdown-content-base.css
+++ b/site/src/styles/starlight/04-markdown-content-base.css
@@ -86,13 +86,25 @@
 }
 
 @media (max-width: 52rem) {
+  /* `100%`, not `100vw`.
+   *
+   * `100vw` is the viewport INCLUDING the classic scrollbar; the content box
+   * excludes it. Below this breakpoint that made html/body/.page wider than
+   * the space available by exactly the scrollbar width, and the children
+   * sized at `width:100%` inherited it -- so every docs page scrolled
+   * sideways by 10px in any desktop window narrower than 832px. Measured at
+   * 650px: clientWidth 641, scrollWidth 651, and the page really did scroll.
+   *
+   * It hid from earlier testing because touch emulation uses overlay
+   * scrollbars, where `100vw` and the content box are the same width. Only a
+   * real narrow desktop window shows it. */
   html,
   body,
   .page,
   .main-frame,
   .main-pane {
-    width: 100vw !important;
-    max-width: 100vw !important;
+    width: 100% !important;
+    max-width: 100% !important;
     overflow-x: clip;
   }
 

--- a/site/src/styles/starlight/07-docs-interaction-b.css
+++ b/site/src/styles/starlight/07-docs-interaction-b.css
@@ -183,3 +183,28 @@ html[data-theme='light'] .sl-markdown-content :not(pre) > code {
     padding-block-start: calc(var(--netscli-code-copy-size) + 0.5rem);
   }
 }
+
+/* Pointer devices: reveal the copy button on hover, not permanently.
+ *
+ * At 0.9 opacity always-on it sat on top of the first line of code, and any
+ * line longer than the block obscured its own text. Measured on
+ * /docs/install/ at 1280px: 5 of 18 blocks had glyphs underneath the button
+ * -- the long `iwr -useb https://…` and `curl -fsSL https://…` installers,
+ * exactly the ones a reader most needs to see in full.
+ *
+ * The narrow-screen band above stays: it is `hover: none` there, so a
+ * hover-reveal would leave no affordance at all. This split is Expressive
+ * Code's own default behaviour, and the widely-used pattern -- the button
+ * appears when you reach for it, and only then can it overlap anything.
+ */
+@media (hover: hover) and (min-width: 43.75rem) {
+  .sl-markdown-content .expressive-code .copy button {
+    opacity: 0;
+    transition: opacity 0.12s ease;
+  }
+  .sl-markdown-content .expressive-code .frame:hover .copy button,
+  .sl-markdown-content .expressive-code .frame:focus-within .copy button,
+  .sl-markdown-content .expressive-code .copy button:focus-visible {
+    opacity: 0.9;
+  }
+}


### PR DESCRIPTION
Responsive coverage had been two widths — 375 and 1280 — with nothing in between and **no tablet size at all**. Sweeping 600, 650, 700, 768, 1024 and 1280 across all 14 routes found two real defects, both in the untested middle.

## 1. Every docs page scrolled sideways below 832px

`width: 100vw !important` on `html`, `body`, `.page`, `.main-frame` and `.main-pane` under `max-width: 52rem`.

`100vw` is the viewport **including** the classic scrollbar; the content box excludes it. Those elements were wider than the available space by exactly the scrollbar width, and children sized at `width:100%` inherited it.

Measured in a real 650px window:

| | |
|---|---|
| clientWidth | 641 |
| scrollWidth | 651 |
| actually scrolls | yes — confirmed by scrolling it |

### Why this survived earlier testing

I hit the same 10px in an iframe sweep before and **dismissed it as the iframe's own scrollbar** — then "confirmed" the page was fine using touch emulation, which uses *overlay* scrollbars where `100vw` and the content box are identical.

The dismissal was wrong, and the confirmation was measuring a case that could not reproduce it. Only a real narrow desktop window shows this.

## 2. Long code lines ran under the copy button at desktop widths

The button sits at opacity 0.9 permanently, over the first line. Any line longer than the block obscured its own text — **5 of 18 blocks on `/docs/install/` at 1280px**, and they were the long `iwr -useb https://…` and `curl -fsSL https://…` installers, the ones a reader most needs whole.

The earlier fix only applied below 700px, so it looked solved while the desktop case was never checked.

Pointer devices now reveal the button on hover or focus — Expressive Code's own default. The narrow-screen band stays: it is `hover: none` there, so a hover-reveal would leave no affordance at all.

## A false positive caught before "fixing" it

The sweep also flagged text under the button on the landing page at 768–1280. Measuring the **text nodes** rather than the container's line box showed the glyphs end at x=443 with the button at x=739 — nearly 300px clear. The detector was measuring the full line box of a block container, not the inked text.

## Result

All 14 routes clean at all six widths: no sideways scroll, nothing obscured by a visible button, no failed images.

`astro check`, build, the a11y gate across both themes, and the file-size guard all pass.