### PR TITLE
Fix the findings from the independent acceptance review

### DIFF
--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -3,7 +3,7 @@
   <defs>
     <linearGradient id="g" x1="0" y1="0" x2="64" y2="0" gradientUnits="userSpaceOnUse">
       <stop offset="0%"  stop-color="#005a1e"/>
-      <stop offset="45%" stop-color="#0aae7a"/>
+      <stop offset="45%" stop-color="#22c55e"/>
       <stop offset="100%" stop-color="#1edcff"/>
     </linearGradient>
     <style>

--- a/site/public/gui-scan.svg
+++ b/site/public/gui-scan.svg
@@ -2,7 +2,7 @@
   <defs>
     <linearGradient id="brand" x1="0" x2="1" y1="0" y2="0">
       <stop offset="0" stop-color="#005a1e"/>
-      <stop offset=".48" stop-color="#0aae7a"/>
+      <stop offset=".48" stop-color="#22c55e"/>
       <stop offset="1" stop-color="#1edcff"/>
     </linearGradient>
     <style>

--- a/site/public/tui-discover.svg
+++ b/site/public/tui-discover.svg
@@ -3,7 +3,7 @@
   <defs>
     <linearGradient id="netscliGradient" x1="0" y1="0" x2="1200" y2="0" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#005a1e"/>
-      <stop offset="45%" stop-color="#0aae7a"/>
+      <stop offset="45%" stop-color="#22c55e"/>
       <stop offset="100%" stop-color="#1edcff"/>
     </linearGradient>
     <style>
@@ -53,25 +53,25 @@
       <tspan x="700" class="label">Hostname</tspan>
     </text>
     <text y="402">
-      <tspan x="195" fill="#0aae7a">workstation.local</tspan>
+      <tspan x="195" fill="#22c55e">workstation.local</tspan>
       <tspan x="350" fill="#f5c84c">lab-node-01</tspan>
       <tspan x="535" class="value">Dell Inc.</tspan>
       <tspan x="700" class="value">workstation</tspan>
     </text>
     <text y="426">
-      <tspan x="195" fill="#0aae7a">phone.local</tspan>
+      <tspan x="195" fill="#22c55e">phone.local</tspan>
       <tspan x="350" fill="#f5c84c">lab-node-02</tspan>
       <tspan x="535" class="value">Apple, Inc.</tspan>
       <tspan x="700" class="value">iphone</tspan>
     </text>
     <text y="450">
-      <tspan x="195" fill="#0aae7a">pi.local</tspan>
+      <tspan x="195" fill="#22c55e">pi.local</tspan>
       <tspan x="350" fill="#f5c84c">lab-node-03</tspan>
       <tspan x="535" class="value">Raspberry Pi</tspan>
       <tspan x="700" class="value">pi</tspan>
     </text>
     <text y="474">
-      <tspan x="195" fill="#0aae7a">nas.local</tspan>
+      <tspan x="195" fill="#22c55e">nas.local</tspan>
       <tspan x="350" fill="#f5c84c">lab-node-04</tspan>
       <tspan x="535" class="value">Dell Inc.</tspan>
       <tspan x="700" class="value">nas</tspan>

--- a/site/src/assets/netscli-docs-logo.svg
+++ b/site/src/assets/netscli-docs-logo.svg
@@ -2,7 +2,7 @@
   <defs>
     <linearGradient id="netscliDocsGradient" x1="0" x2="170" y1="0" y2="0" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#005a1e"/>
-      <stop offset="0.52" stop-color="#0aae7a"/>
+      <stop offset="0.52" stop-color="#22c55e"/>
       <stop offset="1" stop-color="#1edcff"/>
     </linearGradient>
   </defs>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,6 +1,6 @@
 ---
 import { site } from '../data/site';
-const { hero, social, version } = site;
+const { hero, social } = site;
 ---
 <div class="hero">
   <p class="badge">{hero.badge}</p>
@@ -15,8 +15,16 @@ const { hero, social, version } = site;
     <span class="sep" aria-hidden="true" id="metrics-sep" hidden>·</span>
     <a href={`https://github.com/${social.repo}/releases`} id="downloads" hidden></a>
     <span class="sep" aria-hidden="true" id="version-sep" hidden>·</span>
