### PR TITLE
Guard against dead CSS, and delete five dead selectors

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -67,6 +67,16 @@ jobs:
           node-version: 22
       - run: node scripts/check-file-size.mjs
 
+      # A ratchet on dead CSS, not a target. `css-shadowing.mjs` proves a
+      # declaration can never affect the page -- same selector, same media
+      # context, a later rule of equal-or-greater importance. It was written
+      # for B-23, run once in the pull request that added it, and then never
+      # again, so the count it had driven down grew back to 210 unnoticed.
+      # Lower the budget when you prune; it must never rise.
+      - name: Dead CSS budget
+        working-directory: site
+        run: npm run check:css
+
   build:
     name: Build + typecheck
     needs: [changes, maintainability]

--- a/site/package.json
+++ b/site/package.json
@@ -8,6 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
+    "check:css": "node ./scripts/css-shadowing.mjs --max 210",
     "test:a11y": "npm run build && node ./scripts/a11y.mjs"
   },
   "dependencies": {

--- a/site/scripts/css-shadowing.mjs
+++ b/site/scripts/css-shadowing.mjs
@@ -22,6 +22,12 @@
  * Usage:
  *   node scripts/css-shadowing.mjs            # report
  *   node scripts/css-shadowing.mjs --json     # machine-readable
+ *   node scripts/css-shadowing.mjs --max N    # exit 1 above N, for CI
+ *
+ * The --max form is a ratchet, not a target. It was added because this ran
+ * once, in the pull request that wrote it, and then nothing ran it again --
+ * so the count it had driven down grew back unnoticed. Set it to the current
+ * count; it can only be lowered.
  */
 
 import { readFileSync } from 'node:fs';
@@ -168,6 +174,23 @@ if (!runDirectly) {
   // no-op
 } else if (process.argv.includes('--json')) {
   console.log(JSON.stringify({ total: declarations.length, shadowed }, null, 2));
+} else if (process.argv.includes('--max')) {
+  const max = Number(process.argv[process.argv.indexOf('--max') + 1]);
+  console.log(
+    `${shadowed.length} provably shadowed declaration(s) of ${declarations.length}; budget ${max}.`,
+  );
+  if (shadowed.length > max) {
+    console.error(
+      [
+        `Shadowed-declaration budget exceeded by ${shadowed.length - max}.`,
+        'A shadowed declaration cannot affect the page: a later rule with the same',
+        'selector and media context, and at least equal importance, always wins.',
+        'Either delete it, or change the rule that shadows it. Run this without',
+        '--max to see them by file, or `node scripts/css-prune.mjs --write`.',
+      ].join(String.fromCharCode(10)),
+    );
+    process.exitCode = 1;
+  }
 } else {
   const byFile = new Map();
   for (const d of shadowed) byFile.set(d.file, (byFile.get(d.file) ?? 0) + 1);

--- a/site/src/styles/starlight/27-release-qa-overrides.css
+++ b/site/src/styles/starlight/27-release-qa-overrides.css
@@ -24,12 +24,6 @@
     margin-right: 0 !important;
   }
 
-  .docs-header-menu starlight-menu-button button {
-    position: static !important;
-    inset: auto !important;
-    width: 2.5rem !important;
-    height: 2.5rem !important;
-  }
 }
 
 @media (max-width: 42rem) {

--- a/site/src/styles/starlight/28-final-interaction-guardrails.css
+++ b/site/src/styles/starlight/28-final-interaction-guardrails.css
@@ -152,21 +152,10 @@ a.download-count:focus-visible,
 }
 
 @media (max-width: 49.99rem) {
-  .docs-header-actions,
-  .right-nav,
-  .mobile-actions {
-    gap: .45rem !important;
-  }
-
   .docs-header-search,
   .docs-header-search button {
     margin-inline-end: .15rem !important;
   }
-
-  .starlight-menu-button,
-  .starlight-menu-button button {
-    margin-inline-start: .15rem !important;
-  }    
 
   /* Not the section menu.
      PageSidebar renders the mobile section dropdown inside .right-sidebar, so


### PR DESCRIPTION
Two contained actions from the maintainability review.

**Wire up the detector that already exists.** `site/scripts/css-shadowing.mjs` proves a declaration can never affect the page — same selector, same media context, a later rule of equal-or-greater importance. It was written for B-23, run once in the PR that added it, then wired into nothing. The count it drove down has grown back to **210 of 1,723 declarations (12%)** unnoticed.

It takes `--max` now, and the Site workflow runs it at the current 210. A ratchet, not a target — the budget can only be lowered. Verified it actually fails: one deliberately shadowed declaration takes it to 211 and exits 1; removing it exits 0.

**Delete five selectors nothing carries**, checked against every page in `dist/` and against the component sources:

| Selector | File | Note |
|---|---|---|
| `.docs-header-actions, .right-nav, .mobile-actions` | 28 | gap never applied |
| `.starlight-menu-button` (×2) | 28 | Starlight emits it as an **element**; the dot made it a class selector |
| `.docs-header-menu starlight-menu-button button` | 27 | tried to make the menu button `position: static` — it is still `fixed`, which is what put it over the search button until this morning |

Both of those last two were silently inert. That is the class of dead rule the shadowing check *cannot* see; a selector-matches-nothing check would. Adding it is the obvious next step and is not in this change.

Verified on the preview at 375: buttons level and 11px apart, contents bar still pins at 102px, no horizontal overflow. `astro check` clean, a11y clean in both themes, file-size guard passes.