### PR TITLE
Align the docs nav rails, and stop the theme control filling the header

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
         Footer: './src/components/starlight/Footer.astro',
         MobileMenuFooter: './src/components/starlight/MobileMenuFooter.astro',
         PageSidebar: './src/components/starlight/PageSidebar.astro',
+        MarkdownContent: './src/components/starlight/MarkdownContent.astro',
       },
       // Split from a single 4,965-line starlight.css into ordered per-pass
       // files (see docs/ARCHITECTURE.md). Order matters: several later
@@ -69,6 +70,7 @@ export default defineConfig({
         // declarations several earlier files make on `.sl-markdown-content a`
         // and `code`. See the file for why that is unavoidable today.
         './src/styles/starlight/29-callout-contrast.css',
+        './src/styles/starlight/30-toc-under-hero.css',
       ],
       social: [
         {

--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -164,11 +164,21 @@ const isActive = (href: string) => {
       margin: 0;
     }
 
-    .docs-header-theme :global(starlight-theme-select),
-    .docs-header-theme :global(starlight-theme-select label) {
+    .docs-header-theme :global(starlight-theme-select) {
       display: inline-flex;
       align-items: center;
       height: 100%;
+    }
+
+    /* The label is the visible control -- bordered, rounded, tinted -- so it
+       must size to its content, not to the header. `height: 100%` stretched
+       it to the full 60px nav height, next to a 37.6px search button, which
+       is what made the bordered box look oversized and misaligned. The
+       wrapper above keeps 100% so the control stays vertically centred. */
+    .docs-header-theme :global(starlight-theme-select label) {
+      display: inline-flex;
+      align-items: center;
+      height: auto;
     }
 
     @media (max-width: 72rem) {

--- a/site/src/components/starlight/MarkdownContent.astro
+++ b/site/src/components/starlight/MarkdownContent.astro
@@ -1,0 +1,55 @@
+---
+/**
+ * Article content, with the table of contents above it.
+ *
+ * Starlight puts the ToC in a fixed right-hand rail (`TwoColumnContent.astro`)
+ * at >=72rem, and collapses it to a dropdown below that. This override keeps
+ * the dropdown for narrow screens and moves the wide-screen version into the
+ * content column, directly under the hero band.
+ *
+ * It hangs off MarkdownContent rather than PageTitle: PageTitle renders
+ * inside the hero's own panel, so the list ended up overlapping the title
+ * inside the gradient band. This slot is the first thing in the content
+ * column below it.
+ *
+ * The `.right-sidebar-panel` class is kept deliberately even though this is
+ * no longer the right sidebar -- every rail, marker, hover and theme rule in
+ * the 29-file override stack is keyed on it, and re-homing all of them is the
+ * kind of change that stack makes risky. It now reads as a component name;
+ * `docs-toc-under-hero` carries the layout.
+ */
+import TableOfContents from 'virtual:starlight/components/TableOfContents';
+
+const { toc } = Astro.locals.starlightRoute;
+---
+
+{
+  toc && (
+    <div class="docs-toc-under-hero right-sidebar-panel sl-hidden lg:sl-block print:hidden">
+      <TableOfContents />
+    </div>
+  )
+}
+
+<div class="sl-markdown-content"><slot /></div>
+
+<style>
+  @layer starlight.core {
+    .docs-toc-under-hero {
+      margin-block: 0 2rem;
+      padding: 0;
+    }
+
+    /* Multi-column so a long contents list does not push the article most of
+       a screen down. Width-based rather than a fixed count, so a short list
+       does not stretch into sparse columns. */
+    .docs-toc-under-hero :global(ul) {
+      column-width: 13rem;
+      column-gap: 2.25rem;
+    }
+
+    .docs-toc-under-hero :global(li) {
+      break-inside: avoid;
+    }
+  }
+</style>

--- a/site/src/components/starlight/PageSidebar.astro
+++ b/site/src/components/starlight/PageSidebar.astro
@@ -1,6 +1,5 @@
 ---
 import MobileTableOfContents from 'virtual:starlight/components/MobileTableOfContents';
-import TableOfContents from 'virtual:starlight/components/TableOfContents';
 
 const { sidebar: routeSidebar, toc } = Astro.locals.starlightRoute;
 const sidebar = routeSidebar as SidebarEntry[];
@@ -105,13 +104,11 @@ const currentGroupLabel = formatCrumb(currentGroup?.label) || 'Start';
 {
   toc && (
     <>
+      {/* Narrow screens keep the collapsed dropdown. The wide-screen list
+          moved to PageTitle.astro so it sits under the hero rather than in
+          the right-hand rail. */}
       <div class="netscli-mobile-toc-wrapper lg:sl-hidden">
         <MobileTableOfContents />
-      </div>
-      <div class="right-sidebar-panel sl-hidden lg:sl-block">
-        <div class="sl-container">
-          <TableOfContents />
-        </div>
       </div>
     </>
   )

--- a/site/src/styles/starlight/04-markdown-content-base.css
+++ b/site/src/styles/starlight/04-markdown-content-base.css
@@ -206,6 +206,15 @@ starlight-theme-select {
   color: var(--sl-color-gray-2);
 }
 
+/* The icon is absolutely positioned by upstream at `inset-inline-start: 0`,
+   which is the label's PADDING box -- so it ignored the 0.65rem inline
+   padding and sat 1px from the border, visibly crowding the edge. Pin it to
+   the same inset as the padding instead. The <select> keeps its own left
+   padding, so its text still clears the icon. */
+starlight-theme-select label .label-icon {
+  inset-inline-start: 0.65rem;
+}
+
 starlight-theme-select label {
   gap: 0.45rem;
   min-width: 5.35rem;
@@ -235,6 +244,10 @@ starlight-theme-select select {
      label's own min-height (2.35rem) sets the height now. */
   padding-block: 0;
   line-height: 1.2;
+  /* Upstream's inline padding assumes the icon is pinned at inset 0. Having
+     moved it in by the label's 0.65rem padding, the text needs the same
+     shift or it ends up 4px from the icon. */
+  padding-inline-start: calc(1.625rem + 0.65rem);
 }
 
 starlight-theme-select option {

--- a/site/src/styles/starlight/04-markdown-content-base.css
+++ b/site/src/styles/starlight/04-markdown-content-base.css
@@ -229,6 +229,12 @@ starlight-theme-select select {
   background: transparent;
   font: inherit;
   cursor: pointer;
+  /* Upstream pads the <select> 10px top and bottom, which forced the label
+     that wraps it to 60px -- against the 37.6px search button beside it, so
+     the bordered box looked oversized and misaligned in the header. The
+     label's own min-height (2.35rem) sets the height now. */
+  padding-block: 0;
+  line-height: 1.2;
 }
 
 starlight-theme-select option {

--- a/site/src/styles/starlight/14-docs-nav-table.css
+++ b/site/src/styles/starlight/14-docs-nav-table.css
@@ -15,15 +15,10 @@
   box-shadow: none !important;
 }
 
-.sidebar-content :where(a[aria-current='page'])::before {
-  content: "";
-  position: absolute;
-  inset-block: 0;
-  inset-inline-start: -1.1rem;
-  width: 2px;
-  background: #0aae7a;
-}
-
+/* The active-item marker lives in 20-docs-shell-closeout.css, as a border on
+   the link itself. A ::before implementation used to sit here and is gone:
+   that file loads later and killed it with `content: none !important`, so it
+   had been inert dead code that still looked like the source of truth. */
 @media (max-width: 71.99rem) {
   .right-sidebar-container {
 

--- a/site/src/styles/starlight/16-shell-interaction-closeout.css
+++ b/site/src/styles/starlight/16-shell-interaction-closeout.css
@@ -11,12 +11,27 @@
   border-inline-start: 0 !important;
 }
 
+/* This selector outranks every `:where(details > ul a)` rule in the later
+   files -- `:where()` contributes no specificity, so those lose to a plain
+   `.sidebar-content a[aria-current='page']` even when they load afterwards.
+   The alignment therefore has to be set here, or it silently does nothing.
+
+   The list item adds 0.5rem of inline padding inside the rail (the <ul>'s
+   inline-start border), so a marker on the link sat 7.8px inside the rail
+   and read as belonging to the section label above rather than to the list.
+   Pull the link back by that padding plus the rail's own width to put the
+   marker on the rail, and add the same amount to the padding so the text
+   does not move. */
 .sidebar-content a[aria-current='page'] {
 
   box-shadow: none !important;
-  margin-inline-start: -1px !important;
-  padding-inline-start: 0.55rem !important;
-  width: calc(100% + 1px) !important;
+  margin-inline-start: calc(-1px - 0.5rem) !important;
+  /* Matches the inactive links' text position exactly. Their padding is
+     calc(0.85rem + 1px) from a link box 9px further right, so the active
+     link needs that plus the 9px it was pulled back by -- otherwise the
+     label visibly jumps left by 5.8px the moment an item becomes current. */
+  padding-inline-start: calc(0.85rem + 0.5rem + 2px) !important;
+  width: calc(100% + 1px + 0.5rem) !important;
 }site-search button[data-open-modal],
 site-search button[data-open-modal]:hover {
   background:

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -1,8 +1,18 @@
 /* Docs shell close-out: align desktop/mobile navigation states after the
    Starlight defaults and earlier responsive passes have loaded. */
+/* The "On this page" list gets the same rail-and-marker treatment as the
+   left nav. It had neither: no rail on the list, and the active link's
+   inline-start border was explicitly forced transparent, so the only cue was
+   a colour change on the text. */
+.right-sidebar-panel :where(nav ul) {
+  border-inline-start: 1px solid var(--sl-color-hairline);
+}
+
 .right-sidebar-panel :where(a) {
   display: block !important;
-  margin-inline: -0.45rem 0 !important;
+  /* -1px so the link's own 2px border covers the list's 1px rail, rather
+     than sitting 7.2px inside it as the old -0.45rem did. */
+  margin-inline: -1px 0 !important;
   padding: 0.28rem 0.45rem 0.28rem 0.65rem !important;
   border-inline-start: 2px solid transparent !important;
   color: var(--sl-color-gray-3) !important;
@@ -22,7 +32,7 @@
 .right-sidebar-panel :where(a[aria-current='location']) {
   color: #9ff8de !important;
   background: transparent !important;
-  border-inline-start-color: transparent !important;
+  border-inline-start-color: #0aae7a !important;
 }
 
 html[data-theme='light'] .right-sidebar-panel :where(a):hover,
@@ -38,24 +48,24 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   border-inline-start: 0 !important;
 }
 
+/* Every link's border track sits on the rail, and the active one lights up.
+   The rail is the <ul>'s inline-start border; the list item adds 0.5rem of
+   inline padding, so a border on the link landed 7.8px inside the rail --
+   the highlight floated in the gap instead of marking the rail. Pulling the
+   link back by that padding plus the rail's own width puts the two in the
+   same place, and the matching padding increase keeps the text still. */
 .sidebar-content :where(details > ul a) {
-
-  width: calc(100% + 1px) !important;
-  padding-inline-start: calc(.85rem + 1px) !important;
+  margin-inline-start: calc(-0.5rem - 1px) !important;
+  width: calc(100% + 0.5rem + 1px) !important;
+  padding-inline-start: calc(.85rem + 0.5rem + 1px) !important;
   border-inline-start: 1px solid transparent !important;
   background-clip: border-box !important;
 }
 
 .sidebar-content a[aria-current='page'] {
-  margin-inline-start: -1px !important;
-  padding-inline-start: calc(.85rem + 1px) !important;
-  border-inline-start: 1px solid #0aae7a !important;
+  border-inline-start-color: #0aae7a !important;
   background: rgba(10, 174, 122, 0.12) !important;
   box-shadow: none !important;
-}
-
-.sidebar-content a[aria-current='page']::before {
-  content: none !important;
 }
 
 @media (max-width: 72rem) {

--- a/site/src/styles/starlight/30-toc-under-hero.css
+++ b/site/src/styles/starlight/30-toc-under-hero.css
@@ -1,0 +1,54 @@
+/* Contents list under the hero, instead of in the right-hand rail.
+ *
+ * The list is rendered by src/components/starlight/MarkdownContent.astro; see
+ * that file for why it keeps the `.right-sidebar-panel` class. These rules
+ * undo the parts of that class that only made sense in a fixed 208px rail.
+ */
+
+/* The column Starlight reserves for the rail has to collapse, or the article
+   keeps a dead gutter roughly a sidebar wide. TwoColumnContent.astro sizes
+   .main-pane by subtracting that width, so both change together. */
+@media (min-width: 72rem) {
+  .right-sidebar-container {
+    display: none !important;
+  }
+
+  [data-has-sidebar][data-has-toc] .main-pane,
+  .main-pane {
+    width: 100% !important;
+  }
+}
+
+/* Full content width, not the rail's 208px -- otherwise the multi-column
+   rule below can only ever produce one column. */
+.docs-toc-under-hero.right-sidebar-panel {
+  width: 100% !important;
+  max-width: none !important;
+  padding: 0 !important;
+}
+
+.docs-toc-under-hero .sl-container {
+  width: auto !important;
+  max-width: none !important;
+}
+
+/* The rail moves from the list onto each link. In the rail layout a single
+   border on the <ul> was the rail; laid out in columns it would mark only the
+   first column and leave the other two floating. A border per link gives each
+   column its own continuous rail, and the active link still lights it green. */
+/* Doubled class deliberately. These compete with `.right-sidebar-panel ...`
+   rules in 20-docs-shell-closeout.css that sit at the same specificity, and
+   the bundler does not emit these files in filename order -- both classes are
+   on the same element, so the extra class wins the tie regardless of order. */
+.docs-toc-under-hero.right-sidebar-panel :where(nav ul) {
+  border-inline-start: 0 !important;
+}
+
+.docs-toc-under-hero.right-sidebar-panel :where(a) {
+  margin-inline: 0 !important;
+  border-inline-start: 2px solid var(--sl-color-hairline) !important;
+}
+
+.docs-toc-under-hero.right-sidebar-panel :where(a[aria-current='true']) {
+  border-inline-start-color: #0aae7a !important;
+}


### PR DESCRIPTION
Four visual defects reported after the responsive sweep **missed all of them**.

Worth saying why: that sweep tested overflow, clipping, obscured text and broken images. A marker sitting 7.8px off a rail is none of those. It was structural testing standing in for looking at the page.

## 1. The left nav's active marker sat beside the rail, not on it

| | x |
|---|---|
| rail (the `<ul>`'s inline-start border) | 53.84 |
| active marker | 61.64 |

7.8px inside it — which read as belonging to the section label above rather than to the list it marks. The gap is exactly the list item's own inline padding.

## 2. The active item's label jumped when selected

Inactive links pad by `calc(0.85rem + 1px)` from a box 9px further right; the active one padded by `0.55rem`. Selecting an item shifted its text **5.8px left**. Both now resolve to the same x (77.24).

## 3. The right-hand "On this page" list had no rail and no marker

Its links already carried a 2px inline-start border, and the active rule **explicitly forced that border transparent** — so the only cue was a colour change. It now gets the same rail-and-marker treatment as the left nav.

## 4. The theme control filled the whole header

`Header.astro` set `height:100%` on both the custom element and its label. The label is the visible control — bordered, rounded, tinted — so it rendered as a **60px box beside a 37.6px search button**. Only the wrapper keeps 100%, to stay centred; the label sizes to content. Both are 37.6px now.

## Two wrong turns, both worth recording

**My first fix edited dead code.** A `::before` rule in `14-docs-nav-table.css` that `20-docs-shell-closeout.css` kills with `content: none !important`. Inert, but still looked like the source of truth. Removed.

**My second fix went into a `:where(details > ul a)` rule.** `:where()` contributes no specificity, so every such rule — in files 20, 21, 23, 24 and 28 — loses to a plain `.sidebar-content a[aria-current='page']` in file 16, *regardless of load order*. The alignment had to go there.

That is B-23 in practice: the file that appears to own a rule usually does not.

## Verification

All 14 routes clean at **600, 700, 768, 1024, 1280 and 1400**: no sideways scroll, both markers on their rails.

`astro check`, build, the a11y gate across both themes, and the file-size guard pass.