### PR TITLE
Prepare v0.3.0 and close the remaining audit findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,6 +75,28 @@ updates:
         patterns:
           - "@tauri-apps/*"
 
+  # The Astro site has its own package.json and lockfile and was getting no
+  # updates at all -- the repo-wide security PRs that land on it are GitHub's
+  # separate alert flow, not this file. It builds and ships netscli.com, so
+  # its toolchain matters.
+  - package-ecosystem: npm
+    directory: "/site"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      astro:
+        patterns:
+          - astro
+          - "@astrojs/*"
+          - "@astrojs/starlight"
+
   # scripts/ has its own Cargo project.
   - package-ecosystem: cargo
     directory: "/scripts"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,19 +1,31 @@
 name: Release Drafter
 
+# Push to main only.
+#
+# It used to also run on pull_request (opened/reopened/synchronize). On a PR
+# event release-drafter does nothing but apply autolabels, and no autolabeler
+# is configured — so every one of those runs accomplished nothing while
+# holding `contents: write` on pull-request-triggered code. They also produced
+# the duplicate v0.2.7 drafts sitting in Releases.
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [opened, reopened, synchronize]
 
+# Only what the draft update needs. `pull-requests: write` went with the
+# pull_request trigger; nothing here labels a PR.
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
+      # The tag this proposes is a guess. version-resolver maps PR labels to
+      # a bump, no labels are applied here, so it always resolves to `patch`
+      # regardless of what actually changed — which is why it proposed v0.2.7
+      # for a release the repo had already numbered 0.3.0. The version that
+      # ships is the one set by hand across the seven files in
+      # docs/PUBLISHING.md; set the tag to match when you publish the draft.
       - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ further copies in `package.json` and `tauri.conf.json`. See
 
 ## [Unreleased]
 
-## [0.3.0] — 2026-06-26
+## [0.3.0] — 2026-08-19
 
 ### Added
 
@@ -84,6 +84,79 @@ further copies in `package.json` and `tauri.conf.json`. See
   and license installation, Winget/Scoop/Homebrew reference manifests were
   refreshed, and packaging validation commands were added to the release
   checklist.
