### PR TITLE
Stop the changelog linking to a tag that does not exist

### DIFF
--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -148,6 +148,20 @@ const fallbackReleases = parseLocalChangelog(changelogText);
   align-items:start;
 }
 .release-list{display:grid;gap:18px;padding:0}
+/* Shown instead of a tag link when GitHub has no release under that tag. */
+.release-unreleased{
+  margin-left:10px;
+  padding:2px 8px;
+  border:1px solid rgba(var(--netscli-accent-rgb),.32);
+  border-radius:999px;
+  background:rgba(var(--netscli-accent-rgb),.06);
+  color:var(--netscli-accent);
+  font-size:.6875rem;
+  font-weight:600;
+  letter-spacing:.02em;
+  vertical-align:middle;
+  white-space:nowrap;
+}
 .release-timeline{
   position:sticky;
   top:calc(var(--nav-height, 72px) + 22px);

--- a/site/src/scripts/changelog-page.ts
+++ b/site/src/scripts/changelog-page.ts
@@ -16,7 +16,13 @@ export function initChangelogPage(
     fallbackReleases.map((release) => [normalizeTag(release.tag_name || release.name), release])
   );
 
-  const renderedFallback = renderReleaseList(fallbackReleases, repo, fallbackByTag, releaseSummaries);
+  // Nothing is linked to a tag until GitHub confirms that tag exists. The
+  // first paint happens before the fetch resolves, and if the fetch fails it
+  // is the only paint -- linking optimistically is how the v0.3.0 card ended
+  // up pointing at a 404 for weeks. Same rule as the version in the hero:
+  // assert it once it is confirmed, not before.
+  const asUnreleased = fallbackReleases.map((release) => ({ ...release, unreleased: true }));
+  const renderedFallback = renderReleaseList(asUnreleased, repo, fallbackByTag, releaseSummaries);
 
   fetch(`https://api.github.com/repos/${repo}/releases?per_page=8`)
     .then((response) => {
@@ -25,9 +31,10 @@ export function initChangelogPage(
     })
     .then((releases: ChangelogRelease[]) => {
       const remoteTags = new Set(releases.map((release) => normalizeTag(release.tag_name || release.name)));
-      const localOnlyReleases = fallbackReleases.filter(
-        (release) => !remoteTags.has(normalizeTag(release.tag_name || release.name))
-      );
+      // A changelog entry with no release behind it stays unlinked.
+      const localOnlyReleases = fallbackReleases
+        .filter((release) => !remoteTags.has(normalizeTag(release.tag_name || release.name)))
+        .map((release) => ({ ...release, unreleased: true, confirmedUnreleased: true }));
       renderReleaseList([...localOnlyReleases, ...releases], repo, fallbackByTag, releaseSummaries);
     })
     .catch(() => {

--- a/site/src/scripts/changelog/release-list.ts
+++ b/site/src/scripts/changelog/release-list.ts
@@ -83,9 +83,23 @@ export function renderReleaseList(
     const header = el('div', 'release-head');
     const headingGroup = el('div', 'release-title-group');
     const heading = document.createElement('h2');
-    const releaseUrl = release.html_url || `https://github.com/${repo}/releases`;
-    const link = externalLink(releaseUrl, release.name || release.tag_name || 'Release');
-    heading.appendChild(link);
+    const label = release.name || release.tag_name || 'Release';
+    if (release.unreleased) {
+      // No link. Nothing has confirmed the tag exists, and `html_url` would
+      // point at a GitHub 404 if it does not -- which is what the v0.3.0 card
+      // did while the version was bumped in the repo but never tagged.
+      heading.appendChild(document.createTextNode(label));
+      // Labelled only once GitHub has answered. Before that we do not know it
+      // is unreleased, only that we have not confirmed it is released.
+      if (release.confirmedUnreleased) {
+        const pending = el('span', 'release-unreleased');
+        pending.textContent = 'Not yet released';
+        heading.appendChild(pending);
+      }
+    } else {
+      const releaseUrl = release.html_url || `https://github.com/${repo}/releases`;
+      heading.appendChild(externalLink(releaseUrl, label));
+    }
 
     const meta = document.createElement('p');
     meta.className = 'release-meta';

--- a/site/src/scripts/changelog/types.ts
+++ b/site/src/scripts/changelog/types.ts
@@ -2,6 +2,14 @@
  *  CHANGELOG.md-derived fallback releases — a loose subset since either
  *  source may omit fields the other provides (mergeRelease reconciles them). */
 export interface ChangelogRelease {
+  /** Set when nothing has confirmed a release exists under this tag, so its
+   *  `html_url` may 404. Such an entry is never linked. */
+  unreleased?: boolean;
+  /** Set only once GitHub has answered and had no release under this tag --
+   *  i.e. we know it is unreleased rather than merely not knowing yet. Only
+   *  then is it labelled, so a real release is not mislabelled while the
+   *  first paint waits for the fetch. */
+  confirmedUnreleased?: boolean;
   name?: string;
   tag_name?: string;
   html_url?: string;


### PR DESCRIPTION
The newest changelog entry linked to `/releases/tag/v0.3.0`, which returns **404** — the version is bumped across the repo but has not been tagged. Clicking the top release on the changelog page landed on a GitHub error. Confirmed both: that tag 404s, v0.2.6 returns 200.

Nothing is linked to a tag until GitHub confirms it exists. The first paint happens before the fetch resolves, and if the fetch fails it is the *only* paint — linking optimistically is what put a dead link on the public page for weeks. Same rule the hero version now follows.

Two separate flags, because collapsing them mislabels real releases:

- `unreleased` — nothing has confirmed a release under this tag, so don't link it. True of every entry on the first paint.
- `confirmedUnreleased` — GitHub answered and had no release under this tag, so we *know*. Only this draws the "Not yet released" badge.

I had them collapsed at first and caught it in review: v0.2.6 wore the badge until the fetch came back.

Verified on the preview: v0.3.0 renders unlinked and badged, v0.2.6 and below keep their tag links, and no anchor on the page has an href ending in v0.3.0. The badge disappears on its own once the tag exists — no follow-up needed when you cut the release.

`astro check` clean, a11y clean in both themes, dead-CSS budget holds at 126.