### PR TITLE
Rewrite the hero and head metadata for search, and align the landing nav with the docs

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -38,6 +38,7 @@ export default defineConfig({
       // file — do not alphabetize or reorder without checking the affected
       // rules' cascade dependency first.
       customCss: [
+        './src/styles/tokens.css',
         './src/styles/starlight/01-tokens-and-header.css',
         './src/styles/starlight/02-search-and-sidebar-base.css',
         './src/styles/starlight/03-shell-layout-base.css',

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -131,7 +131,10 @@ const { hero, social, version } = site;
 .hero h1{
   font-size:clamp(1.75rem,4vw,2.75rem);font-weight:700;color:#f5f5f5;
   letter-spacing:-.02em;margin:0 auto;line-height:1.2;
-  max-width:15ch;
+  /* Sized for the current heading, which is 62 characters. At the old 15ch
+     -- set when the heading was "A modern network scanner" -- it broke into
+     four lines and pushed the install buttons off the first screen. */
+  max-width:34ch;
 }
 .hero .sub{font-size:1.0625rem;color:#a3a3a3;max-width:640px;margin:14px auto 0}
 .hero .social-proof{

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -99,6 +99,12 @@ body.nav-scrolled nav::after{
   opacity:1;
 }
 .nav-inner{
+  /* Matches the docs top bar. Padding alone gave 12+32+12 plus the 1px
+     border on <nav> = 57px against the docs' 60px, so the bar jumped every
+     time you crossed between the landing page and the docs. The border is
+     on the parent, hence the -1px. Still a min, so the mobile wrapped state
+     grows past it as before. */
+  min-height:calc(var(--netscli-nav-height) - 1px);
   max-width:var(--netscli-shell-width);margin:0 auto;padding:12px var(--netscli-shell-gutter);
   display:flex;align-items:center;justify-content:space-between;gap:18px;
   flex-wrap:wrap;
@@ -151,7 +157,16 @@ body.nav-scrolled nav::after{
   margin-block:-12px;
 }
 .nlinks a:hover{color:#e5e5e5}
-.nlinks a[aria-current="page"]{
+/* Both values, because two different things set this attribute here.
+   Nav.astro marks a genuine current page with "page"; the scroll spy in
+   scripts/site-nav.ts marks the section you are looking at with "location",
+   which is the correct ARIA value for a position within a page. Only "page"
+   was styled, so on the landing page -- where every nav link is an anchor
+   and the spy is the only thing that fires -- the underline never appeared
+   at all. The docs bar was unaffected, which is why the two looked
+   inconsistent. */
+.nlinks a[aria-current="page"],
+.nlinks a[aria-current="location"]{
   color:#e5e5e5;
   border-bottom-color:#0aae7a;
 }
@@ -219,7 +234,8 @@ body.nav-scrolled nav::after{
     margin-block:0;
   }
   .nlinks a:hover,
-  .nlinks a[aria-current='page']{
+  .nlinks a[aria-current='page'],
+  .nlinks a[aria-current='location']{
     border-left-color:#0aae7a;
     border-bottom-color:transparent;
     background:rgba(10,174,122,.1);

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -1,17 +1,9 @@
 ---
 import { site } from '../data/site';
-const { branding, hero } = site;
-const onHome = Astro.url.pathname === '/';
+import { hrefFor, isCurrent, navLinks } from '../data/site-content/nav';
+const { branding } = site;
 const pathname = Astro.url.pathname;
-const homeAnchor = (id: string) => (onHome ? `#${id}` : `/#${id}`);
-const links = [
-  { href: homeAnchor('surfaces'), label: 'Features', active: false, section: 'surfaces' },
-  { href: homeAnchor('install'), label: 'Install', active: false, section: 'install' },
-  { href: homeAnchor('faq'), label: 'FAQ', active: false, section: 'faq' },
-  { href: '/docs/', label: 'Docs', active: pathname.startsWith('/docs') },
-  { href: '/changelog/', label: 'Changelog', active: pathname.startsWith('/changelog') },
-  { href: hero.sourceUrl, label: 'GitHub', active: false, external: true },
-];
+const onHome = pathname === '/';
 ---
 <nav data-site-nav data-open="false">
   <div class="nav-inner">
@@ -31,13 +23,13 @@ const links = [
       <span></span>
     </button>
     <div class="nlinks" id="site-nav-links" data-site-nav-links>
-      {links.map((link) => (
+      {navLinks.map((link) => (
         <a
-          href={link.href}
+          href={hrefFor(link, pathname)}
           class={link.external ? 'external-link' : undefined}
           data-section={link.section}
           data-site-nav-link
-          aria-current={link.active ? 'page' : undefined}
+          aria-current={isCurrent(link, pathname) ? 'page' : undefined}
           {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
         >
           {link.label}

--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -6,26 +6,9 @@ import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
 const shouldRenderSearch =
   config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
 
+import { hrefFor, isCurrent, navLinks } from '../../data/site-content/nav';
+
 const pathname = Astro.url.pathname;
-type NavLink = {
-  href: string;
-  label: string;
-  external?: boolean;
-};
-
-const siteLinks: NavLink[] = [
-  { href: '/#surfaces', label: 'Features' },
-  { href: '/#install', label: 'Install' },
-  { href: '/#faq', label: 'FAQ' },
-  { href: '/docs/', label: 'Docs' },
-  { href: '/changelog/', label: 'Changelog' },
-];
-
-const isActive = (href: string) => {
-  if (href === '/docs/') return pathname.startsWith('/docs');
-  if (href === '/changelog/') return pathname.startsWith('/changelog');
-  return pathname.replace(/\/$/, '') === href.replace(/\/$/, '');
-};
 ---
 
 <div class="docs-topbar">
@@ -39,11 +22,12 @@ const isActive = (href: string) => {
 
   <nav class="docs-nav-links" aria-label="Site navigation">
     {
-      siteLinks.map((link) => (
+      navLinks.map((link) => (
         <a
-          href={link.href}
+          href={hrefFor(link, pathname)}
           class={link.external ? 'external-link' : undefined}
-          aria-current={isActive(link.href) ? 'page' : undefined}
+          aria-current={isCurrent(link, pathname) ? 'page' : undefined}
+          {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
         >
           {link.label}
         </a>

--- a/site/src/components/starlight/MobileMenuFooter.astro
+++ b/site/src/components/starlight/MobileMenuFooter.astro
@@ -1,29 +1,11 @@
 ---
 import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
 
+import { hrefFor, isCurrent, navLinks } from '../../data/site-content/nav';
+
 const pathname = Astro.url.pathname;
-type NavLink = {
-  href: string;
-  label: string;
-  external?: boolean;
-};
-
-const siteLinks: NavLink[] = [
-  { href: '/#surfaces', label: 'Features' },
-  { href: '/#install', label: 'Install' },
-  { href: '/#faq', label: 'FAQ' },
-  { href: '/docs/', label: 'Docs' },
-];
-
-const projectLinks: NavLink[] = [
-  { href: '/changelog/', label: 'Changelog' },
-  { href: 'https://github.com/fstubner/netscli', label: 'GitHub', external: true },
-];
-
-const isActive = (href: string) => {
-  if (href === '/docs/') return pathname.startsWith('/docs');
-  return pathname.replace(/\/$/, '') === href.replace(/\/$/, '');
-};
+const siteLinks = navLinks.filter((link) => link.mobileGroup === 'site');
+const projectLinks = navLinks.filter((link) => link.mobileGroup === 'project');
 ---
 
 <div class="docs-mobile-footer">
@@ -33,9 +15,9 @@ const isActive = (href: string) => {
       {
         siteLinks.map((link) => (
           <a
-            href={link.href}
+            href={hrefFor(link, pathname)}
             class={link.external ? 'external-link' : undefined}
-            aria-current={isActive(link.href) ? 'page' : undefined}
+            aria-current={isCurrent(link, pathname) ? 'page' : undefined}
           >
             {link.label}
           </a>
@@ -50,9 +32,9 @@ const isActive = (href: string) => {
       {
         projectLinks.map((link) => (
           <a
-            href={link.href}
+            href={hrefFor(link, pathname)}
             class={link.external ? 'external-link' : undefined}
-            aria-current={isActive(link.href) ? 'page' : undefined}
+            aria-current={isCurrent(link, pathname) ? 'page' : undefined}
           >
             {link.label}
           </a>

--- a/site/src/data/site-content/hero.ts
+++ b/site/src/data/site-content/hero.ts
@@ -7,7 +7,12 @@ export const hero: Hero = {
   // information. The platform list is the part a visitor cannot get anywhere
   // else above the fold.
   badge: 'Windows · Linux · macOS',
-  heading: 'A modern network scanner',
+  // The H1 is the strongest on-page signal after the title, and this one used
+  // to be "A modern network scanner" -- no brand, no differentiator, and
+  // "modern" is not a word anyone searches for. Naming the surfaces says what
+  // is actually different about it, and "AI agents" carries the MCP server in
+  // language a visitor who has never heard of MCP still understands.
+  heading: 'A network scanner for the desktop, the terminal, and AI agents',
   subhead:
     // Packet capture is scoped deliberately. Listing it alongside the other
     // operations claimed it works "from the desktop app, terminal UI, CLI, or

--- a/site/src/data/site-content/meta.ts
+++ b/site/src/data/site-content/meta.ts
@@ -2,17 +2,24 @@ import type { Branding, Meta } from './types';
 
 export const meta: Meta = {
   domain: 'https://netscli.com',
-  title: 'NetsCLI - Modern Network Scanner and Diagnostics Toolkit',
+  // "Modern" and "Diagnostics Toolkit" were spending 30 of the ~60 characters
+  // a search result shows on words nobody searches for. The interfaces are the
+  // differentiator, and MCP is the one term here with real intent behind it
+  // and almost no competition.
+  title: 'NetsCLI — Network Scanner for Desktop, CLI, and MCP',
+  // 153 characters. The previous one ran to 172 and was cut around 158, which
+  // truncated the MCP mention off the end -- the most valuable word in it. It
+  // also ran operations and interfaces through a single "for" series
+  // ("a scanner for ... packet capture, and desktop, terminal, CLI, and MCP
+  // workflows"), which does not parse cleanly.
   description:
-    'NetsCLI is a Rust-based network scanner for LAN discovery, TCP port scans, DNS, trace routes, host inspection, packet capture, and desktop, terminal, CLI, and MCP workflows.',
+    'Discover LAN devices, scan TCP ports, query DNS, and trace routes from a desktop app, terminal UI, CLI, or MCP server. One Rust core, consistent results.',
   // Same scoping as the hero subhead: capture is not in any published desktop
   // installer, so this must not imply it ships with the app. It is what search
   // results and link previews show, which is where an inaccurate claim travels
   // furthest.
   ogDescription:
     'Discover LAN devices, scan TCP ports, query DNS, trace routes, and inspect hosts from the desktop app, terminal UI, CLI, or MCP server backed by one Rust core. Packet capture in capture-enabled CLI builds.',
-  keywords:
-    'network scanner, rust, cli, tui, mcp server, model context protocol, port scan, host discovery, dns lookup, arp table, bonjour, mdns, packet capture, claude, cursor, ai agent, network tool, cross-platform',
   siteName: 'NetsCLI',
   author: { name: 'Felix Stubner', url: 'https://github.com/fstubner' },
   ogImage: 'https://netscli.com/assets/tui-discover.png',

--- a/site/src/data/site-content/nav.ts
+++ b/site/src/data/site-content/nav.ts
@@ -1,0 +1,61 @@
+/* The site navigation, defined once.
+ *
+ * Three components render this nav: the landing bar (components/Nav.astro),
+ * the docs bar (components/starlight/Header.astro), and the docs mobile menu
+ * (components/starlight/MobileMenuFooter.astro). Each used to carry its own
+ * copy of the list, in a different shape, with its own `isActive`. They had
+ * drifted: six links on the landing bar, five in the docs bar, six split
+ * across two groups in the mobile menu, so GitHub appeared on the landing
+ * page and in the mobile menu but not in the docs bar.
+ *
+ * Anchor targets are stored as `section`, not as a finished href, because the
+ * correct link depends on where you are: `#install` on the landing page,
+ * `/#install` anywhere else. `hrefFor` does that; do not hard-code either
+ * form.
+ */
+
+export interface NavLink {
+  label: string;
+  /** Set for links to another page. Mutually exclusive with `section`. */
+  href?: string;
+  /** Landing-page section id. Mutually exclusive with `href`. */
+  section?: string;
+  external?: boolean;
+  /** Which heading this sits under in the docs mobile menu, which is the one
+   *  place the nav is grouped. The flat bars ignore it. */
+  mobileGroup: 'site' | 'project';
+}
+
+export const navLinks: NavLink[] = [
+  { label: 'Features', section: 'surfaces', mobileGroup: 'site' },
+  { label: 'Install', section: 'install', mobileGroup: 'site' },
+  { label: 'FAQ', section: 'faq', mobileGroup: 'site' },
+  { label: 'Docs', href: '/docs/', mobileGroup: 'site' },
+  { label: 'Changelog', href: '/changelog/', mobileGroup: 'project' },
+  {
+    label: 'GitHub',
+    href: 'https://github.com/fstubner/netscli',
+    external: true,
+    mobileGroup: 'project',
+  },
+];
+
+/** Resolve a link's href for the page currently being rendered. */
+export function hrefFor(link: NavLink, pathname: string): string {
+  if (link.href) return link.href;
+  return pathname === '/' ? `#${link.section}` : `/#${link.section}`;
+}
+
+/** Whether `link` points at the page currently being rendered.
+ *
+ * Section links are never current here -- on the landing page they are marked
+ * by the scroll spy in scripts/site-nav.ts, which writes aria-current
+ * "location" rather than "page". */
+export function isCurrent(link: NavLink, pathname: string): boolean {
+  if (!link.href || link.external) return false;
+  // Prefix match on the trailing-slash-stripped href, so /docs/ is current
+  // for /docs, /docs/, and /docs/install/ alike without depending on which
+  // trailing-slash convention the router hands us.
+  const base = link.href.replace(/\/$/, '');
+  return pathname === base || pathname.startsWith(`${base}/`);
+}

--- a/site/src/data/site-content/types.ts
+++ b/site/src/data/site-content/types.ts
@@ -12,8 +12,6 @@ export interface Meta {
   description: string;
   /** Short form used in OG / Twitter cards. Falls back to description. */
   ogDescription?: string;
-  /** Comma-separated keyword list. */
-  keywords: string;
   /** Site name for OG. */
   siteName: string;
   author: { name: string; url: string };

--- a/site/src/layouts/Page.astro
+++ b/site/src/layouts/Page.astro
@@ -1,4 +1,5 @@
 ---
+import '../styles/tokens.css';
 import '../styles/global.css';
 import '../styles/lightbox.css';
 import { site } from '../data/site';

--- a/site/src/layouts/Page.astro
+++ b/site/src/layouts/Page.astro
@@ -88,7 +88,6 @@ const shouldNoindex = noindex || isPreviewBuild;
 <title>{title}</title>
 <meta name="description" content={description} />
 <meta name="author" content={meta.author.name} />
-<meta name="keywords" content={meta.keywords} />
 <meta property="og:type" content="website" />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={ogDesc} />
@@ -102,7 +101,6 @@ const shouldNoindex = noindex || isPreviewBuild;
 {shouldNoindex && <meta name="robots" content="noindex, nofollow" />}
 <link rel="canonical" href={canonicalUrl} />
 <link rel="icon" type="image/svg+xml" href={meta.faviconPath} />
-<link rel="apple-touch-icon" href={meta.faviconPath} />
 
 <!-- Preconnect hints for the only third-party origins this page hits.
      Shaves ~150-300ms off the first request to each by warming DNS +

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1,6 +1,5 @@
 *,*::before,*::after{box-sizing:border-box}
 :root{
-  --netscli-shell-width:72rem;
   --netscli-shell-gutter:24px;
 }
 html{

--- a/site/src/styles/starlight/01-tokens-and-header.css
+++ b/site/src/styles/starlight/01-tokens-and-header.css
@@ -54,8 +54,7 @@ html[data-theme='light'] ::backdrop {
 }
 
 :root {
-  --sl-nav-height: 3.75rem;
-  --netscli-shell-width: 72rem;
+  --sl-nav-height: var(--netscli-nav-height);
   --netscli-docs-sidebar-width: 16rem;
   --netscli-docs-toc-width: 13rem;
   --netscli-docs-shell-gutter: clamp(1.25rem, 2vw, 2.5rem);

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -1,0 +1,18 @@
+/* Values the landing page and the docs shell both need to agree on.
+ *
+ * These two stacks are otherwise separate: the landing page loads
+ * global.css, the docs load the numbered starlight/ files, and neither sees
+ * the other. Every value duplicated across that boundary is one that can
+ * drift silently -- the nav height already had, leaving the landing bar 57px
+ * against the docs' 60px, which is visible the moment you click "Docs".
+ *
+ * Registered first in astro.config.mjs's customCss and imported at the top of
+ * global.css, so both stacks read the same declaration.
+ */
+:root {
+  /* Total height of the top bar including its bottom border, on both the
+     landing page and the docs. Starlight's own --sl-nav-height is set from
+     this in starlight/01-tokens-and-header.css. */
+  --netscli-nav-height: 3.75rem;
+  --netscli-shell-width: 72rem;
+}


### PR DESCRIPTION
Three related changes to the landing page.

**Search.** The H1 was "A modern network scanner" — no brand, no differentiator, and "modern" is not a term anyone searches for. It is the strongest on-page signal after the title and it was competing head-on with nmap. It now names the interfaces, and carries the MCP server as "AI agents" so a visitor who has never heard of MCP still reads it. The title spent half its visible characters on "Modern" and "Diagnostics Toolkit"; the description ran to 172 characters and was cut around 158, truncating the MCP mention off the end.

**Two dead tags removed.** `meta keywords` has been ignored by Google since 2009 — the type and the data go with it. `apple-touch-icon` pointed at an SVG, which iOS does not accept, so it has never produced a home-screen icon; restoring it needs a 180×180 PNG, which is not in this change.

**Nav.** The landing bar was 57px against the docs' 60px and jumped on every crossing, and its active-link underline never appeared. Same cause for both: the landing page and the docs shell define their layout independently. The height now lives in a shared `styles/tokens.css` that both stacks load. The underline was styled only for `aria-current='page'`, but the landing scroll spy correctly writes `aria-current='location'`; both are styled now.

Verified on the preview at 375, 768 and 1400: nav 60px on both surfaces, underline tracks the section on scroll, heading two lines at desktop and three on mobile with the install buttons above the fold.