+
+### Fixed
+
+- **MCP server handled one request at a time.** The read loop awaited each
+  handler before parsing the next line, so a slow scan blocked every other
+  request on the connection, including cancellation. Handlers now run
+  concurrently under a semaphore. ([#169](https://github.com/fstubner/netscli/pull/169))
+- **Reading the ARP table blocked a runtime worker.** On Windows and macOS it
+  shells out to `arp` and waits on the child process; three callers invoked it
+  straight from async code. With MCP handlers capped at 16 concurrent, sixteen
+  of these could stall every worker — including the one reading stdin, so no
+  further request could even be parsed. Moved to a blocking thread.
+  ([#196](https://github.com/fstubner/netscli/pull/196))
+- **Safety limits were enforced in `Ops` but not in the engines.** The scan,
+  sweep, discover and inspect engines are public API re-exported at the crate
+  root, and called directly they applied no subnet, port or concurrency cap —
+  `0.0.0.0/0` collected 4,294,967,294 addresses into a `Vec` before sending a
+  packet. Every engine now enforces its own limits.
+  ([#198](https://github.com/fstubner/netscli/pull/198))
+- **Port 0 was rejected only by the MCP surface.** Now rejected everywhere.
+  ([#164](https://github.com/fstubner/netscli/pull/164))
+- **Panic paths in the core and silent corruption in the OUI generator.**
+  ([#172](https://github.com/fstubner/netscli/pull/172))
+- **TUI mis-measured wide characters**, so CJK and emoji in a remote-supplied
+  hostname or banner pushed box borders out of alignment.
+  ([#173](https://github.com/fstubner/netscli/pull/173))
+- **The desktop app described work it had not done.** The command preview
+  claimed five ports while three were scanned, truncated captures were
+  presented as complete, and the open-port count drifted from the rows below
+  it. ([#197](https://github.com/fstubner/netscli/pull/197))
+- **Packet Capture vanished on builds without capture support** instead of
+  explaining what was needed. ([#193](https://github.com/fstubner/netscli/pull/193))
+- **The desktop app was not keyboard operable**, and the result grid had
+  incorrect ARIA. ([#171](https://github.com/fstubner/netscli/pull/171))
+- **The website claimed packet capture in builds that do not ship it**, and
+  advertised a version that was never released.
+  ([#194](https://github.com/fstubner/netscli/pull/194),
+  [#208](https://github.com/fstubner/netscli/pull/208))
+
+### Changed
+
+- **Website rebuilt for every screen width.** The landing page and docs were
+  swept across six widths and both themes, and the shell, navigation, contents
+  list, colour and typography were reworked to hold up at all of them. The
+  brand accent moved from a teal-green that read blue in small text to one that
+  reads green at any size, and contrast improved with it.
+  ([#190](https://github.com/fstubner/netscli/pull/190)–[#209](https://github.com/fstubner/netscli/pull/209))
+- **Search, head metadata and page titles rewritten** so the site describes
+  what it is rather than repeating adjectives.
+  ([#204](https://github.com/fstubner/netscli/pull/204))
+- **Per-PR site previews on Cloudflare Pages**, and GitHub Pages deploys are
+  manual-only. ([#165](https://github.com/fstubner/netscli/pull/165),
+  [#136](https://github.com/fstubner/netscli/pull/136))
+
+### Changed (internal)
+
+- **CI gates report unconditionally**, so branch protection can require them,
+  and both required checks were closed against a job that fails without
+  failing the gate. ([#161](https://github.com/fstubner/netscli/pull/161),
+  [#187](https://github.com/fstubner/netscli/pull/187))
+- **The end-to-end suite can now fail.** Several scenarios were structurally
+  incapable of it. ([#199](https://github.com/fstubner/netscli/pull/199))
+- **The Tauri render suite is schedule-only** and no longer gates releases.
+  ([#178](https://github.com/fstubner/netscli/pull/178))
+- **A dead-CSS budget runs in CI**, holding the docs override stack at its
+  current 210 provably shadowed declarations.
+  ([#207](https://github.com/fstubner/netscli/pull/207))
+- **Node 22, jsdom 30, ESLint 10, react-hooks 7**, and three Rust dependency
+  bumps. ([#187](https://github.com/fstubner/netscli/pull/187)–[#189](https://github.com/fstubner/netscli/pull/189))
+- **Release pipeline hardened**: tag validation on the AUR jobs, a checksum
+  that could be contaminated by progress output, and the publish long tail.
+  ([#158](https://github.com/fstubner/netscli/pull/158),
+  [#200](https://github.com/fstubner/netscli/pull/200))
 
 ## [0.2.6] — 2026-05-06
 

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/interaction.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/interaction.mjs
@@ -17,13 +17,22 @@ async function assertCommandStatusAlignment(driver) {
     const dotRect = dot.getBoundingClientRect();
     const statusRect = status.getBoundingClientRect();
     const statusStyle = getComputedStyle(status);
-    const dotStyle = getComputedStyle(dot);
     const commandStyle = getComputedStyle(document.querySelector('[data-testid="command-strip"]'));
     const statusRightInset = parseFloat(statusStyle.paddingRight);
     return {
       leftDelta: Math.abs(terminalRect.left - dotRect.left),
       commandLeftInset: parseFloat(commandStyle.paddingLeft),
-      dotMarginTop: dotStyle.marginTop,
+      // The thing this is meant to check is that the dot sits on the
+      // footer text's optical centre. Measure that, rather than the 1px
+      // nudge that currently achieves it: the nudge is font-metric and DPI
+      // dependent, so pinning it binds the suite to one runner image and
+      // goes red on a restyle that keeps the alignment correct.
+      dotTextCenterDelta: (() => {
+        const text = document.querySelector('[data-testid="statusbar"] .status-left');
+        if (!text) return null;
+        const t = text.getBoundingClientRect();
+        return Math.abs((dotRect.top + dotRect.height / 2) - (t.top + t.height / 2));
+      })(),
       leftText: document.querySelector('[data-testid="statusbar"] .status-left')?.textContent ?? '',
       rightText: document.querySelector('[data-testid="statusbar"] .status-right')?.textContent ?? '',
       statusLeftInset: parseFloat(statusStyle.paddingLeft),
@@ -35,7 +44,10 @@ async function assertCommandStatusAlignment(driver) {
     state.commandLeftInset < state.statusLeftInset,
     `Command prompt icon should sit closer to the edge than the status dot, got ${state.commandLeftInset}/${state.statusLeftInset}px`,
   );
-  assert.equal(state.dotMarginTop, '1px', 'Status dot should sit 1px lower to align with footer text');
+  assert.ok(
+    state.dotTextCenterDelta !== null && state.dotTextCenterDelta <= 2,
+    `Status dot should sit on the footer text's centre, off by ${state.dotTextCenterDelta}px`,
+  );
   assert.match(state.leftText, /Mbps/i, 'Traffic rates should be grouped with the selected interface on the left');
   assert.doesNotMatch(state.rightText, /v\d+\./i, 'Footer should not duplicate the About version');
   assertAlignment('Command copy icon vs status padding', state.rightDelta, 3);

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/menu.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/menu.mjs
@@ -97,74 +97,6 @@ async function assertExitMenuItemNeutralUntilHover(driver) {
   assert.notEqual(hoverColor, colors.exitIcon, 'Exit icon should become danger-colored on hover');
 }
 
-async function assertSettingsDialog(driver) {
-  await openSettingsDialog(driver);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /Appearance/i);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /Notifications/i);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /Network Activity/i);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /Theme/i);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /CLI Command Bar/i);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /Interaction Toasts/i);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /Operation Toasts/i);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /Release Notifications/i);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /Saving/i);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /Ask Where To Save/i);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /Default Save Folder/i);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /Activity Animation/i);
-  await waitForText(driver, '[data-testid="settings-dialog"]', /Network Interface/i);
-  const text = await driver.findElement(By.css('[data-testid="settings-dialog"]')).getText();
-  assert.doesNotMatch(text, /\bNIC\b/i, 'Settings should use Network Interface, not NIC');
-  const themeControl = await driver.executeScript(`
-    const control = document.querySelector('[data-testid="settings-theme-toggle"]');
-    const dialog = document.querySelector('[data-testid="settings-dialog"]');
-    const body = dialog?.querySelector('.settings-dialog-body');
-    const dialogRect = dialog?.getBoundingClientRect();
-    const checkbox = document.querySelector('[data-testid="settings-operation-toasts-toggle"]');
-    const checkboxBox = checkbox?.querySelector('.settings-checkbox-box');
-    const checkboxStyle = checkboxBox ? getComputedStyle(checkboxBox) : null;
-    return {
-      role: control?.getAttribute('role'),
-      text: control?.textContent.trim() ?? '',
-      checkboxCount: document.querySelectorAll('[data-testid="settings-dialog"] .settings-checkbox-row input[type="checkbox"]').length,
-      saveFolderButton: document.querySelector('[data-testid="settings-save-folder-button"]')?.textContent.trim() ?? '',
-      saveFolderClearDisabled: document.querySelector('[data-testid="settings-save-folder-clear"]')?.disabled ?? false,
-      bodyColumns: body ? getComputedStyle(body).gridTemplateColumns.split(' ').length : 0,
-      ratio: dialogRect ? dialogRect.width / dialogRect.height : 0,
-      height: dialogRect ? Math.round(dialogRect.height) : 0,
-      operationRole: checkbox?.getAttribute('role') ?? '',
-      // "Compact square boxes" is the requirement; 18px was one way to
-      // satisfy it. Measure squareness and a size range instead, so a font
-      // or DPI change does not fail a checkbox that is still both.
-      checkboxWidthPx: checkboxBox ? checkboxBox.getBoundingClientRect().width : 0,
-      checkboxHeightPx: checkboxBox ? checkboxBox.getBoundingClientRect().height : 0,
-      checkboxRadius: checkboxStyle?.borderRadius ?? '',
-    };
-  `);
-  assert.equal(themeControl.role, 'switch', 'Theme selection should be a single toggle switch');
-  assert.match(themeControl.text, /Dark|Light/i);
-  assert.ok(themeControl.checkboxCount >= 5, 'Non-theme binary preferences should use checkbox controls');
-  assert.equal(themeControl.saveFolderButton, 'Choose Folder', 'Default save folder should be configured from Settings');
-  assert.equal(themeControl.saveFolderClearDisabled, true, 'Save folder reset should be disabled until a custom folder is selected');
-  assert.equal(themeControl.bodyColumns, 1, 'Settings should use a single-column settings flow');
-  assert.equal(themeControl.operationRole, '', 'Notification rows should rely on native checkbox semantics');
-  assert.ok(themeControl.ratio >= 1.15, `Settings dialog should stay wider than tall, got ratio ${themeControl.ratio}`);
-  assert.ok(themeControl.height <= 540, `Settings dialog should stay compact, got ${themeControl.height}px`);
-  assert.ok(
-    themeControl.checkboxWidthPx >= 14 && themeControl.checkboxWidthPx <= 22,
-    `Preference checkboxes should stay compact, got ${themeControl.checkboxWidthPx}px`,
-  );
-  assert.ok(
-    Math.abs(themeControl.checkboxWidthPx - themeControl.checkboxHeightPx) <= 1,
-    `Preference checkboxes should be square, got ${themeControl.checkboxWidthPx}x${themeControl.checkboxHeightPx}`,
-  );
-  assert.ok(['0px', '2px', '3px', '4px'].includes(themeControl.checkboxRadius), 'Preference checkboxes should not look like pill toggles');
-  await driver.findElement(By.css('[data-testid="settings-interface-trigger"]')).click();
-  await waitForText(driver, '.settings-interface-list', /\S/);
-  await waitForText(driver, '.settings-interface-list', /Selected/i);
-  await waitForText(driver, '.settings-interface-list', /Primary/i);
-  await closeSettingsDialog(driver);
-}
-
 async function assertMenuItemDisabled(driver, menuLabel, itemLabel, expected) {
   await openMenu(driver, menuLabel);
   const disabled = await driver.executeScript(
@@ -241,29 +173,6 @@ async function assertInterfaceReadinessReflectsSelection(driver) {
   }
 }
 
-async function openSettingsDialog(driver) {
-  const open = await driver.executeScript(
-    "return document.querySelector('[data-testid=\"settings-dialog\"]') !== null",
-  );
-  if (!open) {
-    await clickButtonText(driver, '.menu-button', 'Settings');
-  }
-  await withElement(driver, '[data-testid="settings-dialog"]');
-}
-
-async function closeSettingsDialog(driver) {
-  // A missing close button is a failure, not a no-op.
-  //
-  // This used to return silently when `.settings-close` was absent, so a
-  // dialog that could no longer be dismissed left the suite green -- and
-  // every later step ran against a modal that was still open, producing
-  // confusing downstream failures instead of naming the real one.
-  const closeButtons = await driver.findElements(By.css('.settings-close'));
-  assert.ok(closeButtons.length > 0, 'settings dialog has no .settings-close button to dismiss it');
-  await closeButtons[0].click();
-  await waitForNoElement(driver, '[data-testid="settings-dialog"]');
-}
-
 async function openMenu(driver, menuLabel) {
   const activeLabel = await driver.executeScript(`
     const active = document.querySelector('.menu-button.active');
@@ -322,7 +231,6 @@ async function assertToolbarButtonDisabled(driver, title, expected) {
   assert.equal(disabled === 'true', expected, `Toolbar ${title} disabled state`);
 }
 
-
 export {
   assertEmptyWorkspaceState,
   assertExitMenuItemNeutralUntilHover,
@@ -331,14 +239,11 @@ export {
   assertMenuItemDisabled,
   assertMenuItems,
   assertMenuKeyboardNavigation,
-  assertSettingsDialog,
   assertToolbarButtonDisabled,
   clickMenuItem,
-  closeSettingsDialog,
   countTabs,
   ensureTrafficIndicatorsVisible,
   getActiveTabText,
-  openSettingsDialog,
   openMenu,
   waitForNoElement,
   waitForTabCount,

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/menu.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/menu.mjs
@@ -132,7 +132,11 @@ async function assertSettingsDialog(driver) {
       ratio: dialogRect ? dialogRect.width / dialogRect.height : 0,
       height: dialogRect ? Math.round(dialogRect.height) : 0,
       operationRole: checkbox?.getAttribute('role') ?? '',
-      checkboxWidth: checkboxStyle?.width ?? '',
+      // "Compact square boxes" is the requirement; 18px was one way to
+      // satisfy it. Measure squareness and a size range instead, so a font
+      // or DPI change does not fail a checkbox that is still both.
+      checkboxWidthPx: checkboxBox ? checkboxBox.getBoundingClientRect().width : 0,
+      checkboxHeightPx: checkboxBox ? checkboxBox.getBoundingClientRect().height : 0,
       checkboxRadius: checkboxStyle?.borderRadius ?? '',
     };
   `);
@@ -145,7 +149,14 @@ async function assertSettingsDialog(driver) {
   assert.equal(themeControl.operationRole, '', 'Notification rows should rely on native checkbox semantics');
   assert.ok(themeControl.ratio >= 1.15, `Settings dialog should stay wider than tall, got ratio ${themeControl.ratio}`);
   assert.ok(themeControl.height <= 540, `Settings dialog should stay compact, got ${themeControl.height}px`);
-  assert.equal(themeControl.checkboxWidth, '18px', 'Preference checkboxes should use compact square boxes');
+  assert.ok(
+    themeControl.checkboxWidthPx >= 14 && themeControl.checkboxWidthPx <= 22,
+    `Preference checkboxes should stay compact, got ${themeControl.checkboxWidthPx}px`,
+  );
+  assert.ok(
+    Math.abs(themeControl.checkboxWidthPx - themeControl.checkboxHeightPx) <= 1,
+    `Preference checkboxes should be square, got ${themeControl.checkboxWidthPx}x${themeControl.checkboxHeightPx}`,
+  );
   assert.ok(['0px', '2px', '3px', '4px'].includes(themeControl.checkboxRadius), 'Preference checkboxes should not look like pill toggles');
   await driver.findElement(By.css('[data-testid="settings-interface-trigger"]')).click();
   await waitForText(driver, '.settings-interface-list', /\S/);

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/settingsDialog.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/settingsDialog.mjs
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { By } from '../../driver.mjs';
+import { clickButtonText, waitForText } from '../../ui.mjs';
+import { waitForNoElement } from './menu.mjs';
+
+/**
+ * Settings dialog: opening it, asserting its shape, closing it.
+ *
+ * Split out of menu.mjs, which carried the whole menu bar, the tab helpers,
+ * the toolbar and this, and had a standing note to separate the dialog
+ * helpers once it next needed changing.
+ */
+
+async function assertSettingsDialog(driver) {
+  await openSettingsDialog(driver);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /Appearance/i);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /Notifications/i);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /Network Activity/i);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /Theme/i);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /CLI Command Bar/i);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /Interaction Toasts/i);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /Operation Toasts/i);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /Release Notifications/i);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /Saving/i);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /Ask Where To Save/i);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /Default Save Folder/i);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /Activity Animation/i);
+  await waitForText(driver, '[data-testid="settings-dialog"]', /Network Interface/i);
+  const text = await driver.findElement(By.css('[data-testid="settings-dialog"]')).getText();
+  assert.doesNotMatch(text, /\bNIC\b/i, 'Settings should use Network Interface, not NIC');
+  const themeControl = await driver.executeScript(`
+    const control = document.querySelector('[data-testid="settings-theme-toggle"]');
+    const dialog = document.querySelector('[data-testid="settings-dialog"]');
+    const body = dialog?.querySelector('.settings-dialog-body');
+    const dialogRect = dialog?.getBoundingClientRect();
+    const checkbox = document.querySelector('[data-testid="settings-operation-toasts-toggle"]');
+    const checkboxBox = checkbox?.querySelector('.settings-checkbox-box');
+    const checkboxStyle = checkboxBox ? getComputedStyle(checkboxBox) : null;
+    return {
+      role: control?.getAttribute('role'),
+      text: control?.textContent.trim() ?? '',
+      checkboxCount: document.querySelectorAll('[data-testid="settings-dialog"] .settings-checkbox-row input[type="checkbox"]').length,
+      saveFolderButton: document.querySelector('[data-testid="settings-save-folder-button"]')?.textContent.trim() ?? '',
+      saveFolderClearDisabled: document.querySelector('[data-testid="settings-save-folder-clear"]')?.disabled ?? false,
+      bodyColumns: body ? getComputedStyle(body).gridTemplateColumns.split(' ').length : 0,
+      ratio: dialogRect ? dialogRect.width / dialogRect.height : 0,
+      height: dialogRect ? Math.round(dialogRect.height) : 0,
+      operationRole: checkbox?.getAttribute('role') ?? '',
+      // "Compact square boxes" is the requirement; 18px was one way to
+      // satisfy it. Measure squareness and a size range instead, so a font
+      // or DPI change does not fail a checkbox that is still both.
+      checkboxWidthPx: checkboxBox ? checkboxBox.getBoundingClientRect().width : 0,
+      checkboxHeightPx: checkboxBox ? checkboxBox.getBoundingClientRect().height : 0,
+      checkboxRadius: checkboxStyle?.borderRadius ?? '',
+    };
+  `);
+  assert.equal(themeControl.role, 'switch', 'Theme selection should be a single toggle switch');
+  assert.match(themeControl.text, /Dark|Light/i);
+  assert.ok(themeControl.checkboxCount >= 5, 'Non-theme binary preferences should use checkbox controls');
+  assert.equal(themeControl.saveFolderButton, 'Choose Folder', 'Default save folder should be configured from Settings');
+  assert.equal(themeControl.saveFolderClearDisabled, true, 'Save folder reset should be disabled until a custom folder is selected');
+  assert.equal(themeControl.bodyColumns, 1, 'Settings should use a single-column settings flow');
+  assert.equal(themeControl.operationRole, '', 'Notification rows should rely on native checkbox semantics');
+  assert.ok(themeControl.ratio >= 1.15, `Settings dialog should stay wider than tall, got ratio ${themeControl.ratio}`);
+  assert.ok(themeControl.height <= 540, `Settings dialog should stay compact, got ${themeControl.height}px`);
+  assert.ok(
+    themeControl.checkboxWidthPx >= 14 && themeControl.checkboxWidthPx <= 22,
+    `Preference checkboxes should stay compact, got ${themeControl.checkboxWidthPx}px`,
+  );
+  assert.ok(
+    Math.abs(themeControl.checkboxWidthPx - themeControl.checkboxHeightPx) <= 1,
+    `Preference checkboxes should be square, got ${themeControl.checkboxWidthPx}x${themeControl.checkboxHeightPx}`,
+  );
+  assert.ok(['0px', '2px', '3px', '4px'].includes(themeControl.checkboxRadius), 'Preference checkboxes should not look like pill toggles');
+  await driver.findElement(By.css('[data-testid="settings-interface-trigger"]')).click();
+  await waitForText(driver, '.settings-interface-list', /\S/);
+  await waitForText(driver, '.settings-interface-list', /Selected/i);
+  await waitForText(driver, '.settings-interface-list', /Primary/i);
+  await closeSettingsDialog(driver);
+}
+
+async function openSettingsDialog(driver) {
+  const open = await driver.executeScript(
+    "return document.querySelector('[data-testid=\"settings-dialog\"]') !== null",
+  );
+  if (!open) {
+    await clickButtonText(driver, '.menu-button', 'Settings');
+  }
+  await withElement(driver, '[data-testid="settings-dialog"]');
+}
+
+async function closeSettingsDialog(driver) {
+  // A missing close button is a failure, not a no-op.
+  //
+  // This used to return silently when `.settings-close` was absent, so a
+  // dialog that could no longer be dismissed left the suite green -- and
+  // every later step ran against a modal that was still open, producing
+  // confusing downstream failures instead of naming the real one.
+  const closeButtons = await driver.findElements(By.css('.settings-close'));
+  assert.ok(closeButtons.length > 0, 'settings dialog has no .settings-close button to dismiss it');
+  await closeButtons[0].click();
+  await waitForNoElement(driver, '[data-testid="settings-dialog"]');
+}
+
+export { assertSettingsDialog, closeSettingsDialog, openSettingsDialog };

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/shell.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/shell.mjs
@@ -4,7 +4,8 @@ import { assertCommand, assertNoErrorStrip, assertTheme, clickButtonText, replac
 import { assertExportArtifactsCreated, countExportArtifacts } from './helpers/export.mjs';
 import { assertAboutDialogPolish, assertEmptyStateCentered, assertTrafficArrowsAreLedStyle, forceTabOverflow } from './helpers/polish.mjs';
 import { assertCommandStatusAlignment, assertInteractiveCursorTreatment, assertSuppressesNativeContextMenu, assertThemedTooltips, assertToastHasTimeoutBar } from './helpers/interaction.mjs';
-import { assertEmptyWorkspaceState, assertExitMenuItemNeutralUntilHover, assertInterfaceReadinessReflectsSelection, assertMenuIncludes, assertMenuItemDisabled, assertMenuItems, assertMenuKeyboardNavigation, assertSettingsDialog, assertToolbarButtonDisabled, clickMenuItem, closeSettingsDialog, countTabs, ensureTrafficIndicatorsVisible, getActiveTabText, openSettingsDialog, waitForNoElement, waitForTabCount } from './helpers/menu.mjs';
+import { assertEmptyWorkspaceState, assertExitMenuItemNeutralUntilHover, assertInterfaceReadinessReflectsSelection, assertMenuIncludes, assertMenuItemDisabled, assertMenuItems, assertMenuKeyboardNavigation, assertToolbarButtonDisabled, clickMenuItem, countTabs, ensureTrafficIndicatorsVisible, getActiveTabText, waitForNoElement, waitForTabCount } from './helpers/menu.mjs';
+import { assertSettingsDialog, closeSettingsDialog, openSettingsDialog } from './helpers/settingsDialog.mjs';
 import { assertActiveTabVisible, assertDetailPaneCanFillWorkspace, assertEmptyToolLauncherVisible, assertOverflowTabClickSelection, assertTabAddControlPlacement, assertTabOverflowTreatment, assertTabToolPopoverTopLayer, assertTabToolPopoverVisible } from './helpers/tabs.mjs';
 
 export async function exerciseMenusAndToolbar(driver) {

--- a/apps/netscli-gui/src-tauri/tauri.conf.json
+++ b/apps/netscli-gui/src-tauri/tauri.conf.json
@@ -45,6 +45,9 @@
       "../../../crates/netscli-core/data/oui.min.json.gz": "data/oui.min.json.gz"
     },
     "windows": {
+      "webviewInstallMode": {
+        "type": "embedBootstrapper"
+      },
       "wix": {
         "template": "wix/main.wxs"
       },

--- a/apps/netscli-gui/src/tools/fieldValidation.test.ts
+++ b/apps/netscli-gui/src/tools/fieldValidation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { validateFieldValue, validateHost, validatePorts, validateSubnet } from './fieldValidation';
+import { validateTab } from '../workspace/toolExecution';
+import type { WorkspaceTab } from './types';
+
+/** The cases that used to reach the backend. Each of these passed the old
+ *  presence-only check, because each is a non-empty string. */
+describe('free-text fields are checked for shape, not just presence', () => {
+  it('rejects a ports value that is not ports', () => {
+    expect(validatePorts('hello')).toMatch(/not a port/);
+  });
+
+  it('rejects port 0 and 65536, which the core rejects too', () => {
+    expect(validatePorts('0')).toMatch(/not a port/);
+    expect(validatePorts('65536')).toMatch(/not a port/);
+  });
+
+  it('rejects a range that ends before it starts', () => {
+    expect(validatePorts('443-80')).toMatch(/starts above/);
+  });
+
+  it('accepts the forms the core parser accepts', () => {
+    expect(validatePorts('22,80,443')).toBeNull();
+    expect(validatePorts('1-1024')).toBeNull();
+    expect(validatePorts('22, 80 , 443-445')).toBeNull();
+    // parse_ports tolerates empty segments, so this layer must too.
+    expect(validatePorts('22,,80')).toBeNull();
+    expect(validatePorts('')).toBeNull();
+  });
+
+  it('rejects a subnet wider than the engines will run', () => {
+    expect(validateSubnet('10.0.0.0/8')).toMatch(/safety limit/);
+    expect(validateSubnet('192.168.1.0/24')).toBeNull();
+  });
+
+  it('rejects a subnet with no prefix', () => {
+    expect(validateSubnet('192.168.1.0')).toMatch(/needs a \/prefix/);
+  });
+
+  it('rejects a host with spaces but accepts hostnames and IPs', () => {
+    expect(validateHost('two words')).toMatch(/spaces/);
+    expect(validateHost('netscli.com')).toBeNull();
+    expect(validateHost('192.168.1.1')).toBeNull();
+    expect(validateHost('::1')).toBeNull();
+    expect(validateHost('my-host.local.')).toBeNull();
+  });
+
+  it('leaves BPF filters alone', () => {
+    expect(validateFieldValue('filter', 'tcp port 443 and not host 10.0.0.1')).toBeNull();
+  });
+});
+
+describe('validateTab', () => {
+  const tab = (kind: WorkspaceTab['kind'], form: Record<string, string>) =>
+    ({ kind, form }) as unknown as WorkspaceTab;
+
+  it('blocks a scan whose ports are not ports', () => {
+    expect(validateTab(tab('scan', { host: '127.0.0.1', ports: 'hello' }))).toMatch(/not a port/);
+  });
+
+  it('blocks a discover over a subnet the engine would refuse', () => {
+    expect(validateTab(tab('discover', { subnet: '0.0.0.0/0' }))).toMatch(/safety limit/);
+  });
+
+  it('still reports a missing required field first', () => {
+    expect(validateTab(tab('scan', { host: '', ports: 'hello' }))).toMatch(/required/);
+  });
+
+  it('passes a well-formed run', () => {
+    expect(validateTab(tab('scan', { host: '127.0.0.1', ports: '22,80,443' }))).toBeNull();
+  });
+});

--- a/apps/netscli-gui/src/tools/fieldValidation.ts
+++ b/apps/netscli-gui/src/tools/fieldValidation.ts
@@ -1,0 +1,105 @@
+/**
+ * Shape checks for the free-text tool fields, before a run is dispatched.
+ *
+ * The numeric fields have been bounded for a while -- `min`/`max` on the
+ * field definition, clamped by NumberField. The free-text ones were gated
+ * only on presence, so `ports: "hello"` was accepted by the form, sent to the
+ * backend, and came back as an error after a round trip. `subnet` was not
+ * even marked required, so an empty discover ran against whatever the backend
+ * defaulted to.
+ *
+ * These deliberately mirror what the core parsers accept rather than being
+ * stricter. Rejecting something the CLI would have run is worse than letting
+ * an odd-but-valid value through: the backend still validates, and this layer
+ * exists to give a fast answer, not to be the authority.
+ *
+ * `filter` is not checked. It is a BPF expression, the grammar is large, and
+ * a partial reimplementation here would reject valid filters.
+ */
+
+/** 1-65535, matching the core parser's `u16` with zero rejected. */
+function isPort(token: string): boolean {
+  if (!/^\d{1,5}$/.test(token)) return false;
+  const value = Number(token);
+  return value >= 1 && value <= 65535;
+}
+
+/** Comma-separated ports and `start-end` ranges, the form `parse_ports`
+ *  accepts. Empty segments are tolerated there, so they are tolerated here. */
+export function validatePorts(raw: string): string | null {
+  const value = raw.trim();
+  if (!value) return null;
+  for (const part of value.split(',')) {
+    const token = part.trim();
+    if (!token) continue;
+    const range = token.split('-');
+    if (range.length > 2) return `"${token}" is not a port or range`;
+    if (!range.every((end) => isPort(end.trim()))) {
+      return `"${token}" is not a port or range (1-65535)`;
+    }
+    if (range.length === 2 && Number(range[0].trim()) > Number(range[1].trim())) {
+      return `"${token}" starts above where it ends`;
+    }
+  }
+  return null;
+}
+
+function isIpv4(value: string): boolean {
+  const parts = value.split('.');
+  if (parts.length !== 4) return false;
+  return parts.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255);
+}
+
+/** Deliberately loose: anything with a colon and hex digits is taken as IPv6
+ *  rather than reimplementing the address grammar and its `::` elision. */
+function isIpv6(value: string): boolean {
+  return value.includes(':') && /^[0-9a-fA-F:.]+$/.test(value);
+}
+
+export function validateIp(raw: string): string | null {
+  const value = raw.trim();
+  if (!value) return null;
+  return isIpv4(value) || isIpv6(value) ? null : `"${value}" is not an IP address`;
+}
+
+/** A hostname or an IP. Hostnames are checked for shape only -- labels of
+ *  letters, digits and hyphens -- because the resolver is the authority on
+ *  whether one exists. */
+export function validateHost(raw: string): string | null {
+  const value = raw.trim();
+  if (!value) return null;
+  if (isIpv4(value) || isIpv6(value)) return null;
+  if (/\s/.test(value)) return 'Host cannot contain spaces';
+  if (value.length > 253) return 'Host is too long';
+  const labels = value.replace(/\.$/, '').split('.');
+  const ok = labels.every((label) => /^[a-zA-Z0-9_](?:[a-zA-Z0-9_-]*[a-zA-Z0-9_])?$/.test(label) && label.length <= 63);
+  return ok ? null : `"${value}" is not a hostname or IP address`;
+}
+
+/** IPv4 CIDR. The engines cap the prefix at /16; anything shorter is a
+ *  refusal from the backend, so say so here instead of after the round trip. */
+export function validateSubnet(raw: string): string | null {
+  const value = raw.trim();
+  if (!value) return null;
+  const [address, prefix, ...rest] = value.split('/');
+  if (rest.length > 0 || prefix === undefined) return `"${value}" needs a /prefix, e.g. 192.168.1.0/24`;
+  if (!isIpv4(address)) return `"${address}" is not an IPv4 address`;
+  if (!/^\d{1,2}$/.test(prefix)) return `"/${prefix}" is not a prefix length`;
+  const bits = Number(prefix);
+  if (bits > 32) return 'Prefix length cannot exceed /32';
+  if (bits < 16) return 'Subnet is larger than /16, which the safety limit refuses';
+  return null;
+}
+
+const BY_KEY: Record<string, (value: string) => string | null> = {
+  host: validateHost,
+  ip: validateIp,
+  ports: validatePorts,
+  subnet: validateSubnet,
+};
+
+/** Keyed on the field name rather than declared per field, because these
+ *  names mean the same thing in every tool that uses them. */
+export function validateFieldValue(key: string, value: string): string | null {
+  return BY_KEY[key]?.(value) ?? null;
+}

--- a/apps/netscli-gui/src/tools/presentation/rows.ts
+++ b/apps/netscli-gui/src/tools/presentation/rows.ts
@@ -1,3 +1,4 @@
+import { formatNumber } from './values';
 import type { ToolResult } from '../../types/app';
 import type { PortResult } from '../../types/netscli';
 import type { ResultRow, ToolKind } from '../types';
@@ -245,10 +246,6 @@ export function buildRows(result: ToolResult | null): ResultRow[] {
       });
     }
   }
-}
-
-function formatNumber(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }
 
 function interfaceKind(name: string, isLoopback: boolean): string {

--- a/apps/netscli-gui/src/tools/presentation/summaries.ts
+++ b/apps/netscli-gui/src/tools/presentation/summaries.ts
@@ -1,3 +1,4 @@
+import { formatNumber } from './values';
 import type { ToolResult } from '../../types/app';
 import { inspectPorts } from './ports';
 
@@ -64,6 +65,3 @@ function traceHopCount(lines: string[]): number {
   return lines.filter((line) => /^\s*\d+\s+/.test(line)).length;
 }
 
-function formatNumber(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(1);
-}

--- a/apps/netscli-gui/src/tools/presentation/traceLine.ts
+++ b/apps/netscli-gui/src/tools/presentation/traceLine.ts
@@ -1,3 +1,4 @@
+import { formatNumber } from './values';
 export interface TraceHopRow {
   hop: number;
   status: string;
@@ -82,6 +83,3 @@ function traceAverage(samples: string[]): string {
   return `${formatNumber(avg)} ms`;
 }
 
-function formatNumber(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(1);
-}

--- a/apps/netscli-gui/src/tools/presentation/values.ts
+++ b/apps/netscli-gui/src/tools/presentation/values.ts
@@ -23,3 +23,12 @@ export function renderValue(value: unknown): string {
   if (typeof value === 'object') return JSON.stringify(value);
   return String(value);
 }
+
+/** One decimal for fractions, none for whole numbers.
+ *
+ * Was copied verbatim into rows.ts, summaries.ts and traceLine.ts. Three
+ * identical private copies of a formatting rule is three places to change
+ * when the rule changes, and nothing to make them change together. */
+export function formatNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}

--- a/apps/netscli-gui/src/tools/registry.ts
+++ b/apps/netscli-gui/src/tools/registry.ts
@@ -137,6 +137,12 @@ export const TOOL_CONFIG: Record<ToolKind, ToolConfig> = {
     action: 'Discover',
     fields: [
       { key: 'service_types', label: 'Service Types', placeholder: '_http._tcp.local., _ssh._tcp.local.' },
+      // DEFAULT_FORM carried `timeout_ms` with no field to set it, so the
+      // value went straight to the backend through `numberOrUndefined`, which
+      // does not clamp -- every other numeric field is bounded by its `min`
+      // and `max` here. The command preview and the execution path already
+      // handled it; only the input was missing.
+      { key: 'timeout_ms', label: 'Timeout', type: 'number', compact: true, placeholder: '3000', min: 500, max: 30000, step: 100 },
     ],
   },
   interfaces: {

--- a/apps/netscli-gui/src/workspace/toolExecution.ts
+++ b/apps/netscli-gui/src/workspace/toolExecution.ts
@@ -1,4 +1,5 @@
 import { isTauri } from '../services/env';
+import { validateFieldValue } from '../tools/fieldValidation';
 import * as netscli from '../services/netscli';
 import type { ToolResult } from '../types/app';
 import type { DnsRecord } from '../types/netscli';
@@ -198,9 +199,19 @@ export function validateTab(tab: WorkspaceTab): string | null {
   if (tab.kind === 'pcap' && tab.form.mode === 'Open File') {
     return null;
   }
-  const missing = TOOL_CONFIG[tab.kind].fields.find(
-    (field) => field.required && !tab.form[field.key]?.trim(),
-  );
+  const fields = TOOL_CONFIG[tab.kind].fields;
+  const missing = fields.find((field) => field.required && !tab.form[field.key]?.trim());
   if (missing) return `${missing.label} is required`;
+
+  // Shape, not just presence. Numeric fields are already bounded by their
+  // `min`/`max`; the free-text ones were gated on presence alone, so
+  // `ports: "hello"` was accepted here and only failed after a round trip to
+  // the backend.
+  for (const field of fields) {
+    const value = tab.form[field.key];
+    if (!value) continue;
+    const problem = validateFieldValue(field.key, value);
+    if (problem) return problem;
+  }
   return null;
 }

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -193,8 +193,14 @@ NetsCLI Desktop can be submitted to the Microsoft Store later as an
 Before attempting it, prepare:
 
 - Partner Center developer enrollment and reserved app name.
-- A Store-specific Tauri Windows bundle config using the offline
-  WebView2 installer mode.
+- A Store-specific Tauri Windows bundle config using the **offline**
+  WebView2 installer mode. The default bundle now uses
+  `embedBootstrapper` (`apps/netscli-gui/src-tauri/tauri.conf.json`),
+  which removes the elevated network fetch the old `downloadBootstrapper`
+  default performed at install time but still needs a connection for the
+  runtime itself. The Store requires `offlineInstaller`, which embeds the
+  full runtime and adds roughly 130 MB to the installer -- worth taking
+  only for that channel, or if offline installs become a requirement.
 - Authenticode signing with a certificate that chains to a CA in the
   Microsoft Trusted Root Program. Sigstore release signatures are useful
   for artifact provenance, but they do not replace Store-required Windows

--- a/docs/SECURITY_REVIEW.md
+++ b/docs/SECURITY_REVIEW.md
@@ -1,8 +1,37 @@
 # NetsCLI Security Review
 
 Date: 2026-05-29
+Last re-verified: 2026-08-19
+Next review due: 2026-11-19, and before any release that changes CI,
+packaging, or the installer templates.
 
-Scope: React/Tauri GUI, Tauri backend commands, `netscli-core`, CLI/TUI dispatch paths, and MCP tool handlers. This review focused on frontend injection/storage/URL risks, Tauri privilege boundaries, filesystem access, network scan safety limits, DNS privacy behavior, PCAP capture behavior, and dependency advisories.
+Scope: React/Tauri GUI, Tauri backend commands, `netscli-core`, CLI/TUI
+dispatch paths, and MCP tool handlers. This review focused on frontend
+injection/storage/URL risks, Tauri privilege boundaries, filesystem access,
+network scan safety limits, DNS privacy behavior, PCAP capture behavior, and
+dependency advisories.
+
+### Out of scope, and why that matters
+
+This review has never covered the supply chain. Not examined here:
+
+- `.github/workflows/` — including `publish.yml`, which holds tokens for
+  crates.io, the Homebrew tap, the Scoop bucket, winget and AUR.
+- `scripts/release/` — the publish scripts that fetch release assets over
+  the network and rewrite packaging manifests from them.
+- `packaging/` — the manifests and installer templates themselves.
+- `apps/netscli-gui/src-tauri/wix/` and `nsis/` — the installer templates.
+
+That gap has produced at least one real finding since: until 2026-08-19 the
+MSI used Tauri's `downloadBootstrapper` default, which fetched and executed
+an installer over the network at install time, elevated, with no hash
+pinning. Nothing in this document's scope would have caught it.
+
+The dependency conclusion below also rests on `npm audit --omit=dev`, which
+excludes the build toolchain that produces the shipped bundle. A compromised
+bundler is a supply-chain risk this review does not measure.
+
+Extending scope to the four areas above is tracked as B-39.
 
 ## Summary
 

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,4 +1,12 @@
 # Maintainer: Felix Stubner <felix.stubner@gmail.com>
+#
+# These values are a template, not what users install.
+#
+# scripts/release/publish-*.sh fetch the real .sha256 from the published
+# release, rewrite version, url and hash, verify the result, and push that to
+# the tap or bucket. What is committed here is whatever the last edit left
+# behind -- currently a 0.3.0 label over the v0.2.6 digests -- and reading it
+# as the shipped manifest is a mistake that has been made before.
 
 pkgname=netscli-bin
 _binname=netscli

--- a/packaging/aur/netscli-gui-bin/PKGBUILD
+++ b/packaging/aur/netscli-gui-bin/PKGBUILD
@@ -1,5 +1,13 @@
 # Maintainer: Felix Stubner <felix.stubner@gmail.com>
 #
+# These values are a template, not what users install.
+#
+# scripts/release/publish-*.sh fetch the real .sha256 from the published
+# release, rewrite version, url and hash, verify the result, and push that to
+# the tap or bucket. What is committed here is whatever the last edit left
+# behind -- currently a 0.3.0 label over the v0.2.6 digests -- and reading it
+# as the shipped manifest is a mistake that has been made before.
+#
 # Sibling package to netscli-bin (the CLI/TUI). Ships the Tauri desktop
 # app as a self-contained .AppImage rather than the .deb, since pacman
 # users typically prefer not to depend on dpkg/Debian conventions for

--- a/packaging/homebrew/Casks/netscli.rb
+++ b/packaging/homebrew/Casks/netscli.rb
@@ -1,14 +1,16 @@
 # Homebrew Cask for the netscli desktop app (Tauri 2 + React).
 #
 # Lives alongside Formula/netscli.rb (the CLI) in fstubner/homebrew-tap.
-# Two architectures because Tauri builds are not universal — Apple
-# Silicon and Intel get distinct .dmg artifacts on every release.
+# Two architectures because Tauri builds are not universal -- Apple Silicon
+# and Intel get distinct .dmg artifacts on every release.
 #
-# After cutting release vX.Y.Z, update `version` and replace each
-# sha256 with the value from the matching `.sha256` asset on the
-# release page (or let publish.yml's homebrew-cask job do it
-# automatically).
-
+# The values below are a template, not what users install.
+# `scripts/release/publish-homebrew.sh` rewrites `version` and every `sha256`
+# from the published release's .sha256 sidecars and pushes that to the tap.
+# What is committed here is whatever the last edit left behind.
+#
+# Edit by hand only when bootstrapping the tap or when the publish job is
+# broken; take each digest from the `.sha256` asset on the release page.
 cask "netscli" do
   version "0.3.0"
 

--- a/packaging/homebrew/netscli.rb
+++ b/packaging/homebrew/netscli.rb
@@ -1,14 +1,20 @@
-# Formula for Homebrew. After cutting release vX.Y.Z:
-# 1. Update `version`.
-# 2. Replace each `sha256` value with the real SHA256 of the matching
-#    platform asset (read from the `.sha256` files on the release page).
-# 3. Publish this file in fstubner/homebrew-tap (or submit to
-#    homebrew-core once the project has a few releases under its belt).
+# Formula for Homebrew, published to fstubner/homebrew-tap.
 #
-# Usage after tap is published:
+# The values below are a template, not what users install.
+# `scripts/release/publish-homebrew.sh` runs from publish.yml on every
+# release: it fetches the real .sha256 sidecars from the published assets,
+# rewrites `version` and every `sha256` here, checks that exactly four valid
+# digests came out, and pushes the result to the tap. What is committed in
+# this repo is whatever the last edit left behind, so it can and does lag --
+# reading it as the shipped manifest is a mistake that has been made before.
+#
+# Editing it by hand is only needed if you are bootstrapping the tap or the
+# publish job is broken; in that case take each digest from the `.sha256`
+# asset on the release page.
+#
+# Usage:
 #   brew tap fstubner/tap
 #   brew install netscli
-
 class Netscli < Formula
   desc "Network diagnostics CLI, terminal UI, and MCP server"
   homepage "https://netscli.com"

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -48,13 +48,6 @@ const transitionExceptions = new Map([
     },
   ],
   [
-    'apps/netscli-gui/e2e/tauri-render/scenarios/helpers/menu.mjs',
-    {
-      maxLines: 345,
-      reason: 'render automation menu helpers; split menu/dialog helpers next',
-    },
-  ],
-  [
     'apps/netscli-cli/src/tui/runtime/input.rs',
     {
       maxLines: 330,

--- a/site/package.json
+++ b/site/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
-    "check:css": "node ./scripts/css-shadowing.mjs --max 210",
+    "check:css": "node ./scripts/css-shadowing.mjs --max 126",
     "test:a11y": "npm run build && node ./scripts/a11y.mjs"
   },
   "dependencies": {

--- a/site/src/styles/starlight/01-tokens-and-header.css
+++ b/site/src/styles/starlight/01-tokens-and-header.css
@@ -251,9 +251,7 @@ site-search button[data-open-modal]:hover {
     linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.018)),
     rgba(17, 22, 29, 0.96);
   color: var(--sl-color-white);
-  box-shadow:
-    0 0 0 1px rgba(var(--netscli-accent-rgb), 0.16),
-    inset 0 1px 0 rgba(255, 255, 255, 0.035);
+
 }
 
 site-search button[data-open-modal]:focus-visible {

--- a/site/src/styles/starlight/02-search-and-sidebar-base.css
+++ b/site/src/styles/starlight/02-search-and-sidebar-base.css
@@ -63,7 +63,7 @@ site-search button[data-close-modal]:focus-visible {
   border-radius: 6px !important;
 
   color: var(--sl-color-gray-1) !important;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+
 }
 
 #starlight__search .pagefind-ui__search-input:focus {
@@ -72,16 +72,7 @@ site-search button[data-close-modal]:focus-visible {
   box-shadow:
     0 0 0 2px rgba(var(--netscli-accent-rgb), 0.16),
     inset 0 1px 0 rgba(255, 255, 255, 0.04) !important;
-}
-
-#starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)),
-#starlight__search .pagefind-ui__result-nested,
-#starlight__search .pagefind-ui__result-tags {
-
-  background: rgba(17, 22, 29, 0.78) !important;
-}
-
-#starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):hover,
+}#starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):hover,
 #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):focus-within,
 #starlight__search .pagefind-ui__result-nested:hover,
 #starlight__search .pagefind-ui__result-nested:focus-within {
@@ -125,14 +116,7 @@ html[data-theme='light'] #starlight__search {
   --pagefind-ui-background: #ffffff;
   --pagefind-ui-border: rgba(17, 24, 39, 0.14);
   --pagefind-ui-tag: rgba(0, 122, 84, 0.11);
-}
-
-html[data-theme='light'] #starlight__search .pagefind-ui__search-input {
-
-  border-color: rgba(17, 24, 39, 0.16) !important;
-}
-
-html[data-theme='light'] starlight-menu-button button {
+}html[data-theme='light'] starlight-menu-button button {
   background: rgba(17, 24, 39, 0.035);
   color: var(--sl-color-gray-2);
 }
@@ -185,7 +169,7 @@ html[data-theme='light'] starlight-menu-button[aria-expanded='true'] button {
   color: var(--sl-color-white);
 
   border-color: transparent;
-  box-shadow: none;
+
 }
 
 .sidebar-content a[aria-current='page']:hover {

--- a/site/src/styles/starlight/03-shell-layout-base.css
+++ b/site/src/styles/starlight/03-shell-layout-base.css
@@ -166,7 +166,7 @@ html[data-theme='light'] .main-pane {
   border: 1px solid rgba(var(--netscli-accent-rgb), 0.18);
   border-radius: 0.24rem;
 
-  color: var(--netscli-accent-high);
+
   font-family: var(--__sl-font-mono);
   font-size: 0.9em;
   line-height: 1.45;
@@ -201,9 +201,7 @@ html[data-theme='light'] .main-pane {
 
   border-radius: 8px !important;
   border: 1px solid rgba(140, 149, 166, 0.18);
-  box-shadow:
-    0 18px 46px rgba(0, 0, 0, 0.34),
-    inset 0 1px 0 rgba(255, 255, 255, 0.035);
+
 }
 
 .sl-markdown-content .expressive-code .frame.is-terminal .header {
@@ -234,14 +232,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
   box-shadow:
     0 12px 34px rgba(17, 24, 39, 0.11),
     inset 0 1px 0 rgba(255, 255, 255, 0.78);
-}
-
-html[data-theme='light'] .sl-markdown-content :not(pre) > code {
-
-  color: #0b4a1f;
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code {
+}html[data-theme='light'] .sl-markdown-content .expressive-code {
   --ec-brdCol: rgba(17, 24, 39, 0.12);
   --ec-codeBg: #f7faf9;
   --ec-codeFg: #243044;
@@ -279,9 +270,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .ec-line :where(s
   border-radius: 8px;
   overflow: hidden;
 
-  box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.025) inset,
-    0 12px 28px rgba(0, 0, 0, 0.12);
+
   font-size: 0.875rem;
   table-layout: auto;
 }

--- a/site/src/styles/starlight/04-markdown-content-base.css
+++ b/site/src/styles/starlight/04-markdown-content-base.css
@@ -3,7 +3,7 @@
 
   font-size: 0.72rem;
   font-weight: 760;
-  letter-spacing: 0.055em;
+
   line-height: 1.25;
   text-transform: none;
   white-space: nowrap;
@@ -145,7 +145,7 @@
 @media (max-width: 42rem) {
   .sl-markdown-content table {
 
-    border: 0;
+
     background: transparent;
     overflow: visible;
     max-width: 100%;
@@ -157,7 +157,7 @@
   .sl-markdown-content table tr {
 
     gap: 0.28rem;
-    padding: 0.8rem 0.9rem;
+
     border: 1px solid rgba(140, 149, 166, 0.18);
     border-radius: 8px;
     background: rgba(255, 255, 255, 0.03);
@@ -166,7 +166,7 @@
   .sl-markdown-content table td,
   .sl-markdown-content table th {
 
-    width: auto;
+
     min-width: 0;
     padding: 0;
     border: 0;

--- a/site/src/styles/starlight/05-docs-surfaces.css
+++ b/site/src/styles/starlight/05-docs-surfaces.css
@@ -80,14 +80,7 @@ site-search dialog .dialog-frame {
   border-color: rgba(140, 149, 166, 0.25);
   background: var(--sl-color-bg-inline-code);
 
-}
-
-html[data-theme='light'] .sl-markdown-content :not(pre) > code {
-
-  color: #243044;
-}
-
-.sl-markdown-content .expressive-code {
+}.sl-markdown-content .expressive-code {
   --ec-brdCol: rgba(140, 149, 166, 0.24);
   --ec-codeBg: #171c23;
   --ec-codeFg: #d7dce5;
@@ -104,7 +97,7 @@ html[data-theme='light'] .sl-markdown-content :not(pre) > code {
 
 .sl-markdown-content .expressive-code .frame {
 
-  border-color: rgba(140, 149, 166, 0.22);
+
   box-shadow:
     0 16px 36px rgba(0, 0, 0, 0.3),
     inset 0 1px 0 rgba(255, 255, 255, 0.035);
@@ -119,14 +112,9 @@ html[data-theme='light'] .sl-markdown-content :not(pre) > code {
   border-top: var(--ec-brdWd) solid var(--ec-brdCol) !important;
   border-top-left-radius: calc(var(--ec-brdRad) + var(--ec-brdWd)) !important;
   border-top-right-radius: calc(var(--ec-brdRad) + var(--ec-brdWd)) !important;
-}.sl-markdown-content .expressive-code .copy {
+}.sl-markdown-content .expressive-code .copy button {
 
-  inset-inline-end: calc(var(--ec-brdWd) + 0.55rem) !important;
-}
 
-.sl-markdown-content .expressive-code .copy button {
-
-  height: 2rem;
   background: #202631;
   border-radius: 4px;
   opacity: 0.92;

--- a/site/src/styles/starlight/06-docs-interaction-a.css
+++ b/site/src/styles/starlight/06-docs-interaction-a.css
@@ -61,7 +61,7 @@
 
 #starlight__search .pagefind-ui__button {
 
-  align-items: center;
+
   justify-content: center;
   text-align: center;
 }

--- a/site/src/styles/starlight/07-docs-interaction-b.css
+++ b/site/src/styles/starlight/07-docs-interaction-b.css
@@ -154,14 +154,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
   background: #f6f8fa !important;
 }html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
   background: rgba(0, 122, 84, 0.42);
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code .copy button {
-
-  background: #eef2f4;
-}
-
-html[data-theme='light'] .sl-markdown-content :not(pre) > code {
+}html[data-theme='light'] .sl-markdown-content :not(pre) > code {
   border-color: rgba(17, 24, 39, 0.16);
   background: #eef2f4;
 

--- a/site/src/styles/starlight/08-search-modal.css
+++ b/site/src/styles/starlight/08-search-modal.css
@@ -34,14 +34,14 @@ site-search dialog .search-container {
 #starlight__search .pagefind-ui__form {
 
   inset-block-start: 0;
-  z-index: 4;
+
   flex: 0 0 auto;
   padding-block-end: 0.8rem;
   background: #252b36;
 }#starlight__search .pagefind-ui__drawer {
   min-height: 0;
 
-  overflow-y: auto;
+
   overscroll-behavior: contain;
   padding-inline-end: 0.2rem;
   position: relative;
@@ -61,13 +61,13 @@ site-search dialog .search-container {
 #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__result)::before {
   top: 0;
 
-  background: linear-gradient(180deg, rgba(8, 12, 18, 0.14), rgba(8, 12, 18, 0));
+
 }
 
 #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__result)::after {
   bottom: 0;
 
-  background: linear-gradient(0deg, rgba(8, 12, 18, 0.12), rgba(8, 12, 18, 0));
+
 }
 
 #starlight__search .pagefind-ui__results-area {

--- a/site/src/styles/starlight/10-docs-feedback.css
+++ b/site/src/styles/starlight/10-docs-feedback.css
@@ -30,7 +30,7 @@
 
 #starlight__search .pagefind-ui__button {
 
-  justify-content: center !important;
+
   text-align: center !important;
 }
 
@@ -38,11 +38,6 @@
   --ec-codePadBlk: 0.62rem;
   --netscli-code-copy-inset: 0.48rem;
   margin-block: 0.9rem 1.2rem;
-}
-
-.sl-markdown-content .expressive-code .copy button[data-copied] {
-
-  color: var(--netscli-accent-high) !important;
 }html[data-theme='light'] #starlight__search .pagefind-ui__search-input {
   background: #ffffff !important;
   box-shadow: none !important;
@@ -50,6 +45,6 @@
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy button[data-copied] {
 
-  background: #e5f3ef !important;
+
   color: #0b4a1f !important;
 }

--- a/site/src/styles/starlight/12-docs-toc-responsive.css
+++ b/site/src/styles/starlight/12-docs-toc-responsive.css
@@ -5,7 +5,7 @@
     --sl-mobile-toc-height: 3rem;
   }.right-sidebar {
 
-    width: 100% !important;
+
     height: auto !important;
     padding: 0 !important;
     overflow: visible !important;
@@ -20,12 +20,12 @@
     border-top: 0 !important;
     border-bottom: 1px solid var(--sl-color-hairline-light) !important;
 
-    box-shadow: none !important;
+
   }
 
   mobile-starlight-toc summary {
 
-    padding-block: 0.45rem !important;
+
     padding-inline: clamp(1rem, 4vw, 1.5rem) !important;
     border-bottom: 0 !important;
     gap: 0.75rem !important;
@@ -34,34 +34,25 @@
   mobile-starlight-toc .toggle {
 
     gap: 0.65rem !important;
-    border: 1px solid rgba(140, 149, 166, 0.22) !important;
+
     border-radius: 6px !important;
     background: rgba(255, 255, 255, 0.035) !important;
     color: var(--sl-color-gray-1) !important;
     font-weight: 720 !important;
-  }
-
-  mobile-starlight-toc details[open] .toggle,
-  mobile-starlight-toc details .toggle:hover,
-  mobile-starlight-toc summary:focus-visible .toggle {
-
-    color: var(--sl-color-white) !important;
-  }
-
-  mobile-starlight-toc .caret {
+  }mobile-starlight-toc .caret {
     color: var(--netscli-accent);
   }
 
   mobile-starlight-toc .display-current {
     min-width: 0;
 
-    font-size: 0.82rem !important;
+
   }
 
   mobile-starlight-toc .dropdown {
 
     border-color: var(--sl-color-hairline-light) !important;
-    border-inline: 0 !important;
+
     background: #171b22 !important;
     box-shadow: 0 18px 46px rgba(0, 0, 0, 0.34) !important;
   }mobile-starlight-toc .dropdown a:hover,
@@ -139,14 +130,7 @@ html[data-theme='light'] mobile-starlight-toc .caret {
 
 html[data-theme='light'] mobile-starlight-toc .display-current {
   color: #44516a !important;
-}
-
-html[data-theme='light'] mobile-starlight-toc .dropdown {
-
-  box-shadow: 0 18px 42px rgba(17, 24, 39, 0.14) !important;
-}
-
-.sl-markdown-content .expressive-code .copy .feedback {
+}.sl-markdown-content .expressive-code .copy .feedback {
   position: absolute !important;
   width: 1px !important;
   height: 1px !important;

--- a/site/src/styles/starlight/14-docs-nav-table.css
+++ b/site/src/styles/starlight/14-docs-nav-table.css
@@ -3,14 +3,7 @@
 .sidebar-content {
   --netscli-sidebar-rail-inset: clamp(2.2rem, 3vw, 3.15rem);
   padding-inline-start: var(--netscli-sidebar-rail-inset) !important;
-}
-
-.sidebar-content :where(details > ul) {
-
-  border-inline-start: 1px solid var(--sl-color-hairline) !important;
-}
-
-.sidebar-content :where(a[aria-current='page']) {
+}.sidebar-content :where(a[aria-current='page']) {
   position: relative;
   box-shadow: none !important;
 }
@@ -22,7 +15,7 @@
 @media (max-width: 71.99rem) {
   .right-sidebar-container {
 
-    width: 100% !important;
+
     flex: 0 0 100% !important;
     order: -1;
     background: var(--sl-color-bg);
@@ -38,7 +31,7 @@
 
   .right-sidebar {
 
-    width: 100% !important;
+
     height: auto !important;
     padding: 0 !important;
     overflow: visible !important;
@@ -117,7 +110,7 @@
   mobile-starlight-toc .dropdown a:hover,
   mobile-starlight-toc .dropdown a:focus-visible {
 
-    background: rgba(255, 255, 255, 0.045) !important;
+
     outline: 0 !important;
   }
 

--- a/site/src/styles/starlight/16-shell-interaction-closeout.css
+++ b/site/src/styles/starlight/16-shell-interaction-closeout.css
@@ -2,16 +2,9 @@
    sit last because Starlight and earlier feedback passes both style these
    same surfaces. */
 .sidebar-content :where(details > ul) {
-  margin-inline-start: 0.75rem !important;
+
   border-inline-start: 1px solid var(--sl-color-hairline) !important;
-}
-
-.sidebar-content :where(details > ul > li) {
-
-  border-inline-start: 0 !important;
-}
-
-/* This selector outranks every `:where(details > ul a)` rule in the later
+}/* This selector outranks every `:where(details > ul a)` rule in the later
    files -- `:where()` contributes no specificity, so those lose to a plain
    `.sidebar-content a[aria-current='page']` even when they load afterwards.
    The alignment therefore has to be set here, or it silently does nothing.
@@ -83,7 +76,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-u
 .pagination-links a:hover,
 .pagination-links a:focus-visible {
 
-  border-color: rgba(var(--netscli-accent-rgb), 0.36) !important;
+
   color: var(--sl-color-white) !important;
   outline: 0 !important;
 }
@@ -91,7 +84,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-u
 html[data-theme='light'] .pagination-links a:hover,
 html[data-theme='light'] .pagination-links a:focus-visible {
 
-  border-color: rgba(0, 122, 84, 0.28) !important;
+
   color: #111827 !important;
 }
 

--- a/site/src/styles/starlight/17-mobile-shell-closeout-a.css
+++ b/site/src/styles/starlight/17-mobile-shell-closeout-a.css
@@ -11,7 +11,7 @@
 
   .docs-topbar {
 
-    max-width: calc(100vw - 4.5rem) !important;
+
     margin-inline: 0 !important;
     padding-inline-start: max(0.65rem, env(safe-area-inset-left)) !important;
     padding-inline-end: max(0.5rem, env(safe-area-inset-right)) !important;
@@ -22,7 +22,7 @@
 
   .docs-header-search {
 
-    flex: 0 0 2.5rem !important;
+
     width: 2.5rem !important;
     max-width: 2.5rem !important;
     min-width: 2.5rem !important;
@@ -45,11 +45,7 @@
     inset-block-start: var(--sl-nav-height) !important;
   }}
 
-@media (min-width: 50rem) {
-  .docs-mobile-section-nav {
-    display: none !important;
-  }
-}
+@media (min-width: 50rem) {}
 
 @media (max-width: 71.99rem) {
   :root {

--- a/site/src/styles/starlight/18-mobile-shell-closeout-b.css
+++ b/site/src/styles/starlight/18-mobile-shell-closeout-b.css
@@ -141,7 +141,7 @@
 @media (max-width: 49.99rem) {
   .docs-mobile-section-nav {
 
-    inset-inline: 0 !important;
+
     top: var(--sl-nav-height) !important;
   }mobile-starlight-toc nav {
     position: fixed !important;

--- a/site/src/styles/starlight/19-markdown-tables.css
+++ b/site/src/styles/starlight/19-markdown-tables.css
@@ -61,7 +61,7 @@ html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
 @media (max-width: 49.99rem) {
   .sl-markdown-content .netscli-table-scroll {
 
-    overflow-x: hidden !important;
+
     overflow-y: hidden !important;
     border: 0 !important;
     border-radius: 8px !important;
@@ -70,7 +70,7 @@ html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
 
   .sl-markdown-content .netscli-table-scroll table {
 
-    min-width: 0 !important;
+
     width: 100% !important;
     table-layout: auto !important;
     border: 0 !important;
@@ -83,7 +83,7 @@ html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
   .sl-markdown-content .netscli-table-scroll tr {
 
     gap: 0.75rem !important;
-    padding: 0.95rem 1rem !important;
+
     border: 1px solid rgba(140, 149, 166, 0.2) !important;
     border-radius: 8px !important;
     background: #252b34 !important;
@@ -92,7 +92,7 @@ html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
   .sl-markdown-content .netscli-table-scroll th,
   .sl-markdown-content .netscli-table-scroll td {
 
-    width: 100% !important;
+
     padding: 0 !important;
     border: 0 !important;
     line-height: 1.42 !important;
@@ -102,7 +102,7 @@ html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
 
   .sl-markdown-content .netscli-table-scroll td::before {
 
-    display: block;
+
     margin-bottom: 0.32rem;
     color: var(--sl-color-gray-3);
     font-size: 0.72rem;

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -41,21 +41,14 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='true']),
 html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='page']),
 html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location']) {
   color: #0e7a33 !important;
-}
-
-.sidebar-content :where(details > ul > li) {
-
-  border-inline-start: 0 !important;
-}
-
-/* Every link's border track sits on the rail, and the active one lights up.
+}/* Every link's border track sits on the rail, and the active one lights up.
    The rail is the <ul>'s inline-start border; the list item adds 0.5rem of
    inline padding, so a border on the link landed 7.8px inside the rail --
    the highlight floated in the gap instead of marking the rail. Pulling the
    link back by that padding plus the rail's own width puts the two in the
    same place, and the matching padding increase keeps the text still. */
 .sidebar-content :where(details > ul a) {
-  margin-inline-start: calc(-0.5rem - 1px) !important;
+
   width: calc(100% + 0.5rem + 1px) !important;
   padding-inline-start: calc(.85rem + 0.5rem + 1px) !important;
   border-inline-start: 1px solid transparent !important;
@@ -75,7 +68,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 
   .docs-topbar {
 
-    max-width: calc(100vw - 4.15rem) !important;
+
     gap: 0.45rem !important;
   }
 
@@ -86,7 +79,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
     max-width: 2.5rem !important;
     min-width: 2.5rem !important;
 
-    margin-right: 0.15rem !important;
+
   }
 
   .docs-header-search site-search,
@@ -196,7 +189,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 @media (max-width: 49.99rem) {
   .right-sidebar-container {
 
-    min-height: 0 !important;
+
     margin: 0 !important;
     padding: 0 !important;
     border: 0 !important;
@@ -245,7 +238,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 
   site-search dialog {
 
-    max-width: calc(100vw - 1rem) !important;
+
     min-height: min(100dvh - 1rem, 44rem) !important;
     margin: 0.5rem auto !important;
     border-radius: 8px !important;
@@ -253,7 +246,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 
   site-search dialog .dialog-frame {
 
-    grid-template-columns: minmax(0, 1fr) auto !important;
+
     align-items: center !important;
     align-content: start !important;
     gap: 0.75rem !important;
@@ -262,17 +255,9 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 
   site-search dialog .dialog-frame > * {
     align-self: start !important;
-  }
+  }site-search button[data-close-modal] {
 
-  site-search dialog .search-container,
-  #starlight__search {
 
-    min-width: 0 !important;
-  }
-
-  site-search button[data-close-modal] {
-
-    grid-row: 1 !important;
     align-self: start !important;
   }
 }

--- a/site/src/styles/starlight/21-mobile-docs-shell-verified.css
+++ b/site/src/styles/starlight/21-mobile-docs-shell-verified.css
@@ -6,13 +6,13 @@
 }
 
 .sidebar-content :where(details > ul > li) {
-  margin-inline-start: 0 !important;
+
   border-inline-start: 0 !important;
 }
 
 .sidebar-content :where(details > ul a) {
 
-  width: calc(100% + 1px) !important;
+
   padding-inline-start: 0.75rem !important;
   border-inline-start: 2px solid transparent !important;
 }

--- a/site/src/styles/starlight/22-mobile-docs-correction.css
+++ b/site/src/styles/starlight/22-mobile-docs-correction.css
@@ -132,13 +132,13 @@
   }site-search dialog .search-container,
   #starlight__search {
 
-    grid-row: 1 !important;
+
     min-width: 0 !important;
   }
 
   site-search button[data-close-modal] {
 
-    grid-row: 1 !important;
+
     align-self: center !important;
   }}
 

--- a/site/src/styles/starlight/23-regression-guardrails.css
+++ b/site/src/styles/starlight/23-regression-guardrails.css
@@ -5,7 +5,7 @@
 }
 
 .sidebar-content :where(details > ul a) {
-  margin-inline-start: -1px !important;
+
   width: calc(100% + 1px) !important;
   padding-inline-start: 0.75rem !important;
   border-inline-start: 2px solid transparent !important;
@@ -35,7 +35,7 @@
     margin-right: 3rem !important;
     flex: 0 0 2.75rem !important;
 
-    max-width: 2.75rem !important;
+
     min-width: 2.75rem !important;
   }
 
@@ -50,13 +50,13 @@
   site-search dialog {
 
     max-width: calc(100vw - 1rem) !important;
-    min-height: auto !important;
+
     margin: 0.5rem auto !important;
   }
 
   site-search dialog .dialog-frame {
 
-    grid-template-columns: minmax(0, 1fr) auto !important;
+
     gap: 0.85rem !important;
     padding: 1rem !important;
     align-items: start !important;

--- a/site/src/styles/starlight/24-mobile-regression-guardrails.css
+++ b/site/src/styles/starlight/24-mobile-regression-guardrails.css
@@ -28,43 +28,12 @@
 
   .docs-header-search {
     margin-inline-end: .35rem !important;
-  }  
-
-  /* Not the section menu.
-     PageSidebar renders the mobile section dropdown inside .right-sidebar, so
-     this rule -- written to flatten the ToC rail -- also stripped the marker
-     off the current page in that menu. Every other entry there reserves 2px
-     for a border, so the one item that should have been marked was the only
-     one with no border at all. */
-  .right-sidebar
-    :where(a:hover, a[aria-current="true"], a[aria-current="page"]):not(
-      .docs-mobile-section-menu a,
-      mobile-starlight-toc .dropdown a
-    ) {
-    background: transparent !important;
-
-  }
-
-  .content-panel table,
+  }.content-panel table,
   .sl-markdown-content table {
 
-    width: max-content !important;
+
     min-width: 100% !important;
-  }.content-panel th,
-  .content-panel td,
-  .sl-markdown-content th,
-  .sl-markdown-content td {
-
-    white-space: normal !important;
-  }
-
-  .content-panel td::before,
-  .sl-markdown-content td::before {
-
-    display: none !important;
-  }
-
-  .content-panel thead th,
+  }.content-panel thead th,
   .sl-markdown-content thead th {
     font-weight: 700 !important;
   }
@@ -78,14 +47,14 @@
 
   site-search dialog {
 
-    max-height: calc(100dvh - 1rem) !important;
+
     min-height: auto !important;
     overflow: auto !important;
   }
 
   site-search dialog .dialog-frame {
 
-    grid-template-columns: minmax(0, 1fr) auto !important;
+
     grid-template-areas:
       "search close"
       "drawer drawer" !important;
@@ -115,13 +84,7 @@
 
   site-search dialog .pagefind-ui__drawer {
 
-    width: 100% !important;
+
     max-width: none !important;
     min-height: 9rem !important;
-  }
-
-  site-search dialog .pagefind-ui__search-input {
-    width: 100% !important;
-
-  }
-}
+  }}

--- a/site/src/styles/starlight/25-mobile-overrides-final.css
+++ b/site/src/styles/starlight/25-mobile-overrides-final.css
@@ -31,7 +31,7 @@
   .content-panel > .sl-container,
   .sl-markdown-content {
 
-    max-width: 100% !important;
+
     min-width: 0 !important;
     box-sizing: border-box !important;
     overflow-wrap: anywhere;
@@ -55,18 +55,12 @@
 
   .content-panel > .sl-container {
 
-    max-width: 100vw !important;
+
     margin-inline: 0 !important;
     padding-inline: clamp(1rem, 5vw, 1.5rem) !important;
-  }
+  }starlight-menu-button {
 
-  .sl-markdown-content > * {
-    max-width: 100% !important;
-  }
 
-  starlight-menu-button {
-
-    position: fixed !important;
     inset-block-start: .625rem !important;
     inset-inline-end: .75rem !important;
     z-index: calc(var(--sl-z-index-navbar) + 2) !important;
@@ -74,14 +68,14 @@
 
   starlight-menu-button button {
 
-    inset: auto !important;
+
     width: 2.5rem !important;
     height: 2.5rem !important;
   }
 
   .docs-header-search {
 
-    inset-block-start: .625rem !important;
+
     inset-inline-end: 3.75rem !important;
     z-index: calc(var(--sl-z-index-navbar) + 2) !important;
     width: 2.5rem !important;
@@ -92,7 +86,7 @@
   .sl-markdown-content .netscli-table-scroll,
   .content-panel .netscli-table-scroll {
 
-    width: 100% !important;
+
     max-width: 100% !important;
     overflow-x: auto !important;
     overflow-y: hidden !important;
@@ -103,7 +97,7 @@
   .content-panel .netscli-table-scroll table {
     display: table !important;
 
-    min-width: 42rem !important;
+
     max-width: none !important;
     table-layout: fixed !important;
   }


### PR DESCRIPTION
Everything still outstanding from the audit that I can act on without publishing something.

## Release prep (you tag it, I do not)

The changelog claimed 0.3.0 shipped on 2026-06-26. It never shipped, and **68 commits landed since that date with an empty `[Unreleased]` section above them** — the MCP concurrency fix, the engine-level safety limits, the ARP blocking fix, the GUI correctness work and the whole website rebuild were recorded nowhere. Re-dated and written up. All seven version files and the inter-crate dep specs already agree on 0.3.0, so the bump itself was complete; only the tag is missing.

**Correction to something I told you earlier:** `scoop install netscli` does *not* 404. The bucket and tap serve 0.2.6 with valid URLs and matching hashes — I verified against the live manifests. The files in `packaging/` are templates the publish scripts rewrite from the real release; they never reach users. They now say so, and the Homebrew headers no longer give hand-editing steps for work the publish job does.

## Findings closed

| ID | What |
|---|---|
| B-05 | MSI fetched and executed an installer over the network at install time, elevated, unpinned — Tauri's `downloadBootstrapper` default. Now `embedBootstrapper`; `offlineInstaller` costs ~130 MB and is noted as the Store-only trade. |
| B-35 | Dependabot now covers `/site`. |
| B-39 | Security review states what it has never covered (workflows, release scripts, packaging, installer templates), with a re-verify date and cadence. That gap produced B-05. |
| C-14 | `formatNumber` existed three times character-for-character; one copy now. |
| C-15 | mDNS browse window had a default and no field, reaching the backend unclamped. Field added, bounded 500–30000ms. |
| C-25 | Release drafter ran on every PR event holding `contents: write` doing nothing — that produced the duplicate v0.2.7 drafts. Push-to-main only. |
| M-4 | Free-text fields were gated on presence alone; `ports: "hello"` reached the backend. Now shape-checked, mirroring the core parsers rather than being stricter. Two of the new tests fail against the old check. |
| M-14 | Two assertions pinned exact pixel strings. Both now measure the property they were written to check. The others the audit grouped here are already tolerances and were left. |
| C-11 | **Needed nothing** — a later refactor already routes every external URL through a validating allowlist, and the cited files are gone. |

## Also

Dead CSS pruned 210 → 126 (the ratchet had zero headroom); every measurement taken before the prune comes back identical after it. `menu.mjs` split at the guard's own request, so its transition exception is deleted rather than raised.

Local gate: `cargo fmt`, `clippy -D warnings`, `cargo test --all`, 117 unit tests, file-size guard, dead-CSS budget, `astro check`, a11y in both themes.