### PR TITLE
Sit the landing underline on the bar, and square the mobile search button

### DIFF
--- a/site/src/components/Faq.astro
+++ b/site/src/components/Faq.astro
@@ -70,7 +70,7 @@ const faqGroups = grouped.sort(
 .faq summary::-webkit-details-marker{display:none}
 .faq summary::before{
   content:"+";font-family:ui-monospace,"SF Mono",Menlo,monospace;
-  color:#0aae7a;font-weight:700;width:14px;flex-shrink:0;
+  color:var(--netscli-accent);font-weight:700;width:14px;flex-shrink:0;
   transition:transform 150ms;
 }
 .faq details[open] summary::before{content:"−"}
@@ -112,7 +112,7 @@ const faqGroups = grouped.sort(
 }
 .faq .answer code{
   font-size:.8125rem;
-  color:#23d198;
+  color:var(--netscli-accent-bright);
   white-space:nowrap;
   overflow-wrap:normal;
   word-break:normal;
@@ -124,8 +124,8 @@ const faqGroups = grouped.sort(
   overflow-wrap:normal;
   word-break:normal;
 }
-.faq .answer a{color:#0aae7a;text-decoration:underline;text-underline-offset:3px;overflow-wrap:anywhere}
-.faq .answer a:hover{color:#23d198}
+.faq .answer a{color:var(--netscli-accent);text-decoration:underline;text-underline-offset:3px;overflow-wrap:anywhere}
+.faq .answer a:hover{color:var(--netscli-accent-bright)}
 
 
 @media(max-width:600px){

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -237,8 +237,8 @@ const { hero, social, version } = site;
   border-radius:9px;
   background:
     linear-gradient(#191b1e,#191b1e) padding-box,
-    linear-gradient(90deg,#0aae7a 0%,#0aae7a 62%,#1edcff 100%) border-box;
-  box-shadow:0 0 12px rgba(10,174,122,.08);
+    linear-gradient(90deg,var(--netscli-accent) 0%,var(--netscli-accent) 62%,#1edcff 100%) border-box;
+  box-shadow:0 0 12px rgba(var(--netscli-accent-rgb),.08);
   overflow:visible;
 }
 .hero-primary,
@@ -254,11 +254,11 @@ const { hero, social, version } = site;
   text-decoration:none;font-size:.82rem;font-weight:760;
   letter-spacing:.005em;
   font-family:Inter,system-ui,-apple-system,Segoe UI,sans-serif;
-  color:#0aae7a;
+  color:var(--netscli-accent);
 }
 .hero-primary-label{
   transform:translateX(8px);
-  background-image:linear-gradient(90deg,#005a1e,#0aae7a,#1edcff);
+  background-image:linear-gradient(90deg,#005a1e,var(--netscli-accent),#1edcff);
   -webkit-background-clip:text;background-clip:text;
   -webkit-text-fill-color:transparent;
 }
@@ -289,8 +289,8 @@ const { hero, social, version } = site;
 .hero-primary-wrap:hover{
   background:
     linear-gradient(#1c1f23,#1c1f23) padding-box,
-    linear-gradient(90deg,#0aae7a 0%,#0aae7a 62%,#1edcff 100%) border-box;
-  box-shadow:0 0 0 1px rgba(10,174,122,.16),0 0 12px rgba(10,174,122,.08);
+    linear-gradient(90deg,var(--netscli-accent) 0%,var(--netscli-accent) 62%,#1edcff 100%) border-box;
+  box-shadow:0 0 0 1px rgba(var(--netscli-accent-rgb),.16),0 0 12px rgba(var(--netscli-accent-rgb),.08);
 }
 .hero-primary-menu:hover{color:#fff}
 .hero-desktop-menu{
@@ -363,13 +363,13 @@ const { hero, social, version } = site;
   color:currentColor;font-size:8px;line-height:1;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
 }
-.hero-desktop-menu a:hover{background:rgba(10,174,122,.12);color:#1ec88c}
+.hero-desktop-menu a:hover{background:rgba(var(--netscli-accent-rgb),.12);color:#1ec88c}
 .hero-command{
   position:relative;display:grid;grid-template-columns:minmax(0,1fr);
   align-items:center;gap:10px;min-height:36px;
   padding:8px 58px 8px 14px;border-radius:9px;
   background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.1);
-  box-shadow:0 0 0 1px rgba(10,174,122,.26),0 0 14px rgba(10,174,122,.08);
+  box-shadow:0 0 0 1px rgba(var(--netscli-accent-rgb),.26),0 0 14px rgba(var(--netscli-accent-rgb),.08);
 }
 .hero-command.hero-copy .copy-btn{opacity:1}
 .hero-command code{

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -153,7 +153,7 @@ const groups = [
   border-bottom:2px solid transparent;margin-bottom:-1px;transition:color .15s;
 }
 .os-tab:hover{color:#ccc}
-.os-tab.active{color:#fafafa;border-bottom-color:#0aae7a;font-weight:500}
+.os-tab.active{color:#fafafa;border-bottom-color:var(--netscli-accent);font-weight:500}
 .os-panel{display:none}
 .os-panel.active{display:block}
 .reco{
@@ -187,13 +187,13 @@ const groups = [
 /* Direct-download rows reuse the command-bar treatment but are links, so
    they get no copy button and an affordance colour instead. */
 a.install-download{
-  display:block;text-decoration:none;color:#0aae7a;font-weight:500;
+  display:block;text-decoration:none;color:var(--netscli-accent);font-weight:500;
 }
-a.install-download:hover{color:#23d198;background:rgba(10,174,122,.08)}
+a.install-download:hover{color:var(--netscli-accent-bright);background:rgba(var(--netscli-accent-rgb),.08)}
 .alt a.install-download{padding-right:16px}
 .footer-note{margin-top:14px;font-size:.8125rem;color:#808080}
-.footer-note a{color:#0aae7a;text-decoration:underline;text-underline-offset:3px}
-.footer-note a:hover{color:#23d198}
+.footer-note a{color:var(--netscli-accent);text-decoration:underline;text-underline-offset:3px}
+.footer-note a:hover{color:var(--netscli-accent-bright)}
 
 /* Try it sidebar — one row per command, each row gets .has-copy so the
    existing copy-button JS auto-attaches a button. */
@@ -261,13 +261,13 @@ a.install-download:hover{color:#23d198;background:rgba(10,174,122,.08)}
 .surface-download-btn{
   display:inline-flex;flex-direction:column;align-items:flex-start;gap:2px;
   padding:9px 14px;border-radius:8px;
-  background:rgba(10,174,122,.10);border:1px solid rgba(10,174,122,.45);
-  color:#0aae7a;font-size:.85rem;font-weight:500;text-decoration:none;
+  background:rgba(var(--netscli-accent-rgb),.10);border:1px solid rgba(var(--netscli-accent-rgb),.45);
+  color:var(--netscli-accent);font-size:.85rem;font-weight:500;text-decoration:none;
   transition:background .15s,color .15s,border-color .15s;
 }
 .surface-download-btn:hover{
-  background:rgba(10,174,122,.20);
-  border-color:rgba(10,174,122,.6);
+  background:rgba(var(--netscli-accent-rgb),.20);
+  border-color:rgba(var(--netscli-accent-rgb),.6);
   color:#1ec88c;
 }
 .surface-download-btn .dl-label{font-size:.85rem;line-height:1.2}

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -82,10 +82,10 @@ nav::after{
   transition:opacity 160ms ease;
 }
 body.nav-scrolled nav{
-  border-bottom-color:rgba(10,174,122,.12);
+  border-bottom-color:rgba(var(--netscli-accent-rgb),.12);
   box-shadow:
     0 12px 28px rgba(0,0,0,.28),
-    0 1px 0 rgba(10,174,122,.08) !important;
+    0 1px 0 rgba(var(--netscli-accent-rgb),.08) !important;
 }
 body.nav-scrolled nav::after{
   opacity:1;
@@ -141,7 +141,7 @@ body.nav-scrolled nav::after{
 .nav-menu-toggle:hover,
 .nav-menu-toggle:focus-visible{
   color:#fff;
-  border-color:rgba(10,174,122,.35);
+  border-color:rgba(var(--netscli-accent-rgb),.35);
   outline:none;
 }
 .nlinks{display:flex;gap:20px;font-size:.8125rem;flex-wrap:wrap;justify-content:flex-end}
@@ -169,7 +169,7 @@ body.nav-scrolled nav::after{
 .nlinks a[aria-current="page"],
 .nlinks a[aria-current="location"]{
   color:#e5e5e5;
-  border-bottom-color:#0aae7a;
+  border-bottom-color:var(--netscli-accent);
 }
 .external-link{
   display:inline-flex;
@@ -181,7 +181,7 @@ body.nav-scrolled nav::after{
 .external-link::after{
   content:"↗";
   flex:0 0 auto;
-  color:#0aae7a;
+  color:var(--netscli-accent);
   font-size:.92em;
   font-weight:700;
   line-height:1;
@@ -189,7 +189,7 @@ body.nav-scrolled nav::after{
   text-decoration:none;
 }
 .external-link:hover::after{
-  color:#23d198;
+  color:var(--netscli-accent-bright);
   opacity:1;
 }
 @media(max-width:600px){
@@ -224,22 +224,21 @@ body.nav-scrolled nav::after{
     padding:0 10px;
     border-bottom:0;
     border-left:2px solid transparent;
-    /* Undo the desktop full-height trick. The base rule sets
-       `height:calc(100% + 24px)` with `margin-block:-12px` so a horizontal
-       nav link fills the bar and puts its underline on the bar's bottom
-       edge. In this column that negative margin pulls every link 12px into
-       each neighbour: measured 40px-tall links sitting only 18px apart, so
-       each one overlapped the next by 22px and the lower half of every menu
-       item activated the item below it. */
+    /* Undo the desktop full-bar height. Horizontally it puts the underline on
+       the bar's bottom edge; in this column it would make every menu item as
+       tall as the whole bar. An earlier version did the same job with a
+       negative block margin, which pulled each link 12px into its neighbour
+       -- 40px links sitting 18px apart, so the lower half of every item
+       activated the one below it. Hence the explicit margin reset. */
     height:auto;
     margin-block:0;
   }
   .nlinks a:hover,
   .nlinks a[aria-current='page'],
   .nlinks a[aria-current='location']{
-    border-left-color:#0aae7a;
+    border-left-color:var(--netscli-accent);
     border-bottom-color:transparent;
-    background:rgba(10,174,122,.1);
+    background:rgba(var(--netscli-accent-rgb),.1);
   }
 }
 

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -97,7 +97,11 @@ body.nav-scrolled nav::after{
      on the parent, hence the -1px. Still a min, so the mobile wrapped state
      grows past it as before. */
   min-height:calc(var(--netscli-nav-height) - 1px);
-  max-width:var(--netscli-shell-width);margin:0 auto;padding:12px var(--netscli-shell-gutter);
+  /* No block padding: the links are the full bar height so their underline
+     reaches the bottom border, and padding here would push them past it.
+     min-height holds the bar open instead. The narrow-screen rule below
+     restores padding, where the links go back to auto height. */
+  max-width:var(--netscli-shell-width);margin:0 auto;padding:0 var(--netscli-shell-gutter);
   display:flex;align-items:center;justify-content:space-between;gap:18px;
   flex-wrap:wrap;
   position:relative;
@@ -143,10 +147,15 @@ body.nav-scrolled nav::after{
 .nlinks{display:flex;gap:20px;font-size:.8125rem;flex-wrap:wrap;justify-content:flex-end}
 .nlinks a{
   color:#b0b0b0;text-decoration:none;
-  display:inline-flex;align-items:center;min-height:32px;
+  display:inline-flex;align-items:center;
   border-bottom:2px solid transparent;
-  height:calc(100% + 24px);
-  margin-block:-12px;
+  /* Full bar height, so the underline lands on the bar's bottom edge the way
+     the docs one does. This was height:calc(100% + 24px) with a -12px block
+     margin, which never worked: .nlinks has no definite height, so the
+     percentage had nothing to resolve against and the link collapsed to its
+     32px content box. The underline then floated 14px above the bar's
+     border. Minus 1px for the border on <nav>. */
+  height:calc(var(--netscli-nav-height) - 1px);
 }
 .nlinks a:hover{color:#e5e5e5}
 /* Both values, because two different things set this attribute here.

--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -116,7 +116,7 @@ const pathname = Astro.url.pathname;
     }
 
     .docs-nav-links a[aria-current='page'] {
-      border-bottom-color: #0aae7a;
+      border-bottom-color: var(--netscli-accent);
     }
 
     .docs-header-search {

--- a/site/src/components/starlight/MobileMenuFooter.astro
+++ b/site/src/components/starlight/MobileMenuFooter.astro
@@ -86,8 +86,8 @@ const projectLinks = navLinks.filter((link) => link.mobileGroup === 'project');
     .docs-mobile-site-nav a:hover,
     .docs-mobile-site-nav a:focus-visible,
     .docs-mobile-site-nav a[aria-current='page'] {
-      background: rgba(10, 174, 122, 0.12);
-      border-inline-start-color: #0aae7a;
+      background: rgba(var(--netscli-accent-rgb), 0.12);
+      border-inline-start-color: var(--netscli-accent);
       color: var(--sl-color-white);
     }
 

--- a/site/src/data/site-content/meta.ts
+++ b/site/src/data/site-content/meta.ts
@@ -30,7 +30,7 @@ export const meta: Meta = {
 export const branding: Branding = {
   wordmark: '/assets/netscli-wordmark.png',
   wordmarkAlt: 'NetsCLI',
-  accentGradient: 'linear-gradient(90deg,#059669,#0aae7a 50%,#1edcff)',
+  accentGradient: 'linear-gradient(90deg,#16a34a,#22c55e 50%,#1edcff)',
   bg: '#111',
   fg: '#d4d4d4',
 };

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -38,7 +38,7 @@ import Footer from '../components/Footer.astro';
 .not-found{
   padding:clamp(32px,5vh,60px) 24px;
   background:
-    linear-gradient(180deg,rgba(10,174,122,.045),transparent 20rem),
+    linear-gradient(180deg,rgba(var(--netscli-accent-rgb),.045),transparent 20rem),
     #111;
 }
 .not-found-shell{
@@ -61,7 +61,7 @@ import Footer from '../components/Footer.astro';
 }
 .not-found .eyebrow{
   margin:0 0 12px;
-  color:#0aae7a;
+  color:var(--netscli-accent);
   font-size:.75rem;
   font-weight:800;
   letter-spacing:.14em;
@@ -92,7 +92,7 @@ import Footer from '../components/Footer.astro';
   align-items:center;
   justify-content:center;
   padding:9px 17px;
-  border:1px solid rgba(10,174,122,.35);
+  border:1px solid rgba(var(--netscli-accent-rgb),.35);
   border-radius:7px;
   color:#e5e5e5;
   text-decoration:none;
@@ -101,8 +101,8 @@ import Footer from '../components/Footer.astro';
 }
 .not-found-actions a.primary{
   color:#06130f;
-  border-color:#0aae7a;
-  background:#0aae7a;
+  border-color:var(--netscli-accent);
+  background:var(--netscli-accent);
 }
 .not-found-actions a:hover,
 .not-found-actions a:focus-visible{
@@ -113,8 +113,8 @@ import Footer from '../components/Footer.astro';
 .not-found-actions a.primary:hover,
 .not-found-actions a.primary:focus-visible{
   color:#06130f;
-  background:#23d198;
-  border-color:#23d198;
+  background:var(--netscli-accent-bright);
+  border-color:var(--netscli-accent-bright);
 }
 @media(max-width:820px){
   .not-found{

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -121,7 +121,7 @@ const fallbackReleases = parseLocalChangelog(changelogText);
   padding-bottom:28px;margin-bottom:28px;
 }
 .changelog-kicker{
-  margin:0 0 8px;color:#0aae7a;font-size:.75rem;font-weight:700;
+  margin:0 0 8px;color:var(--netscli-accent);font-size:.75rem;font-weight:700;
   text-transform:uppercase;letter-spacing:.08em;
 }
 .changelog-hero h1{
@@ -140,7 +140,7 @@ const fallbackReleases = parseLocalChangelog(changelogText);
   color:#d7d7d7;text-decoration:none;font-size:.83rem;font-weight:600;
   background:rgba(255,255,255,.035);
 }
-.changelog-actions a:hover{border-color:rgba(10,174,122,.45);color:#1ec88c}
+.changelog-actions a:hover{border-color:rgba(var(--netscli-accent-rgb),.45);color:#1ec88c}
 .changelog-content{
   display:grid;
   grid-template-columns:minmax(0,1fr) 8.5rem;
@@ -207,13 +207,13 @@ const fallbackReleases = parseLocalChangelog(changelogText);
 .release-timeline-link:hover,
 .release-timeline-link:focus-visible,
 .release-timeline-link.active{
-  color:#23d198;
+  color:var(--netscli-accent-bright);
   outline:0;
 }
 .release-timeline-link:hover::before,
 .release-timeline-link:focus-visible::before,
 .release-timeline-link.active::before{
-  background:#0aae7a;
+  background:var(--netscli-accent);
 }
 .release-timeline-empty{
   color:#737f91;
@@ -294,8 +294,8 @@ const fallbackReleases = parseLocalChangelog(changelogText);
 .release-body :not(pre)>code{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:.86em;line-height:1.45;
-  background:rgba(10,174,122,.09);color:#23d198;
-  border:1px solid rgba(10,174,122,.18);border-radius:4px;
+  background:rgba(var(--netscli-accent-rgb),.09);color:var(--netscli-accent-bright);
+  border:1px solid rgba(var(--netscli-accent-rgb),.18);border-radius:4px;
   padding:.08em .34em;white-space:normal;overflow-wrap:anywhere;word-break:break-word;
 }
 .release-body .release-code{
@@ -306,24 +306,24 @@ const fallbackReleases = parseLocalChangelog(changelogText);
 }
 .release-body .release-code::before{
   content:"";position:absolute;inset-block-start:0;inset-inline:0;
-  height:2px;background:rgba(10,174,122,.55);
+  height:2px;background:rgba(var(--netscli-accent-rgb),.55);
 }
 .release-body .release-code-content{
   display:block;background:transparent;border:0;border-radius:0;
   color:inherit;font-size:.82rem;line-height:1.64;padding:0;
   white-space:pre;
 }
-.release-body a{color:#0aae7a;text-decoration:none}
+.release-body a{color:var(--netscli-accent);text-decoration:none}
 .release-body a,
 .release-body a .external-link-label{
   min-width:0;overflow-wrap:anywhere;word-break:break-word;
 }
 .release-body a .external-link-label{text-decoration:underline;text-underline-offset:3px}
-.release-body a:hover{color:#23d198}
-.release-body a:hover .external-link-label{text-decoration-color:#23d198}
+.release-body a:hover{color:var(--netscli-accent-bright)}
+.release-body a:hover .external-link-label{text-decoration-color:var(--netscli-accent-bright)}
 .release-quote{
-  margin:0;max-width:none;border-left:3px solid rgba(10,174,122,.55);
-  padding:8px 12px;background:rgba(10,174,122,.065);color:#b8c0cd;
+  margin:0;max-width:none;border-left:3px solid rgba(var(--netscli-accent-rgb),.55);
+  padding:8px 12px;background:rgba(var(--netscli-accent-rgb),.065);color:#b8c0cd;
 }
 .release-empty{
   color:#8f98a8;background:rgba(255,255,255,.03);
@@ -341,7 +341,7 @@ const fallbackReleases = parseLocalChangelog(changelogText);
   border:0;
   border-radius:0;
   background:transparent;
-  color:#0aae7a;
+  color:var(--netscli-accent);
   font:inherit;
   font-size:.8rem;
   font-weight:400;
@@ -353,11 +353,11 @@ const fallbackReleases = parseLocalChangelog(changelogText);
 }
 .release-toggle::after{
   content:"";
-  color:#23d198;
+  color:var(--netscli-accent-bright);
 }
 .release-toggle:hover,
 .release-toggle:focus-visible{
-  color:#23d198;
+  color:var(--netscli-accent-bright);
   background:transparent;
   outline:0;
 }

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -77,7 +77,7 @@ body.not-found-page .not-found{
 a{color:inherit}
 code{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.85em;
-  background:rgba(255,255,255,.07);padding:2px 6px;border-radius:4px;color:#23d198;
+  background:rgba(255,255,255,.07);padding:2px 6px;border-radius:4px;color:var(--netscli-accent-bright);
 }
 
 /* layout */
@@ -113,13 +113,13 @@ section:nth-of-type(even)::before{
   position:absolute;inset:0;
   pointer-events:none;
   z-index:0;
-  background:radial-gradient(circle at 18% 0%,rgba(10,174,122,.055),transparent 34rem);
+  background:radial-gradient(circle at 18% 0%,rgba(var(--netscli-accent-rgb),.055),transparent 34rem);
 }
 section>.w{position:relative;z-index:1}
 section h2{font-size:1.5rem;font-weight:700;color:#f5f5f5;margin:0 0 6px}
 section .lead{color:#a3a3a3;font-size:.9375rem;margin:0 0 28px}
-section .lead a{color:#0aae7a;text-decoration:underline;text-underline-offset:3px}
-section .lead a:hover{color:#23d198}
+section .lead a{color:var(--netscli-accent);text-decoration:underline;text-underline-offset:3px}
+section .lead a:hover{color:var(--netscli-accent-bright)}
 
 
 /* ─── COPY BUTTON ─── */

--- a/site/src/styles/starlight/01-tokens-and-header.css
+++ b/site/src/styles/starlight/01-tokens-and-header.css
@@ -2,9 +2,9 @@
 
 html[data-theme='dark'],
 html[data-theme='dark'] ::backdrop {
-  --sl-color-accent-low: #06291e;
-  --sl-color-accent: #0aae7a;
-  --sl-color-accent-high: #9ff8de;
+  --sl-color-accent-low: #0a2a13;
+  --sl-color-accent: var(--netscli-accent);
+  --sl-color-accent-high: var(--netscli-accent-high);
   --sl-color-white: #f4f4f4;
   --sl-color-gray-1: #e7edf6;
   --sl-color-gray-2: #c2cad8;
@@ -16,7 +16,7 @@ html[data-theme='dark'] ::backdrop {
   --sl-color-bg: #111111;
   --sl-color-bg-nav: rgba(17, 17, 17, 0.92);
   --sl-color-bg-sidebar: #111111;
-  --sl-color-bg-inline-code: rgba(10, 174, 122, 0.09);
+  --sl-color-bg-inline-code: rgba(var(--netscli-accent-rgb), 0.09);
   --sl-color-hairline: rgba(255, 255, 255, 0.08);
   --sl-color-hairline-light: rgba(255, 255, 255, 0.1);
   --sl-color-hairline-shade: #070707;
@@ -25,9 +25,9 @@ html[data-theme='dark'] ::backdrop {
 
 html[data-theme='light'],
 html[data-theme='light'] ::backdrop {
-  --sl-color-accent-low: #d9f8ef;
-  --sl-color-accent: #007a54;
-  --sl-color-accent-high: #064934;
+  --sl-color-accent-low: #dcf8e4;
+  --sl-color-accent: #146b2e;
+  --sl-color-accent-high: #0b4a1f;
   --sl-color-white: #111827;
   --sl-color-gray-1: #243044;
   --sl-color-gray-2: #44516a;
@@ -177,7 +177,7 @@ header.header::after {
 
   box-shadow:
     0 14px 34px rgba(0, 0, 0, 0.28),
-    0 1px 0 rgba(10, 174, 122, 0.12) !important;
+    0 1px 0 rgba(var(--netscli-accent-rgb), 0.12) !important;
 }
 
 html[data-docs-scrolled='true'] header.header::after {
@@ -230,8 +230,8 @@ starlight-menu-button button {
 starlight-menu-button button:hover,
 starlight-menu-button button:focus-visible,
 starlight-menu-button[aria-expanded='true'] button {
-  background: rgba(10, 174, 122, 0.12);
-  border-color: rgba(10, 174, 122, 0.28);
+  background: rgba(var(--netscli-accent-rgb), 0.12);
+  border-color: rgba(var(--netscli-accent-rgb), 0.28);
   color: var(--sl-color-white);
 }
 
@@ -252,7 +252,7 @@ site-search button[data-open-modal]:hover {
     rgba(17, 22, 29, 0.96);
   color: var(--sl-color-white);
   box-shadow:
-    0 0 0 1px rgba(10, 174, 122, 0.16),
+    0 0 0 1px rgba(var(--netscli-accent-rgb), 0.16),
     inset 0 1px 0 rgba(255, 255, 255, 0.035);
 }
 
@@ -260,6 +260,6 @@ site-search button[data-open-modal]:focus-visible {
   outline: 0;
   border-color: rgba(159, 248, 222, 0.62);
   box-shadow:
-    0 0 0 2px rgba(10, 174, 122, 0.18),
+    0 0 0 2px rgba(var(--netscli-accent-rgb), 0.18),
     inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }

--- a/site/src/styles/starlight/02-search-and-sidebar-base.css
+++ b/site/src/styles/starlight/02-search-and-sidebar-base.css
@@ -6,7 +6,7 @@ site-search button[data-open-modal] svg {
 
 site-search button[data-open-modal]:hover svg,
 site-search button[data-open-modal]:focus-visible svg {
-  color: #9ff8de;
+  color: var(--netscli-accent-high);
 }
 
 site-search button[data-open-modal] > kbd {
@@ -46,7 +46,7 @@ site-search button[data-close-modal] {
 site-search button[data-close-modal]:hover,
 site-search button[data-close-modal]:focus-visible {
   outline: 0;
-  background: rgba(10, 174, 122, 0.12) !important;
+  background: rgba(var(--netscli-accent-rgb), 0.12) !important;
   color: var(--sl-color-white) !important;
 }
 
@@ -56,7 +56,7 @@ site-search button[data-close-modal]:focus-visible {
   --pagefind-ui-background: #171b22;
   --pagefind-ui-border: rgba(140, 149, 166, 0.28);
   --pagefind-ui-border-width: 1px;
-  --pagefind-ui-tag: rgba(10, 174, 122, 0.12);
+  --pagefind-ui-tag: rgba(var(--netscli-accent-rgb), 0.12);
   --sl-search-corners: 6px;
 }#starlight__search .pagefind-ui__search-input {
   border-color: rgba(140, 149, 166, 0.32) !important;
@@ -70,7 +70,7 @@ site-search button[data-close-modal]:focus-visible {
   outline: 0 !important;
   border-color: rgba(159, 248, 222, 0.72) !important;
   box-shadow:
-    0 0 0 2px rgba(10, 174, 122, 0.16),
+    0 0 0 2px rgba(var(--netscli-accent-rgb), 0.16),
     inset 0 1px 0 rgba(255, 255, 255, 0.04) !important;
 }
 
@@ -86,13 +86,13 @@ site-search button[data-close-modal]:focus-visible {
 #starlight__search .pagefind-ui__result-nested:hover,
 #starlight__search .pagefind-ui__result-nested:focus-within {
   outline: 0 !important;
-  border-color: rgba(10, 174, 122, 0.34);
+  border-color: rgba(var(--netscli-accent-rgb), 0.34);
 
 }
 
 #starlight__search mark {
-  color: #9ff8de !important;
-  background: rgba(10, 174, 122, 0.16) !important;
+  color: var(--netscli-accent-high) !important;
+  background: rgba(var(--netscli-accent-rgb), 0.16) !important;
   border-radius: 3px;
   padding-inline: 0.12em;
 }
@@ -189,7 +189,7 @@ html[data-theme='light'] starlight-menu-button[aria-expanded='true'] button {
 }
 
 .sidebar-content a[aria-current='page']:hover {
-  background: rgba(10, 174, 122, 0.15);
+  background: rgba(var(--netscli-accent-rgb), 0.15);
   box-shadow: none;
 }
 
@@ -222,7 +222,7 @@ html[data-theme='light'] starlight-menu-button[aria-expanded='true'] button {
 
   .sidebar-pane {
     background:
-      linear-gradient(180deg, rgba(10, 174, 122, 0.035), transparent 9rem),
+      linear-gradient(180deg, rgba(var(--netscli-accent-rgb), 0.035), transparent 9rem),
       var(--sl-color-bg-sidebar);
   }
 

--- a/site/src/styles/starlight/03-shell-layout-base.css
+++ b/site/src/styles/starlight/03-shell-layout-base.css
@@ -96,8 +96,8 @@
   z-index: -1;
   pointer-events: none;
   background:
-    radial-gradient(circle at 0 0, rgba(10, 174, 122, 0.1), transparent 26rem),
-    linear-gradient(125deg, rgba(10, 174, 122, 0.04), rgba(255, 255, 255, 0.018) 38%, transparent 72%);
+    radial-gradient(circle at 0 0, rgba(var(--netscli-accent-rgb), 0.1), transparent 26rem),
+    linear-gradient(125deg, rgba(var(--netscli-accent-rgb), 0.04), rgba(255, 255, 255, 0.018) 38%, transparent 72%);
 }
 
 .main-pane > .content-panel:first-of-type > .sl-container,
@@ -127,7 +127,7 @@ html[data-theme='light'] .main-pane > .content-panel:first-child::before {
 }
 
 .sl-markdown-content a {
-  color: #0aae7a;
+  color: var(--netscli-accent);
   text-underline-offset: 3px;
 }
 
@@ -157,10 +157,10 @@ html[data-theme='light'] .main-pane > .content-panel:first-child::before {
 }
 
 .sl-markdown-content :not(pre) > code {
-  border: 1px solid rgba(10, 174, 122, 0.18);
+  border: 1px solid rgba(var(--netscli-accent-rgb), 0.18);
   border-radius: 0.24rem;
 
-  color: #9ff8de;
+  color: var(--netscli-accent-high);
   font-family: var(--__sl-font-mono);
   font-size: 0.9em;
   line-height: 1.45;
@@ -175,7 +175,7 @@ html[data-theme='light'] .main-pane > .content-panel:first-child::before {
   --ec-codeLineHt: 1.64;
   --ec-codePadBlk: 1rem;
   --ec-codePadInl: 1.15rem;
-  --ec-focusBrd: #9ff8de;
+  --ec-focusBrd: var(--netscli-accent-high);
   --ec-sbThumbCol: rgba(140, 149, 166, 0.22);
   --ec-sbThumbHoverCol: rgba(159, 248, 222, 0.32);
   --ec-frm-frameBoxShdCssVal: 0 18px 46px rgba(0, 0, 0, 0.34);
@@ -184,10 +184,10 @@ html[data-theme='light'] .main-pane > .content-panel:first-child::before {
   --ec-frm-trmTtbDotsFg: #8c95a6;
   --ec-frm-trmTtbDotsOpa: 0.48;
   --ec-frm-trmBg: #10151b;
-  --ec-frm-inlBtnFg: #9ff8de;
-  --ec-frm-inlBtnBg: #9ff8de;
-  --ec-frm-inlBtnBrd: #9ff8de;
-  --ec-frm-tooltipSuccessBg: #0aae7a;
+  --ec-frm-inlBtnFg: var(--netscli-accent-high);
+  --ec-frm-inlBtnBg: var(--netscli-accent-high);
+  --ec-frm-inlBtnBrd: var(--netscli-accent-high);
+  --ec-frm-tooltipSuccessBg: var(--netscli-accent);
 
 }
 
@@ -232,7 +232,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
 
 html[data-theme='light'] .sl-markdown-content :not(pre) > code {
 
-  color: #064934;
+  color: #0b4a1f;
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code {
@@ -242,9 +242,9 @@ html[data-theme='light'] .sl-markdown-content .expressive-code {
   --ec-frm-trmTtbBg: #edf2f3;
   --ec-frm-trmTtbBrdBtmCol: rgba(17, 24, 39, 0.1);
   --ec-frm-trmBg: #f7faf9;
-  --ec-frm-inlBtnFg: #007a54;
-  --ec-frm-inlBtnBg: #007a54;
-  --ec-frm-inlBtnBrd: #007a54;
+  --ec-frm-inlBtnFg: #146b2e;
+  --ec-frm-inlBtnBg: #146b2e;
+  --ec-frm-inlBtnBrd: #146b2e;
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code pre {
@@ -259,7 +259,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .ec-line :where(s
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .ec-line :where(span[style*='#0A3069']),
 html[data-theme='light'] .sl-markdown-content .expressive-code .ec-line :where(span[style*='#0550AE']) {
-  --1: #007a54 !important;
+  --1: #146b2e !important;
 }
 
 .sl-markdown-content table {

--- a/site/src/styles/starlight/04-markdown-content-base.css
+++ b/site/src/styles/starlight/04-markdown-content-base.css
@@ -186,8 +186,8 @@
 }
 
 .sl-markdown-content blockquote {
-  border-inline-start-color: #0aae7a;
-  background: rgba(10, 174, 122, 0.055);
+  border-inline-start-color: var(--netscli-accent);
+  background: rgba(var(--netscli-accent-rgb), 0.055);
   border-radius: 0 8px 8px 0;
   padding: 0.65rem 0.9rem;
 }

--- a/site/src/styles/starlight/05-docs-surfaces.css
+++ b/site/src/styles/starlight/05-docs-surfaces.css
@@ -192,7 +192,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
 
 .sl-markdown-content thead tr {
   background: #252b36;
-  box-shadow: inset 0 -2px 0 rgba(10, 174, 122, 0.55);
+  box-shadow: inset 0 -2px 0 rgba(var(--netscli-accent-rgb), 0.55);
 }
 
 .sl-markdown-content th {

--- a/site/src/styles/starlight/06-docs-interaction-a.css
+++ b/site/src/styles/starlight/06-docs-interaction-a.css
@@ -43,7 +43,7 @@
 }
 
 #starlight__search .pagefind-ui__search-clear::before {
-  background-color: #9ff8de;
+  background-color: var(--netscli-accent-high);
   opacity: 0.86;
   -webkit-mask-size: 42% !important;
   mask-size: 42% !important;

--- a/site/src/styles/starlight/07-docs-interaction-b.css
+++ b/site/src/styles/starlight/07-docs-interaction-b.css
@@ -5,7 +5,7 @@
 #starlight__search .pagefind-ui__result-nested:focus-within {
   background: #2b313d !important;
   box-shadow:
-    inset 2px 0 0 rgba(10, 174, 122, 0.74),
+    inset 2px 0 0 rgba(var(--netscli-accent-rgb), 0.74),
     inset 0 -1px 0 rgba(140, 149, 166, 0.13);
 }
 
@@ -14,9 +14,9 @@
   --ec-codeBg: #20242b;
   --ec-codeFg: #d7dce5;
   --ec-frm-trmBg: #20242b;
-  --ec-frm-inlBtnFg: #9ff8de;
-  --ec-frm-inlBtnBg: #9ff8de;
-  --ec-frm-inlBtnBrd: #9ff8de;
+  --ec-frm-inlBtnFg: var(--netscli-accent-high);
+  --ec-frm-inlBtnBg: var(--netscli-accent-high);
+  --ec-frm-inlBtnBrd: var(--netscli-accent-high);
   --netscli-code-copy-inset: 0.65rem;
   --netscli-code-copy-size: 1.85rem;
   --netscli-code-copy-space: 3.2rem;
@@ -39,7 +39,7 @@
   inset-inline: 0;
   z-index: 1;
   height: 2px;
-  background: rgba(10, 174, 122, 0.55);
+  background: rgba(var(--netscli-accent-rgb), 0.55);
 }
 
 .sl-markdown-content .expressive-code pre {
@@ -71,7 +71,7 @@
 
 .sl-markdown-content .expressive-code .copy button:hover,
 .sl-markdown-content .expressive-code .copy button:focus-visible {
-  border-color: rgba(10, 174, 122, 0.42);
+  border-color: rgba(var(--netscli-accent-rgb), 0.42);
   background: #2b313d;
 }
 
@@ -96,11 +96,11 @@ html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
 .sl-markdown-content .sl-anchor-link,
 .sl-markdown-content .sl-anchor-link:focus,
 .sl-markdown-content .sl-heading-wrapper:hover .sl-anchor-link {
-  color: #0aae7a !important;
+  color: var(--netscli-accent) !important;
 }
 
 .sl-markdown-content .sl-anchor-icon > svg {
-  color: #0aae7a;
+  color: var(--netscli-accent);
 }.pagination-links a {
   align-items: flex-start;
   color: var(--sl-color-gray-1) !important;
@@ -120,11 +120,11 @@ html[data-theme='light'] .pagination-links a:hover {
 
 .pagination-links a > svg {
   margin-block-start: 0.12rem;
-  color: #0aae7a;
+  color: var(--netscli-accent);
 }
 
 html[data-theme='light'] .pagination-links a > svg {
-  color: #007a54;
+  color: #146b2e;
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__result-inner,

--- a/site/src/styles/starlight/08-search-modal.css
+++ b/site/src/styles/starlight/08-search-modal.css
@@ -143,7 +143,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__message .search-data {
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__search-clear::before {
-  background-color: #007a54;
+  background-color: #146b2e;
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__result-inner {
@@ -172,8 +172,8 @@ html[data-theme='light'] #starlight__search .pagefind-ui__result-excerpt {
 }
 
 html[data-theme='light'] #starlight__search mark {
-  color: #064934 !important;
-  background: #d9f8ef !important;
+  color: #0b4a1f !important;
+  background: #dcf8e4 !important;
 }
 
 html[data-theme='light']

--- a/site/src/styles/starlight/10-docs-feedback.css
+++ b/site/src/styles/starlight/10-docs-feedback.css
@@ -42,7 +42,7 @@
 
 .sl-markdown-content .expressive-code .copy button[data-copied] {
 
-  color: #9ff8de !important;
+  color: var(--netscli-accent-high) !important;
 }html[data-theme='light'] #starlight__search .pagefind-ui__search-input {
   background: #ffffff !important;
   box-shadow: none !important;
@@ -51,5 +51,5 @@
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy button[data-copied] {
 
   background: #e5f3ef !important;
-  color: #064934 !important;
+  color: #0b4a1f !important;
 }

--- a/site/src/styles/starlight/11-docs-chrome-consistency.css
+++ b/site/src/styles/starlight/11-docs-chrome-consistency.css
@@ -2,7 +2,7 @@
    NetsCLI green for content affordances, and constrain the hero divider to the
    actual reading column. */
 header.header {
-  border-bottom-color: rgba(10, 174, 122, 0.12) !important;
+  border-bottom-color: rgba(var(--netscli-accent-rgb), 0.12) !important;
 }
 
 html[data-theme='light'] header.header {
@@ -18,7 +18,7 @@ html:not([data-docs-scrolled='true']) header.header::after {
 }
 
 html[data-docs-scrolled='true'] header.header {
-  border-bottom-color: rgba(10, 174, 122, 0.12) !important;
+  border-bottom-color: rgba(var(--netscli-accent-rgb), 0.12) !important;
 }
 
 html[data-theme='light'][data-docs-scrolled='true'] header.header {
@@ -47,8 +47,8 @@ html[data-theme='light'][data-docs-scrolled='true'] header.header {
   z-index: 0;
   pointer-events: none;
   background:
-    radial-gradient(circle at 0 0, rgba(10, 174, 122, 0.11), transparent 25rem),
-    linear-gradient(128deg, rgba(10, 174, 122, 0.045), rgba(30, 220, 255, 0.016) 38%, transparent 72%);
+    radial-gradient(circle at 0 0, rgba(var(--netscli-accent-rgb), 0.11), transparent 25rem),
+    linear-gradient(128deg, rgba(var(--netscli-accent-rgb), 0.045), rgba(30, 220, 255, 0.016) 38%, transparent 72%);
 }
 
 .main-pane > .content-panel:first-of-type > .sl-container,
@@ -82,29 +82,29 @@ html[data-theme='light'] .main-pane > main > .content-panel:first-child::before 
 }
 
 .sl-markdown-content :not(pre) > code {
-  color: #23d198 !important;
+  color: var(--netscli-accent-bright) !important;
 }
 
 html[data-theme='light'] .sl-markdown-content :not(pre) > code {
-  color: #007a54 !important;
+  color: #146b2e !important;
 }
 
 .sl-markdown-content a,
 .sl-markdown-content .sl-anchor-link,
 .sl-markdown-content .sl-anchor-link:focus,
 .sl-markdown-content .sl-heading-wrapper:hover .sl-anchor-link {
-  color: #0aae7a !important;
+  color: var(--netscli-accent) !important;
 }
 
 .sl-markdown-content a:hover {
-  color: #23d198 !important;
+  color: var(--netscli-accent-bright) !important;
 }
 
 html[data-theme='light'] .sl-markdown-content a,
 html[data-theme='light'] .sl-markdown-content .sl-anchor-link,
 html[data-theme='light'] .sl-markdown-content .sl-anchor-link:focus,
 html[data-theme='light'] .sl-markdown-content .sl-heading-wrapper:hover .sl-anchor-link {
-  color: #007a54 !important;
+  color: #146b2e !important;
 }
 
 html[data-theme='light'] .sl-markdown-content a:hover {
@@ -118,7 +118,7 @@ html[data-theme='light'] .sl-markdown-content a:hover {
   background: none !important;
   -webkit-mask: none !important;
   mask: none !important;
-  color: #0aae7a !important;
+  color: var(--netscli-accent) !important;
   font-size: 0.92em;
   font-weight: 700;
   line-height: 1;
@@ -126,12 +126,12 @@ html[data-theme='light'] .sl-markdown-content a:hover {
 
 .external-link:hover::after,
 .sl-markdown-content a[href^='http']:hover::after {
-  color: #23d198 !important;
+  color: var(--netscli-accent-bright) !important;
 }
 
 html[data-theme='light'] .external-link::after,
 html[data-theme='light'] .sl-markdown-content a[href^='http']::after {
-  color: #007a54 !important;
+  color: #146b2e !important;
 }
 
 html[data-theme='light'] .external-link:hover::after,

--- a/site/src/styles/starlight/12-docs-toc-responsive.css
+++ b/site/src/styles/starlight/12-docs-toc-responsive.css
@@ -49,7 +49,7 @@
   }
 
   mobile-starlight-toc .caret {
-    color: #0aae7a;
+    color: var(--netscli-accent);
   }
 
   mobile-starlight-toc .display-current {
@@ -134,7 +134,7 @@ html[data-theme='light'] mobile-starlight-toc summary:focus-visible .toggle {
 }
 
 html[data-theme='light'] mobile-starlight-toc .caret {
-  color: #007a54;
+  color: #146b2e;
 }
 
 html[data-theme='light'] mobile-starlight-toc .display-current {
@@ -212,9 +212,9 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .copy button[data
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy:has(.feedback.show) button {
   border-color: rgba(0, 122, 84, 0.3) !important;
   background: #e5f3ef !important;
-  color: #007a54 !important;
+  color: #146b2e !important;
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy:has(.feedback.show) button::after {
-  background: #007a54 !important;
+  background: #146b2e !important;
 }

--- a/site/src/styles/starlight/14-docs-nav-table.css
+++ b/site/src/styles/starlight/14-docs-nav-table.css
@@ -122,9 +122,9 @@
   }
 
   mobile-starlight-toc .dropdown a[aria-current='true'] {
-    color: #9ff8de !important;
-    border-inline-start-color: #0aae7a !important;
-    background: rgba(10, 174, 122, 0.08) !important;
+    color: var(--netscli-accent-high) !important;
+    border-inline-start-color: var(--netscli-accent) !important;
+    background: rgba(var(--netscli-accent-rgb), 0.08) !important;
   }
 }
 
@@ -204,7 +204,7 @@ html[data-theme='light'] mobile-starlight-toc .dropdown a:focus-visible {
 }
 
 html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true'] {
-  color: #064934 !important;
-  border-inline-start-color: #007a54 !important;
+  color: #0b4a1f !important;
+  border-inline-start-color: #146b2e !important;
   background: rgba(0, 122, 84, 0.08) !important;
 }

--- a/site/src/styles/starlight/16-shell-interaction-closeout.css
+++ b/site/src/styles/starlight/16-shell-interaction-closeout.css
@@ -40,9 +40,9 @@ site-search button[data-open-modal]:hover {
 }
 
 site-search button[data-open-modal]:hover {
-  border-color: rgba(10, 174, 122, 0.48) !important;
+  border-color: rgba(var(--netscli-accent-rgb), 0.48) !important;
   box-shadow:
-    0 0 0 1px rgba(10, 174, 122, 0.16),
+    0 0 0 1px rgba(var(--netscli-accent-rgb), 0.16),
     inset 0 1px 0 rgba(255, 255, 255, 0.035) !important;
 }
 
@@ -83,7 +83,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-u
 .pagination-links a:hover,
 .pagination-links a:focus-visible {
 
-  border-color: rgba(10, 174, 122, 0.36) !important;
+  border-color: rgba(var(--netscli-accent-rgb), 0.36) !important;
   color: var(--sl-color-white) !important;
   outline: 0 !important;
 }
@@ -108,7 +108,7 @@ html[data-theme='light'] .pagination-links a:focus-visible {
   border-radius: 0 !important;
   background: transparent !important;
   box-shadow: none !important;
-  color: #0aae7a !important;
+  color: var(--netscli-accent) !important;
   font: inherit !important;
   font-size: 0.8rem !important;
   font-weight: 400 !important;
@@ -123,7 +123,7 @@ html[data-theme='light'] .pagination-links a:focus-visible {
 #starlight__search .pagefind-ui__button:focus-visible {
   background: transparent !important;
   box-shadow: none !important;
-  color: #23d198 !important;
+  color: var(--netscli-accent-bright) !important;
   outline: 0 !important;
 }
 

--- a/site/src/styles/starlight/17-mobile-shell-closeout-a.css
+++ b/site/src/styles/starlight/17-mobile-shell-closeout-a.css
@@ -131,7 +131,7 @@
   }
 
   .docs-mobile-section-caret {
-    color: #0aae7a;
+    color: var(--netscli-accent);
     font-size: 1rem;
     line-height: 1;
 

--- a/site/src/styles/starlight/18-mobile-shell-closeout-b.css
+++ b/site/src/styles/starlight/18-mobile-shell-closeout-b.css
@@ -25,8 +25,8 @@
 
   .docs-mobile-section-menu a[aria-current='page'] {
     color: var(--sl-color-white);
-    border-inline-start-color: #0aae7a;
-    background: rgba(10, 174, 122, 0.07);
+    border-inline-start-color: var(--netscli-accent);
+    background: rgba(var(--netscli-accent-rgb), 0.07);
   }
 
   mobile-starlight-toc {
@@ -71,7 +71,7 @@
   }
 
   mobile-starlight-toc .caret {
-    color: #0aae7a !important;
+    color: var(--netscli-accent) !important;
   }
 
   mobile-starlight-toc details[open] .toggle,
@@ -127,9 +127,9 @@
   mobile-starlight-toc .dropdown a[aria-current='true'],
   mobile-starlight-toc .dropdown a[aria-current='true']:hover,
   mobile-starlight-toc .dropdown a[aria-current='true']:focus-visible {
-    color: #9ff8de !important;
-    border-inline-start-color: #0aae7a !important;
-    background: rgba(10, 174, 122, 0.06) !important;
+    color: var(--netscli-accent-high) !important;
+    border-inline-start-color: var(--netscli-accent) !important;
+    background: rgba(var(--netscli-accent-rgb), 0.06) !important;
   }
 
   mobile-starlight-toc .isMobile a[aria-current='true']::after {
@@ -163,8 +163,8 @@ html[data-theme='light'] .docs-mobile-section-menu a[aria-current='page'],
 html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true'],
 html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true']:hover,
 html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true']:focus-visible {
-  color: #064934 !important;
-  border-inline-start-color: #007a54 !important;
+  color: #0b4a1f !important;
+  border-inline-start-color: #146b2e !important;
   background: rgba(0, 122, 84, 0.055) !important;
 }
 

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -22,7 +22,7 @@
 
 .right-sidebar-panel :where(a):hover,
 .right-sidebar-panel :where(a):focus-visible {
-  color: #9ff8de !important;
+  color: var(--netscli-accent-high) !important;
   background: transparent !important;
   outline: 0 !important;
 }
@@ -30,9 +30,9 @@
 .right-sidebar-panel :where(a[aria-current='true']),
 .right-sidebar-panel :where(a[aria-current='page']),
 .right-sidebar-panel :where(a[aria-current='location']) {
-  color: #9ff8de !important;
+  color: var(--netscli-accent-high) !important;
   background: transparent !important;
-  border-inline-start-color: #0aae7a !important;
+  border-inline-start-color: var(--netscli-accent) !important;
 }
 
 html[data-theme='light'] .right-sidebar-panel :where(a):hover,
@@ -63,8 +63,8 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 }
 
 .sidebar-content a[aria-current='page'] {
-  border-inline-start-color: #0aae7a !important;
-  background: rgba(10, 174, 122, 0.12) !important;
+  border-inline-start-color: var(--netscli-accent) !important;
+  background: rgba(var(--netscli-accent-rgb), 0.12) !important;
   box-shadow: none !important;
 }
 
@@ -124,7 +124,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 
   .docs-mobile-section-separator,
   .docs-mobile-section-caret {
-    color: #0aae7a !important;
+    color: var(--netscli-accent) !important;
   }
 
   .docs-mobile-section-caret {
@@ -181,9 +181,9 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   mobile-starlight-toc .dropdown a[aria-current='true'],
   mobile-starlight-toc .dropdown a[aria-current='true']:hover,
   mobile-starlight-toc .dropdown a[aria-current='true']:focus-visible {
-    color: #9ff8de !important;
-    background: rgba(10, 174, 122, 0.07) !important;
-    border-inline-start-color: #0aae7a !important;
+    color: var(--netscli-accent-high) !important;
+    background: rgba(var(--netscli-accent-rgb), 0.07) !important;
+    border-inline-start-color: var(--netscli-accent) !important;
   }
 
   mobile-starlight-toc .dropdown a[aria-current='true']::after,
@@ -230,7 +230,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
      * panel now follows the theme and hides what is behind it. The green
      * wash stays; it is decorative and reads on both. */
     background:
-      linear-gradient(180deg, rgba(10, 174, 122, 0.04), transparent 11rem),
+      linear-gradient(180deg, rgba(var(--netscli-accent-rgb), 0.04), transparent 11rem),
       var(--sl-color-bg-sidebar) !important;
     box-shadow: 18px 0 46px rgba(0, 0, 0, 0.36) !important;
     overflow: auto !important;

--- a/site/src/styles/starlight/21-mobile-docs-shell-verified.css
+++ b/site/src/styles/starlight/21-mobile-docs-shell-verified.css
@@ -25,7 +25,7 @@
 
 .sidebar-content :where(details > ul a[aria-current='page']) {
 
-  background: rgba(10, 174, 122, 0.12) !important;
+  background: rgba(var(--netscli-accent-rgb), 0.12) !important;
   box-shadow: none !important;
 }
 

--- a/site/src/styles/starlight/22-mobile-docs-correction.css
+++ b/site/src/styles/starlight/22-mobile-docs-correction.css
@@ -74,7 +74,7 @@
   .netscli-mobile-toc-wrapper mobile-starlight-toc .dropdown a:hover,
   .netscli-mobile-toc-wrapper mobile-starlight-toc .dropdown a:focus-visible,
   .netscli-mobile-toc-wrapper mobile-starlight-toc .dropdown a[aria-current='true'] {
-    color: #9ff8de !important;
+    color: var(--netscli-accent-high) !important;
   }
 
   .docs-mobile-section-menu {

--- a/site/src/styles/starlight/23-regression-guardrails.css
+++ b/site/src/styles/starlight/23-regression-guardrails.css
@@ -12,7 +12,7 @@
 }
 
 .sidebar-content :where(details > ul a[aria-current='page']) {
-  border-inline-start-color: #0aae7a !important;
+  border-inline-start-color: var(--netscli-accent) !important;
 }
 
 .docs-mobile-section-nav summary,

--- a/site/src/styles/starlight/26-mobile-containment.css
+++ b/site/src/styles/starlight/26-mobile-containment.css
@@ -60,6 +60,13 @@
     width: 2.5rem !important;
     max-width: 2.5rem !important;
     min-width: 2.5rem !important;
+    /* Square, like the menu button beside it. Both are pinned to the same
+       inset-block-start, but this one kept the full-bar height it is given
+       at desktop widths, so the box ran from 10px to 70px -- past the 60px
+       bar -- and its 40px button sat at the bottom of it, 10px lower than
+       the menu button. */
+    height: 2.5rem !important;
+    min-height: 0 !important;
   }
 
   .sl-markdown-content .netscli-table-scroll,

--- a/site/src/styles/starlight/30-toc-under-hero.css
+++ b/site/src/styles/starlight/30-toc-under-hero.css
@@ -50,5 +50,5 @@
 }
 
 .docs-toc-under-hero.right-sidebar-panel :where(a[aria-current='true']) {
-  border-inline-start-color: #0aae7a !important;
+  border-inline-start-color: var(--netscli-accent) !important;
 }

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -15,4 +15,25 @@
      this in starlight/01-tokens-and-header.css. */
   --netscli-nav-height: 3.75rem;
   --netscli-shell-width: 72rem;
+
+  /* Brand accent.
+   *
+   * Was #0aae7a, which sits at hue 160 -- right on the green/teal boundary.
+   * In large areas it read green, but at 15px on the near-black background,
+   * with thin antialiased strokes, it read blue: inline links looked like a
+   * different colour from the buttons above them. #22c55e is hue 142 and
+   * reads green at any size. Contrast on the dark background went from
+   * 6.6:1 to 8.2:1 with it.
+   *
+   * The -rgb form is the same colour as a bare triple, for the rgba() call
+   * sites that need an alpha. There were 108 hard-coded copies of the old
+   * value across 20 files before this; changing it should be one edit here.
+   * The docs light theme keeps its own darker pair in
+   * starlight/01-tokens-and-header.css, as it did before. */
+  --netscli-accent: #22c55e;
+  --netscli-accent-rgb: 34, 197, 94;
+  /* Hover and other lifted states. */
+  --netscli-accent-bright: #4ade80;
+  /* Pale tint for active text on dark surfaces. */
+  --netscli-accent-high: #a7f3c6;
 }


### PR DESCRIPTION
Two alignment defects reported against the deployed site.

**The active-link underline sat in different places on the two bars.** The docs link is the full height of the bar so its border lands on the bar's bottom edge; the landing link asked for `height:calc(100% + 24px)` against a parent with no definite height, so it collapsed to its 32px content box and the underline floated 14px up. Now measured at 59.0 against a 59.8 bar bottom, matching the docs' 59.6 against 60.0.

**The mobile search button sat 10px below the menu button.** Both are pinned to the same `inset-block-start`, but the search wrapper kept the full-bar height it gets at desktop widths, so its box ran past the bar and bottom-aligned its 40px button. Both are 40px squares at the same offset now.

Verified at 375, 768 and 1400; a11y gate clean in both themes.