### PR TITLE
Make the installer download a button, and stop crediting winget for it

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -304,6 +304,7 @@ const { hero, social } = site;
 .hero-desktop-menu{
   position:absolute;top:calc(100% + 6px);left:0;z-index:20;
   width:min(260px,calc(100vw - 48px));min-width:0;box-sizing:border-box;
+  /* See the wrapped-layout rule below, which widens this to the trigger. */
   padding:5px;border-radius:8px;
   background:#181b20;border:1px solid rgba(255,255,255,.12);
   box-shadow:0 18px 40px rgba(0,0,0,.42);
@@ -416,9 +417,15 @@ const { hero, social } = site;
   }
   .hero-cta-main,
   .hero-cta-sub{display:contents}
+  /* Full width once the CTA has wrapped into a column. At 174px the button
+     sat as a short centred pill above two full-width command bars, and the
+     installer menu -- anchored to its left edge -- opened off to one side
+     and past the column. Matching the bars lines all four rows up on the
+     same edges and gives the menu the same width to open into. */
   .hero-primary-wrap{
     order:1;
-    width:174px;
+    width:min(100%,380px);
+    flex:0 1 min(100%,380px);
   }
   .hero-command-wide{
     order:3;
@@ -429,6 +436,15 @@ const { hero, social } = site;
     order:4;
     flex:0 1 min(100%,380px);
     width:min(100%,380px);
+  }
+  /* Exactly the button's outer edges, not its padding box. The trigger has
+     a 1px gradient border, so a plain `width:100%` left the menu inset by a
+     pixel on each side, which reads as a misalignment against the command
+     bars directly below it. */
+  .hero-desktop-menu{
+    left:-1px;
+    width:calc(100% + 2px);
+    max-width:calc(100% + 2px);
   }
   .hero-command{padding-right:50px;gap:3px}
   .hero-install-link{
@@ -445,7 +461,10 @@ const { hero, social } = site;
     width:min(100%,calc(100vw - 32px));
     gap:10px 18px;
   }