-    <a href={`https://github.com/${social.repo}/releases/latest`} id="latest-version">v{version}</a>
-    <span class="sep" aria-hidden="true">·</span>
+    {/* Empty and hidden, like every other metric beside it.
+        It used to ship the version from the GUI package.json, which is the
+        version being developed, not the one released -- the page advertised
+        v0.3.0 while the latest release was v0.2.6. Its siblings were already
+        hidden-until-confirmed for exactly this reason; this one was not, so a
+        rate-limited or failed GitHub call left the wrong number on screen
+        indefinitely rather than showing nothing. Unauthenticated GitHub is 60
+        requests an hour per IP and each load spends two. */}
+    <a href={`https://github.com/${social.repo}/releases/latest`} id="latest-version" hidden></a>
+    <span class="sep" aria-hidden="true" id="source-sep" hidden>·</span>
     <a class="plain" href={hero.sourceUrl}>
       <svg class="gh-icon" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:-2px;margin-right:3px">
         <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -299,7 +299,12 @@ a.install-download:hover{color:var(--netscli-accent-bright);background:rgba(var(
  */
 @media(max-width:700px){
   .cmd,
-  .cmd.big{
+  .cmd.big,
+  /* `.alt-cmd` too. It was left on `overflow-wrap:anywhere`, so while the
+     recommended command truncated to one line the alternates below it broke
+     mid-token across four -- the Scoop line did exactly that at 375px. Same
+     treatment, same reason: the copy button carries the full command. */
+  .alt-cmd{
     white-space:nowrap;
     overflow:hidden;
     text-overflow:ellipsis;

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -29,7 +29,7 @@ const onHome = pathname === '/';
           class={link.external ? 'external-link' : undefined}
           data-section={link.section}
           data-site-nav-link
-          aria-current={isCurrent(link, pathname) ? 'page' : undefined}
+          aria-current={isCurrent(link, pathname)}
           {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
         >
           {link.label}
@@ -57,6 +57,11 @@ const onHome = pathname === '/';
 /* nav */
 nav{
   position:sticky;top:0;z-index:10;
+  /* Border-box, so this is the whole bar including its border -- the docs
+     header sets the same value the same way. Sizing it from the inner box
+     plus a border instead left the landing bar 0.2px shorter, because a 1px
+     border renders as 0.8 at this device pixel ratio. */
+  min-height:var(--netscli-nav-height);
   background:rgba(17,17,17,.85);backdrop-filter:blur(12px);
   border-bottom:1px solid rgba(255,255,255,.06);
   box-shadow:none;
@@ -166,8 +171,10 @@ body.nav-scrolled nav::after{
    and the spy is the only thing that fires -- the underline never appeared
    at all. The docs bar was unaffected, which is why the two looked
    inconsistent. */
-.nlinks a[aria-current="page"],
-.nlinks a[aria-current="location"]{
+/* Any aria-current value. `page` is the exact page, `true` a section that
+   contains it, `location` the scroll-spy section on the landing page --
+   all three should look current. */
+.nlinks a[aria-current]{
   color:#e5e5e5;
   border-bottom-color:var(--netscli-accent);
 }
@@ -234,8 +241,7 @@ body.nav-scrolled nav::after{
     margin-block:0;
   }
   .nlinks a:hover,
-  .nlinks a[aria-current='page'],
-  .nlinks a[aria-current='location']{
+  .nlinks a[aria-current]{
     border-left-color:var(--netscli-accent);
     border-bottom-color:transparent;
     background:rgba(var(--netscli-accent-rgb),.1);

--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -26,7 +26,7 @@ const pathname = Astro.url.pathname;
         <a
           href={hrefFor(link, pathname)}
           class={link.external ? 'external-link' : undefined}
-          aria-current={isCurrent(link, pathname) ? 'page' : undefined}
+          aria-current={isCurrent(link, pathname)}
           {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
         >
           {link.label}
@@ -43,9 +43,10 @@ const pathname = Astro.url.pathname;
 
 <script>
   import { initDocsHeader } from '../../scripts/docs-header';
-  import { initDocsSearchKeys } from '../../scripts/docs-search-keys';
+  import { initDocsSearchKeys, initDocsSearchResilience } from '../../scripts/docs-search-keys';
   initDocsHeader();
   initDocsSearchKeys();
+  initDocsSearchResilience();
 </script>
 
 <style>
@@ -111,11 +112,11 @@ const pathname = Astro.url.pathname;
     }
 
     .docs-nav-links a:hover,
-    .docs-nav-links a[aria-current='page'] {
+    .docs-nav-links a[aria-current] {
       color: var(--sl-color-white);
     }
 
-    .docs-nav-links a[aria-current='page'] {
+    .docs-nav-links a[aria-current] {
       border-bottom-color: var(--netscli-accent);
     }
 

--- a/site/src/components/starlight/MobileMenuFooter.astro
+++ b/site/src/components/starlight/MobileMenuFooter.astro
@@ -17,7 +17,7 @@ const projectLinks = navLinks.filter((link) => link.mobileGroup === 'project');
           <a
             href={hrefFor(link, pathname)}
             class={link.external ? 'external-link' : undefined}
-            aria-current={isCurrent(link, pathname) ? 'page' : undefined}
+            aria-current={isCurrent(link, pathname)}
           >
             {link.label}
           </a>
@@ -34,7 +34,7 @@ const projectLinks = navLinks.filter((link) => link.mobileGroup === 'project');
           <a
             href={hrefFor(link, pathname)}
             class={link.external ? 'external-link' : undefined}
-            aria-current={isCurrent(link, pathname) ? 'page' : undefined}
+            aria-current={isCurrent(link, pathname)}
           >
             {link.label}
           </a>
@@ -85,7 +85,7 @@ const projectLinks = navLinks.filter((link) => link.mobileGroup === 'project');
 
     .docs-mobile-site-nav a:hover,
     .docs-mobile-site-nav a:focus-visible,
-    .docs-mobile-site-nav a[aria-current='page'] {
+    .docs-mobile-site-nav a[aria-current] {
       background: rgba(var(--netscli-accent-rgb), 0.12);
       border-inline-start-color: var(--netscli-accent);
       color: var(--sl-color-white);

--- a/site/src/data/site-content/nav.ts
+++ b/site/src/data/site-content/nav.ts
@@ -46,16 +46,28 @@ export function hrefFor(link: NavLink, pathname: string): string {
   return pathname === '/' ? `#${link.section}` : `/#${link.section}`;
 }
 
-/** Whether `link` points at the page currently being rendered.
+/** How `link` relates to the page currently being rendered, as the ARIA
+ *  value to put on it -- or undefined when it is neither.
  *
- * Section links are never current here -- on the landing page they are marked
- * by the scroll spy in scripts/site-nav.ts, which writes aria-current
- * "location" rather than "page". */
-export function isCurrent(link: NavLink, pathname: string): boolean {
-  if (!link.href || link.external) return false;
-  // Prefix match on the trailing-slash-stripped href, so /docs/ is current
-  // for /docs, /docs/, and /docs/install/ alike without depending on which
-  // trailing-slash convention the router hands us.
+ * `page` is reserved for the exact page. A link to a section that merely
+ * contains it gets `true`, which is the ARIA value for "current within this
+ * set" and does not claim to be the page.
+ *
+ * The distinction is not cosmetic. This used to prefix-match and return the
+ * same value for both, so on /docs/install/ the Starlight sidebar marked
+ * "Installation" as the current page and the "Docs" link here marked itself
+ * as the current page too. Two elements claiming aria-current="page" on one
+ * document makes a screen reader announce "current page" twice, for two
+ * different destinations.
+ *
+ * Section links are never current here -- on the landing page the scroll spy
+ * in scripts/site-nav.ts marks those with "location". */
+export function isCurrent(link: NavLink, pathname: string): 'page' | 'true' | undefined {
+  if (!link.href || link.external) return undefined;
+  // Trailing-slash-stripped, so this does not depend on which convention the
+  // router hands us.
+  const here = pathname.replace(/\/$/, '');
   const base = link.href.replace(/\/$/, '');
-  return pathname === base || pathname.startsWith(`${base}/`);
+  if (here === base) return 'page';
+  return here.startsWith(`${base}/`) ? 'true' : undefined;
 }

--- a/site/src/scripts/docs-search-keys.ts
+++ b/site/src/scripts/docs-search-keys.ts
@@ -63,3 +63,82 @@ export function initDocsSearchKeys(): void {
   document.addEventListener('keydown', handleKeyDown);
   onDispose(() => document.removeEventListener('keydown', handleKeyDown));
 }
+
+/**
+ * Two things Pagefind's default UI does not do: say anything when its own
+ * assets cannot be fetched, and give focus back when the dialog closes.
+ *
+ * Offline, the index request never resolves, so the drawer sits on
+ * "Searching for <query>…" indefinitely -- measured at 16s with no error, no
+ * retry and no way to tell a slow search from a dead one. And closing the
+ * dialog with Escape dropped focus to <body>, so a keyboard user landed at
+ * the top of the document instead of back on the button they opened.
+ */
+const MESSAGE_SELECTOR = '.pagefind-ui__message';
+const SEARCH_TIMEOUT_MS = 8000;
+const OFFLINE_NOTE = 'netscli-search-offline';
+
+export function initDocsSearchResilience(): void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let opener: HTMLElement | null = null;
+
+  const clearNote = (dialog: Element) => {
+    dialog.querySelector(`.${OFFLINE_NOTE}`)?.remove();
+  };
+
+  const showNote = (dialog: Element) => {
+    if (dialog.querySelector(`.${OFFLINE_NOTE}`)) return;
+    const message = dialog.querySelector(MESSAGE_SELECTOR);
+    if (!message) return;
+    const note = document.createElement('p');
+    note.className = OFFLINE_NOTE;
+    note.setAttribute('role', 'status');
+    note.textContent = navigator.onLine
+      ? 'Search is not responding. Check your connection, then edit the query to try again.'
+      : 'Search needs a connection and you appear to be offline. The pages themselves still work.';
+    message.insertAdjacentElement('afterend', note);
+  };
+
+  const onInput = (event: Event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement) || !target.matches(INPUT_SELECTOR)) return;
+    const dialog = target.closest('dialog');
+    if (!dialog) return;
+    clearNote(dialog);
+    if (timer) clearTimeout(timer);
+    // Only complain if the drawer is still *searching* when the timer fires.
+    // A slow-but-working search resolves and rewrites this message itself.
+    timer = setTimeout(() => {
+      const message = dialog.querySelector(MESSAGE_SELECTOR);
+      if (message && /^\s*Searching/i.test(message.textContent ?? '')) showNote(dialog);
+    }, SEARCH_TIMEOUT_MS);
+  };
+
+  const rememberOpener = (event: Event) => {
+    const target = event.target;
+    if (target instanceof HTMLElement && target.closest('button[data-open-modal]')) {
+      opener = target.closest('button[data-open-modal]');
+    }
+  };
+
+  const onClose = (event: Event) => {
+    const dialog = event.target;
+    if (!(dialog instanceof HTMLDialogElement)) return;
+    clearNote(dialog);
+    if (timer) clearTimeout(timer);
+    // Native <dialog> restores focus to whatever was focused when it opened,
+    // which here is nothing -- Starlight opens it from a keyboard shortcut as
+    // well as a click. Put focus back on the trigger explicitly.
+    if (opener?.isConnected) opener.focus();
+  };
+
+  document.addEventListener('input', onInput, true);
+  document.addEventListener('click', rememberOpener, true);
+  document.addEventListener('close', onClose, true);
+  onDispose(() => {
+    if (timer) clearTimeout(timer);
+    document.removeEventListener('input', onInput, true);
+    document.removeEventListener('click', rememberOpener, true);
+    document.removeEventListener('close', onClose, true);
+  });
+}

--- a/site/src/scripts/landing-page.ts
+++ b/site/src/scripts/landing-page.ts
@@ -1,5 +1,6 @@
 import { initCopyButtons } from "./landing/copy-buttons";
 import { initScreenshotLightbox } from "./landing/lightbox";
+import { initOsTabs } from "./landing/os-tabs";
 
 interface GitHubAsset {
   download_count?: number;
@@ -12,17 +13,6 @@ interface GitHubRelease {
   tag_name?: string;
   html_url?: string;
 }
-
-interface NavigatorWithUserAgentData extends Navigator {
-  userAgentData?: {
-    platform?: string;
-    /** Async, and Chromium-only. `architecture` is a high-entropy hint,
-     *  so it is not exposed on the object directly. */
-    getHighEntropyValues?: (hints: string[]) => Promise<{ architecture?: string }>;
-  };
-}
-
-type OperatingSystem = "windows" | "macos" | "linux";
 
 export function initLandingPage(repo: string): void {
     const year = document.getElementById("y");
@@ -42,15 +32,25 @@ export function initLandingPage(repo: string): void {
         if (n < 1000000) return `${(Math.floor(n / 100) / 10).toFixed(1)}K+`;
         return `${(Math.floor(n / 100000) / 10).toFixed(1)}M+`;
       };
+      // Every separator is derived from what is actually on screen, so a
+      // partial failure cannot leave a dangling interpunct. The version is
+      // part of this now: it is only rendered once a release has confirmed
+      // it, so it can be absent like the rest.
       const refreshMetricSeparators = () => {
-        const stars = document.getElementById("stars");
-        const downloads = document.getElementById("downloads");
-        const metricsSep = document.getElementById("metrics-sep");
-        const versionSep = document.getElementById("version-sep");
-        const hasStars = Boolean(stars && !stars.hidden);
-        const hasDownloads = Boolean(downloads && !downloads.hidden);
-        if (metricsSep) metricsSep.hidden = !(hasStars && hasDownloads);
-        if (versionSep) versionSep.hidden = !(hasStars || hasDownloads);
+        const shown = (id: string) => {
+          const el = document.getElementById(id);
+          return Boolean(el && !el.hidden);
+        };
+        const setSep = (id: string, visible: boolean) => {
+          const el = document.getElementById(id);
+          if (el) el.hidden = !visible;
+        };
+        const hasStars = shown("stars");
+        const hasDownloads = shown("downloads");
+        const hasVersion = shown("latest-version");
+        setSep("metrics-sep", hasStars && hasDownloads);
+        setSep("version-sep", (hasStars || hasDownloads) && hasVersion);
+        setSep("source-sep", hasStars || hasDownloads || hasVersion);
       };
       fetch(`https://api.github.com/repos/${repo}`)
         .then((r) => (r.ok ? r.json() : null))
@@ -86,9 +86,12 @@ export function initLandingPage(repo: string): void {
           const latest = releases.find((release) => !release.draft && !release.prerelease)
             ?? releases.find((release) => !release.draft);
           const versionEl = document.getElementById("latest-version");
-          if (latest && versionEl) {
-            if (latest.tag_name) versionEl.textContent = latest.tag_name;
+          // Only reveal a version a release actually carries.
+          if (latest?.tag_name && versionEl) {
+            versionEl.textContent = latest.tag_name;
             if (latest.html_url) versionEl.setAttribute("href", latest.html_url);
+            versionEl.hidden = false;
+            refreshMetricSeparators();
           }
         })
         .catch(() => {});
@@ -96,155 +99,8 @@ export function initLandingPage(repo: string): void {
 
     initCopyButtons();
     initScreenshotLightbox();
+    initOsTabs();
 
-    // OS tab swap. Keep visual state and ARIA state aligned so package
-    // manager choices work for mouse, keyboard, and assistive tech users.
-    const osTabs = Array.from(document.querySelectorAll<HTMLButtonElement>(".os-tab"));
-    const osPanels = Array.from(document.querySelectorAll<HTMLElement>(".os-panel"));
-    function setOS(os: OperatingSystem, options: { focus?: boolean } = {}) {
-      osTabs.forEach((b) => {
-        const active = b.dataset.os === os;
-        b.classList.toggle("active", active);
-        b.setAttribute("aria-selected", String(active));
-        b.tabIndex = active ? 0 : -1;
-        if (active && options.focus) b.focus();
-      });
-      osPanels.forEach((p) => {
-        const active = p.dataset.os === os;
-        p.classList.toggle("active", active);
-        p.hidden = !active;
-      });
-    }
-    osTabs.forEach((b, index) => {
-      b.addEventListener("click", () => {
-        const os = b.dataset.os as OperatingSystem | undefined;
-        if (os) setOS(os);
-      });
-      b.addEventListener("keydown", (event) => {
-        const keys = ["ArrowLeft", "ArrowRight", "Home", "End"];
-        if (!keys.includes(event.key)) return;
-        event.preventDefault();
-        const last = osTabs.length - 1;
-        const nextIndex =
-          event.key === "Home" ? 0
-            : event.key === "End" ? last
-            : event.key === "ArrowLeft" ? (index + last) % osTabs.length
-            : (index + 1) % osTabs.length;
-        const os = osTabs[nextIndex]?.dataset.os as OperatingSystem | undefined;
-        if (os) setOS(os, { focus: true });
-      });
-    });
-
-    // Auto-detect visitor OS on load. UA-CH is preferred, with the legacy
-    // user-agent string retained as a broad-browser fallback.
-    {
-      const navigatorWithUaData = navigator as NavigatorWithUserAgentData;
-      const ua =
-        navigatorWithUaData.userAgentData?.platform ||
-        navigator.userAgent ||
-        "";
-      // Mobile and Chrome OS have to be matched explicitly.
-      //
-      // UA-CH reports `platform` as one of a small fixed set: "Windows",
-      // "macOS", "Linux", "Android", "Chrome OS", "iOS". The previous three
-      // tests covered only the first three, so Android, iOS and Chrome OS
-      // all fell through to the `"macos"` default -- every phone visitor was
-      // shown the macOS install tab and offered a .dmg from the hero button.
-      // Confirmed on a Pixel 8 UA, where `platform` is exactly "Android".
-      //
-      // Apple's mobile platforms group with macOS, and Android/Chrome OS
-      // with Linux. Neither can actually run NetsCLI, so the goal is only to
-      // show the least wrong thing to someone browsing on a phone and to
-      // stop claiming a Mac is involved when it is not.
-      //
-      // `cros` is matched before `linux` deliberately: Chrome OS is
-      // Linux-based and some UA strings contain both.
-      const detected: OperatingSystem = /win/i.test(ua) ? "windows"
-        : /mac|ios|iphone|ipad/i.test(ua) ? "macos"
-        : /android|cros|chrome\s?os|linux/i.test(ua) ? "linux"
-        : "windows";
-      setOS(detected);
-
-      // Both hero command boxes are OS-aware, and they must differ.
-      //
-      // Only the second box used to be. The first held `hero.quickInstall`
-      // -- the `curl … install.sh | bash` line -- for everyone, which made
-      // two separate problems:
-      //
-      //   Windows: the most prominent command on the page was a bash
-      //   pipeline that does not run there, with the correct `winget` line
-      //   demoted to the smaller box below it.
-      //
-      //   Linux: `packageCommands.linux` was byte-identical to
-      //   `hero.quickInstall`, so the hero printed the same command twice.
-      //
-      // Primary is whatever the install section recommends for that
-      // platform, so the hero and "Get started" agree; secondary is a
-      // genuinely different route.
-      const heroCommands: Record<OperatingSystem, { primary: string; secondary: string }> = {
-        windows: {
-          primary: "winget install fstubner.netscli",
-          secondary:
-            "iwr -useb https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.ps1 | iex",
-        },
-        macos: {
-          primary: "brew tap fstubner/tap && brew install netscli",
-          secondary:
-            "curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash",
-        },
-        linux: {
-          primary:
-            "curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash",
-          secondary: "yay -S netscli-bin",
-        },
-      };
-
-      const setHeroCommand = (id: string, command: string) => {
-        const host = document.getElementById(id);
-        if (!host) return;
-        host.dataset.copy = command;
-        const code = host.querySelector("code");
-        if (code) code.textContent = command;
-      };
-      setHeroCommand("hero-quick-install", heroCommands[detected].primary);
-      setHeroCommand("hero-package-install", heroCommands[detected].secondary);
-
-      const desktopDownload = document.querySelector<HTMLAnchorElement>("#hero-desktop-download");
-      if (desktopDownload) {
-        const base = "https://github.com/fstubner/netscli/releases/latest/download";
-        // macOS ships two .dmgs and they are NOT interchangeable. This
-        // button used to hand every Mac visitor the Apple Silicon build,
-        // so Intel users downloaded something that would not run.
-        //
-        // Default to the Intel build, because Rosetta 2 runs it on Apple
-        // Silicon too — an asymmetry worth exploiting, since the wrong
-        // guess in that direction still works and the reverse does not.
-        // Then upgrade to the native arm64 build if the browser will
-        // actually tell us the architecture.
-        const desktopUrls: Record<OperatingSystem, string> = {
-          windows: `${base}/netscli-gui-windows-x86_64.msi`,
-          macos: `${base}/netscli-gui-macos-x86_64.dmg`,
-          linux: `${base}/netscli-gui-linux-x86_64.AppImage`,
-        };
-        desktopDownload.href = desktopUrls[detected];
-
-        if (detected === "macos") {
-          // High-entropy hints are async and Chromium-only; Safari never
-          // resolves this, which is exactly why the default above has to
-          // be the one that runs everywhere.
-          navigatorWithUaData.userAgentData
-            ?.getHighEntropyValues?.(["architecture"])
-            .then(({ architecture }) => {
-              if (architecture === "arm") {
-                desktopDownload.href = `${base}/netscli-gui-macos-aarch64.dmg`;
-              }
-            })
-            .catch(() => {
-              /* keep the Intel default */
-            });
-        }
-      }
-    }
 
     // Desktop installer dropdown in the hero.
     {

--- a/site/src/scripts/landing/os-tabs.ts
+++ b/site/src/scripts/landing/os-tabs.ts
@@ -1,0 +1,181 @@
+/**
+ * Which operating system the install section is showing, and the hero's
+ * desktop download link that follows from it.
+ *
+ * Split out of landing-page.ts when that file crossed the 300-line guard.
+ * It is the one part of the page with its own state: a detected default, an
+ * explicit user choice that overrides and outlives it, and a download URL
+ * derived from both.
+ */
+import type { NavigatorWithUserAgentData, OperatingSystem } from './os-types';
+
+export function initOsTabs(): void {
+  // OS tab swap. Keep visual state and ARIA state aligned so package
+  // manager choices work for mouse, keyboard, and assistive tech users.
+  const osTabs = Array.from(document.querySelectorAll<HTMLButtonElement>(".os-tab"));
+  const osPanels = Array.from(document.querySelectorAll<HTMLElement>(".os-panel"));
+  // A chosen tab outlives the page. Detection is a guess -- someone on a
+  // Windows machine installing on a Linux box was re-guessed back to
+  // Windows on every reload, losing the choice they had just made.
+  const OS_KEY = "netscli:install-os";
+  const remember = (os: OperatingSystem) => {
+    try {
+      localStorage.setItem(OS_KEY, os);
+    } catch {
+      // Private mode or a blocked origin: detection still applies.
+    }
+  };
+  const remembered = (): OperatingSystem | null => {
+    try {
+      const value = localStorage.getItem(OS_KEY);
+      return value === "windows" || value === "macos" || value === "linux" ? value : null;
+    } catch {
+      return null;
+    }
+  };
+  function setOS(os: OperatingSystem, options: { focus?: boolean; persist?: boolean } = {}) {
+    osTabs.forEach((b) => {
+      const active = b.dataset.os === os;
+      b.classList.toggle("active", active);
+      b.setAttribute("aria-selected", String(active));
+      b.tabIndex = active ? 0 : -1;
+      if (active && options.focus) b.focus();
+    });
+    osPanels.forEach((p) => {
+      const active = p.dataset.os === os;
+      p.classList.toggle("active", active);
+      p.hidden = !active;
+    });
+    if (options.persist) remember(os);
+  }
+  osTabs.forEach((b, index) => {
+    b.addEventListener("click", () => {
+      const os = b.dataset.os as OperatingSystem | undefined;
+      if (os) setOS(os, { persist: true });
+    });
+    b.addEventListener("keydown", (event) => {
+      const keys = ["ArrowLeft", "ArrowRight", "Home", "End"];
+      if (!keys.includes(event.key)) return;
+      event.preventDefault();
+      const last = osTabs.length - 1;
+      const nextIndex =
+        event.key === "Home" ? 0
+          : event.key === "End" ? last
+          : event.key === "ArrowLeft" ? (index + last) % osTabs.length
+          : (index + 1) % osTabs.length;
+      const os = osTabs[nextIndex]?.dataset.os as OperatingSystem | undefined;
+      if (os) setOS(os, { focus: true, persist: true });
+    });
+  });
+
+  // Auto-detect visitor OS on load. UA-CH is preferred, with the legacy
+  // user-agent string retained as a broad-browser fallback.
+  {
+    const navigatorWithUaData = navigator as NavigatorWithUserAgentData;
+    const ua =
+      navigatorWithUaData.userAgentData?.platform ||
+      navigator.userAgent ||
+      "";
+    // Mobile and Chrome OS have to be matched explicitly.
+    //
+    // UA-CH reports `platform` as one of a small fixed set: "Windows",
+    // "macOS", "Linux", "Android", "Chrome OS", "iOS". The previous three
+    // tests covered only the first three, so Android, iOS and Chrome OS
+    // all fell through to the `"macos"` default -- every phone visitor was
+    // shown the macOS install tab and offered a .dmg from the hero button.
+    // Confirmed on a Pixel 8 UA, where `platform` is exactly "Android".
+    //
+    // Apple's mobile platforms group with macOS, and Android/Chrome OS
+    // with Linux. Neither can actually run NetsCLI, so the goal is only to
+    // show the least wrong thing to someone browsing on a phone and to
+    // stop claiming a Mac is involved when it is not.
+    //
+    // `cros` is matched before `linux` deliberately: Chrome OS is
+    // Linux-based and some UA strings contain both.
+    const detected: OperatingSystem = /win/i.test(ua) ? "windows"
+      : /mac|ios|iphone|ipad/i.test(ua) ? "macos"
+      : /android|cros|chrome\s?os|linux/i.test(ua) ? "linux"
+      : "windows";
+    setOS(remembered() ?? detected);
+
+    // Both hero command boxes are OS-aware, and they must differ.
+    //
+    // Only the second box used to be. The first held `hero.quickInstall`
+    // -- the `curl … install.sh | bash` line -- for everyone, which made
+    // two separate problems:
+    //
+    //   Windows: the most prominent command on the page was a bash
+    //   pipeline that does not run there, with the correct `winget` line
+    //   demoted to the smaller box below it.
+    //
+    //   Linux: `packageCommands.linux` was byte-identical to
+    //   `hero.quickInstall`, so the hero printed the same command twice.
+    //
+    // Primary is whatever the install section recommends for that
+    // platform, so the hero and "Get started" agree; secondary is a
+    // genuinely different route.
+    const heroCommands: Record<OperatingSystem, { primary: string; secondary: string }> = {
+      windows: {
+        primary: "winget install fstubner.netscli",
+        secondary:
+          "iwr -useb https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.ps1 | iex",
+      },
+      macos: {
+        primary: "brew tap fstubner/tap && brew install netscli",
+        secondary:
+          "curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash",
+      },
+      linux: {
+        primary:
+          "curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash",
+        secondary: "yay -S netscli-bin",
+      },
+    };
+
+    const setHeroCommand = (id: string, command: string) => {
+      const host = document.getElementById(id);
+      if (!host) return;
+      host.dataset.copy = command;
+      const code = host.querySelector("code");
+      if (code) code.textContent = command;
+    };
+    setHeroCommand("hero-quick-install", heroCommands[detected].primary);
+    setHeroCommand("hero-package-install", heroCommands[detected].secondary);
+
+    const desktopDownload = document.querySelector<HTMLAnchorElement>("#hero-desktop-download");
+    if (desktopDownload) {
+      const base = "https://github.com/fstubner/netscli/releases/latest/download";
+      // macOS ships two .dmgs and they are NOT interchangeable. This
+      // button used to hand every Mac visitor the Apple Silicon build,
+      // so Intel users downloaded something that would not run.
+      //
+      // Default to the Intel build, because Rosetta 2 runs it on Apple
+      // Silicon too — an asymmetry worth exploiting, since the wrong
+      // guess in that direction still works and the reverse does not.
+      // Then upgrade to the native arm64 build if the browser will
+      // actually tell us the architecture.
+      const desktopUrls: Record<OperatingSystem, string> = {
+        windows: `${base}/netscli-gui-windows-x86_64.msi`,
+        macos: `${base}/netscli-gui-macos-x86_64.dmg`,
+        linux: `${base}/netscli-gui-linux-x86_64.AppImage`,
+      };
+      desktopDownload.href = desktopUrls[detected];
+
+      if (detected === "macos") {
+        // High-entropy hints are async and Chromium-only; Safari never
+        // resolves this, which is exactly why the default above has to
+        // be the one that runs everywhere.
+        navigatorWithUaData.userAgentData
+          ?.getHighEntropyValues?.(["architecture"])
+          .then(({ architecture }) => {
+            if (architecture === "arm") {
+              desktopDownload.href = `${base}/netscli-gui-macos-aarch64.dmg`;
+            }
+          })
+          .catch(() => {
+            /* keep the Intel default */
+          });
+      }
+    }
+  }
+}

--- a/site/src/scripts/landing/os-types.ts
+++ b/site/src/scripts/landing/os-types.ts
@@ -1,0 +1,11 @@
+/** Shared between landing-page.ts and os-tabs.ts. */
+export type OperatingSystem = 'windows' | 'macos' | 'linux';
+
+export interface NavigatorWithUserAgentData extends Navigator {
+  userAgentData?: {
+    platform?: string;
+    /** Async, and Chromium-only. `architecture` is a high-entropy hint,
+     *  so it is not exposed on the object directly. */
+    getHighEntropyValues?: (hints: string[]) => Promise<{ architecture?: string }>;
+  };
+}

--- a/site/src/styles/starlight/30-toc-under-hero.css
+++ b/site/src/styles/starlight/30-toc-under-hero.css
@@ -79,3 +79,14 @@
 .docs-toc-under-hero :where(a[aria-current='true']) {
   border-inline-start-color: var(--netscli-accent) !important;
 }
+
+/* The search dialog's own failure message, injected by
+   scripts/docs-search-keys.ts when Pagefind neither answers nor errors.
+   Sized and coloured like the message it sits under, so it reads as part of
+   the dialog rather than as content that failed to load. */
+#starlight__search .netscli-search-offline {
+  margin: 0.35rem 0 0;
+  color: var(--sl-color-gray-2);
+  font-size: 0.875rem;
+  line-height: 1.45;
+}


### PR DESCRIPTION
An independent acceptance pass (fresh context, no knowledge of the build) found one BLOCK-level defect and six smaller ones. All fixed.

**BLOCK — the hero advertised a version that was never released.** `#latest-version` was rendered at build time from `apps/netscli-gui/package.json` — the version being *developed*, not released — so the page showed `v0.3.0` while the latest release was `v0.2.6`. Its siblings (`stars`, `downloads`, both separators) already shipped `hidden` and appeared only once the GitHub API confirmed them; this one shipped visible, so a rate-limited or failed call left the wrong number on screen indefinitely. Unauthenticated GitHub is 60 req/hr/IP and each load spends two, so that is routine behind shared NAT. It now ships empty and hidden, and the trailing separator is derived from what is actually on screen.

**Two `aria-current="page"` for different destinations.** `isCurrent` prefix-matched, so on `/docs/install/` the sidebar marked "Installation" as the current page *and* the "Docs" link marked itself as the current page. `page` is now the exact page only; a containing section gets `true`. Introduced when I consolidated the three nav lists.

**The accent change missed the artwork.** My replacement was filtered to `.css/.astro/.ts`, so `favicon.svg`, the docs logo and two screenshots still carried `#0aae7a` — the favicon was off-palette from the UI beside it. Eight occurrences, four files.

**Alternate install commands wrapped.** `.cmd` truncated to one line; `.alt-cmd` was on `overflow-wrap:anywhere` and broke mid-token across four lines (the Scoop command, at 375px).

**Docs search said nothing when it could not reach its index** — 16s on "Searching for…" offline, no error, no retry. Now reports after 8s, and only if still searching, so a slow-but-working search is unaffected.

**Escape from search dropped focus to `<body>`.** Native restore targets whatever was focused at `showModal()`, which is nothing when opened by shortcut. Focus returns to the trigger.

**The install OS choice did not survive a reload** — detection overrode it every load. Now stored, and it beats detection.

**The landing bar was 59.8px against the docs bar's 60** — sized from the inner box plus a border, which renders at 0.8px on this DPR. Both are border-box against the same token now.

`landing-page.ts` crossed the 300-line guard with the OS work, so that concern moved to `landing/os-tabs.ts`.

Verified on the preview: shipped HTML contains zero occurrences of `v0.3.0`; version reveals as `v0.2.6` after the API responds; one `page` destination per document; alternates one line at 375px; offline note appears and clears; focus returns to the search button; OS choice survives reload; both bars exactly 60.00px. `astro check` clean, a11y clean in both themes, file-size and dead-CSS budgets pass.