-  .hero-primary-wrap{width:168px}
+  .hero-primary-wrap{
+    width:min(100%,330px);
+    flex-basis:min(100%,330px);
+  }
   .hero-install-link{font-size:.72rem}
   .hero-command-wide,
   .hero-cta-sub .hero-command{

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -184,13 +184,37 @@ const groups = [
 }
 .install-hint{font-size:.7rem;color:#808080;margin:8px 0 0}
 .alt-hint{display:block;font-size:.7rem;color:#7b7b7b;margin-top:2px;line-height:1.35}
-/* Direct-download rows reuse the command-bar treatment but are links, so
-   they get no copy button and an affordance colour instead. */
+/* Direct-download rows sit in the same column as the commands, but this is
+   an action, not something to type.
+   It used to be a bare monospace link with `display:block`, so it filled the
+   whole 522px column and its hover painted that entire strip -- a 522x21px
+   tint with no padding, on text set in the same face as the code above it.
+   It read as a command and hovered like a bar. It is a button now: its own
+   box, sized to its label, in the body face. */
 a.install-download{
-  display:block;text-decoration:none;color:var(--netscli-accent);font-weight:500;
+  display:inline-flex;
+  align-items:center;
+  gap:.4em;
+  width:max-content;
+  max-width:100%;
+  font-family:inherit;
+  font-size:.8125rem;
+  font-weight:500;
+  line-height:1;
+  color:var(--netscli-accent);
+  text-decoration:none;
+  padding:8px 14px;
+  border:1px solid rgba(var(--netscli-accent-rgb),.32);
+  border-radius:7px;
+  background:rgba(var(--netscli-accent-rgb),.06);
+  transition:background 140ms ease,border-color 140ms ease,color 140ms ease;
 }
-a.install-download:hover{color:var(--netscli-accent-bright);background:rgba(var(--netscli-accent-rgb),.08)}
-.alt a.install-download{padding-right:16px}
+a.install-download:hover,
+a.install-download:focus-visible{
+  color:var(--netscli-accent-bright);
+  border-color:rgba(var(--netscli-accent-rgb),.62);
+  background:rgba(var(--netscli-accent-rgb),.14);
+}
 .footer-note{margin-top:14px;font-size:.8125rem;color:#808080}
 .footer-note a{color:var(--netscli-accent);text-decoration:underline;text-underline-offset:3px}
 .footer-note a:hover{color:var(--netscli-accent-bright)}
@@ -246,7 +270,8 @@ a.install-download:hover{color:var(--netscli-accent-bright);background:rgba(var(
     padding:12px 14px;
   }
   .alt-label{font-size:.82rem}
-  .alt-cmd{
+  /* 44px reserves room for the copy button, which only command rows have. */
+  .alt-cmd:not(.install-download){
     padding-right:44px;
     line-height:1.45;
   }
@@ -304,7 +329,7 @@ a.install-download:hover{color:var(--netscli-accent-bright);background:rgba(var(
      recommended command truncated to one line the alternates below it broke
      mid-token across four -- the Scoop line did exactly that at 375px. Same
      treatment, same reason: the copy button carries the full command. */
-  .alt-cmd{
+  .alt-cmd:not(.install-download){
     white-space:nowrap;
     overflow:hidden;
     text-overflow:ellipsis;

--- a/site/src/data/site-content/install.ts
+++ b/site/src/data/site-content/install.ts
@@ -16,7 +16,14 @@ const RELEASE_DOWNLOAD = 'https://github.com/fstubner/netscli/releases/latest/do
  *  Gatekeeper or SmartScreen dialog with no context and assuming the
  *  download is malware. */
 const MACOS_UNSIGNED_HINT = 'Unsigned — right-click → Open on first launch';
-const WINDOWS_UNSIGNED_HINT = 'Unsigned — SmartScreen may warn; winget verifies the hash';
+/* Describes the row it is attached to, which is the direct .msi download.
+ * It used to end "winget verifies the hash" -- true of winget, and winget is
+ * not what this row does. Someone clicking Download gets the installer
+ * straight from GitHub Releases with nothing checking it, and was being told
+ * otherwise at the moment they did it. The checksums are real and published;
+ * this now points at them. */
+const WINDOWS_UNSIGNED_HINT =
+  'Unsigned — SmartScreen may warn; checksums are published with the release';
 
 export const installByPlatform: Record<Platform, PlatformInstall> = {
   windows: {

--- a/site/src/data/site-content/install.ts
+++ b/site/src/data/site-content/install.ts
@@ -25,17 +25,25 @@ const MACOS_UNSIGNED_HINT = 'Unsigned — right-click → Open on first launch';
 const WINDOWS_UNSIGNED_HINT =
   'Unsigned — SmartScreen may warn; checksums are published with the release';
 
+/* Both of these check the download against a SHA256 in their own manifest
+ * and abort on a mismatch, which is the thing the direct-download row cannot
+ * do for you. Stated on both rather than only on winget: scoop does it too,
+ * and naming one would have implied the other does not. */
+const WINDOWS_MANAGER_HASH_HINT = 'Verifies the download against the hash in its manifest';
+
 export const installByPlatform: Record<Platform, PlatformInstall> = {
   windows: {
     cli: [
       {
         label: 'Winget',
         command: 'winget install fstubner.netscli',
+        hint: WINDOWS_MANAGER_HASH_HINT,
       },
       {
         label: 'Scoop',
         command:
           'scoop bucket add fstubner https://github.com/fstubner/scoop-bucket && scoop install netscli',
+        hint: WINDOWS_MANAGER_HASH_HINT,
       },
       {
         label: 'PowerShell script',
@@ -51,11 +59,13 @@ export const installByPlatform: Record<Platform, PlatformInstall> = {
       {
         label: 'Winget',
         command: 'winget install fstubner.netscli.gui',
+        hint: WINDOWS_MANAGER_HASH_HINT,
       },
       {
         label: 'Scoop',
         command:
           'scoop bucket add fstubner https://github.com/fstubner/scoop-bucket && scoop install netscli-gui',
+        hint: WINDOWS_MANAGER_HASH_HINT,
       },
       {
         label: 'Installer',


### PR DESCRIPTION
Two problems in the same row of the install section.

**The copy credited winget for a path that does not use it.** The direct `.msi` row's hint read *"Unsigned — SmartScreen may warn; winget verifies the hash"*. Winget does verify the hash in its manifest — but that row is a direct download from GitHub Releases, where nothing checks anything. The one place the page reassured someone about verification was the one path where no verification happens. It now points at the published checksums instead.

**The download control was styled as a command.** It carried `.alt-cmd` — the class the command rows use — with `display:block`, so it was monospace text filling the full 522px command column, and its hover painted that whole 522×21px strip with no padding around the label. It read as something to type and hovered like a bar.

It is a button now: its own box sized to its label (105×31), body face not monospace, hover confined to the control with the box unchanged. Two knock-on rules that only made sense for commands now exclude it — the narrow-screen ellipsis truncation, and the 44px right padding reserving space for a copy button it does not have.

Verified across all three OS tabs (5 download buttons), at 1400 and 375, hover measured. `astro check` clean, a11y clean in both themes, dead-CSS and file-size budgets pass.