### PR TITLE
Give docs pages a share image, and add /llms.txt

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -12,13 +12,30 @@ export default defineConfig({
       // src/layouts/Page.astro, so the noindex that layout emits for a
       // preview build does not reach them. Inject it here too, or a
       // preview deploy leaves 11 of 14 pages crawlable.
-      head:
-        process.env.NETSCLI_PREVIEW === '1'
+      head: [
+        // Starlight emits `twitter:card: summary_large_image` on every docs
+        // page but supplies no image, so sharing a docs link produced a card
+        // that declared a large image and had none. The landing page and the
+        // changelog set theirs in Page.astro; these are the same asset.
+        { tag: 'meta', attrs: { property: 'og:image', content: 'https://netscli.com/assets/tui-discover.png' } },
+        { tag: 'meta', attrs: { name: 'twitter:image', content: 'https://netscli.com/assets/tui-discover.png' } },
+        {
+          tag: 'meta',
+          attrs: {
+            name: 'twitter:image:alt',
+            content: 'netscli terminal UI running /discover with sanitized lab hostnames, vendors, and response times',
+          },
+        },
+        ...(process.env.NETSCLI_PREVIEW === '1'
           ? [{ tag: 'meta', attrs: { name: 'robots', content: 'noindex, nofollow' } }]
-          : [],
+          : []),
+      ],
       title: 'NetsCLI docs',
+      // "network scanner", not "network scanner and diagnostics toolkit" --
+      // one name for the product, matching the title, H1 and description on
+      // the landing page.
       description:
-        'Technical documentation for NetsCLI, a Rust-based network scanner and diagnostics toolkit with a desktop app, terminal UI, CLI, MCP server, and shared core library.',
+        'Technical documentation for NetsCLI, a Rust-based network scanner with a desktop app, terminal UI, CLI, MCP server, and shared core library.',
       disable404Route: true,
       logo: {
         src: './public/assets/netscli-wordmark.png',

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -6,3 +6,9 @@ Allow: /
 # to ship alongside it with all 13 lastmod values frozen at 2026-07-02, and
 # this file pointed at that stale copy rather than the generated one (B-24).
 Sitemap: https://netscli.com/sitemap-index.xml
+
+# A curated map of this site for answer engines, generated from the same
+# content the pages render (src/pages/llms.txt.ts) so it cannot drift from
+# them. Not a standard robots.txt directive -- a discovery hint, since the
+# convention has no other advertised location.
+# llms.txt: https://netscli.com/llms.txt

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -54,8 +54,18 @@ const onHome = pathname === '/';
 </script>
 
 <style is:global>
-/* nav */
-nav{
+/* nav
+ *
+ * Every rule here is scoped to `nav[data-site-nav]`, the one element this
+ * component renders. They used to select the bare `nav` element, and these
+ * styles are `is:global` -- so the whole top-bar treatment landed on any
+ * other <nav> on the page. The changelog's release timeline is a <nav>, and
+ * it was picking up `position:sticky; top:0`, the translucent bar
+ * background, the green bottom border, a 12px backdrop blur and the
+ * scrolled drop shadow, which is what made a sticky sidebar look like a
+ * floating toolbar.
+ */
+nav[data-site-nav]{
   position:sticky;top:0;z-index:10;
   /* Border-box, so this is the whole bar including its border -- the docs
      header sets the same value the same way. Sizing it from the inner box
@@ -68,15 +78,15 @@ nav{
   transition:box-shadow 160ms ease,border-color 160ms ease;
 }
 
-body:not(.nav-scrolled) nav{
+body:not(.nav-scrolled) nav[data-site-nav]{
   box-shadow:none !important;
 }
 
-body:not(.nav-scrolled) nav::after{
+body:not(.nav-scrolled) nav[data-site-nav]::after{
   opacity:0 !important;
 }
 
-nav::after{
+nav[data-site-nav]::after{
   content:"";
   position:absolute;
   left:0;right:0;bottom:-22px;
@@ -86,13 +96,13 @@ nav::after{
   background:linear-gradient(180deg,rgba(0,0,0,.42),rgba(0,0,0,0));
   transition:opacity 160ms ease;
 }
-body.nav-scrolled nav{
+body.nav-scrolled nav[data-site-nav]{
   border-bottom-color:rgba(var(--netscli-accent-rgb),.12);
   box-shadow:
     0 12px 28px rgba(0,0,0,.28),
     0 1px 0 rgba(var(--netscli-accent-rgb),.08) !important;
 }
-body.nav-scrolled nav::after{
+body.nav-scrolled nav[data-site-nav]::after{
   opacity:1;
 }
 .nav-inner{

--- a/site/src/content/docs/docs/index.md
+++ b/site/src/content/docs/docs/index.md
@@ -3,7 +3,7 @@ title: Overview
 description: NetsCLI documentation for the shared Rust core, CLI, TUI, desktop app, and MCP server.
 ---
 
-NetsCLI is a cross-platform network diagnostics toolkit written in Rust. It is built around one shared core library and several interfaces: a desktop app, terminal UI, command-line interface, and MCP server.
+NetsCLI is a cross-platform network scanner written in Rust. It is built around one shared core library and several interfaces: a desktop app, terminal UI, command-line interface, and MCP server.
 
 The goal is consistency. A port scan, DNS lookup, host inspection, or ARP cache read means the same thing whether you run it from the desktop app, a shell script, the TUI, or an AI agent.
 

--- a/site/src/data/site-content/faq.ts
+++ b/site/src/data/site-content/faq.ts
@@ -14,9 +14,9 @@ export const faq: FaqItem[] = [
   {
     group: 'What it is',
     q: 'What is NetsCLI?',
-    a: 'NetsCLI is an open-source network scanner and diagnostics toolkit written in Rust. It discovers hosts on a subnet, scans TCP ports, queries DNS, traces routes, reads local interfaces and the ARP neighbor cache, and can capture packets when packet-capture support and the required system library are available. You can use it from the desktop app, terminal UI, CLI, or Model Context Protocol (MCP) server.',
+    a: 'NetsCLI is an open-source network scanner written in Rust. It discovers hosts on a subnet, scans TCP ports, queries DNS, traces routes, reads local interfaces and the ARP neighbor cache, and can capture packets when packet-capture support and the required system library are available. You can use it from the desktop app, terminal UI, CLI, or Model Context Protocol (MCP) server.',
     aHtml:
-      'NetsCLI is an open-source network scanner and diagnostics toolkit written in Rust. It discovers hosts on a subnet, scans TCP ports, queries DNS, traces routes, reads local interfaces and the ARP neighbor cache, and can capture packets when packet-capture support and the required system library are available. You can use it from the desktop app, <a href="#surfaces">terminal UI</a>, CLI, or Model Context Protocol (MCP) server.',
+      'NetsCLI is an open-source network scanner written in Rust. It discovers hosts on a subnet, scans TCP ports, queries DNS, traces routes, reads local interfaces and the ARP neighbor cache, and can capture packets when packet-capture support and the required system library are available. You can use it from the desktop app, <a href="#surfaces">terminal UI</a>, CLI, or Model Context Protocol (MCP) server.',
   },
   {
     group: 'Install and updates',

--- a/site/src/data/site-content/surfaces.ts
+++ b/site/src/data/site-content/surfaces.ts
@@ -3,14 +3,14 @@ import type { SectionCopy, SurfaceCard } from './types';
 export const surfacesCopy: SectionCopy = {
   heading: 'Choose how to work with your network',
   leadHtml:
-    'Use the desktop app for review, the terminal UI for live sessions, the CLI for scripts, and MCP for agent workflows. They all call the same Rust core, so results stay consistent no matter which interface you choose. <a href="/docs/">Full docs →</a>',
+    'Four ways in, one engine behind them. Whichever you pick — desktop app, terminal UI, CLI or MCP — a port scan means the same thing and returns the same answer. <a href="/docs/">Full docs →</a>',
 };
 
 export const surfaces: SurfaceCard[] = [
   {
     title: 'Desktop app',
     body:
-      'Use the desktop app when you want tabs, sortable tables, filters, row details, history, and exports. It is the best interface for comparing results across scans, discovery, DNS, route checks, local inventory, and packet capture in builds that include packet-capture support.',
+      'The desktop app is where you compare results side by side. Tabs keep several investigations open at once, and every result is sortable, filterable, and exportable, with the full history kept as you go.',
     image: {
       src: '/gui-scan.png',
       webp: '/gui-scan.webp',
@@ -23,7 +23,7 @@ export const surfaces: SurfaceCard[] = [
   {
     title: 'Terminal UI',
     body:
-      'Run <code>netscli</code> with no subcommand to start the terminal UI. Use it when you want an interactive session without leaving the terminal, with command history, autocomplete, readable status colors, and local interface activity close to the current investigation.',
+      'Run <code>netscli</code> with no subcommand to start the terminal UI. It is the one to reach for when you are already in a shell and want to stay there — history and autocomplete included, with local interface activity beside the results.',
     image: {
       src: '/assets/tui-discover.png',
       webp: '/assets/tui-discover.webp',
@@ -52,7 +52,7 @@ export const surfaces: SurfaceCard[] = [
   {
     title: 'MCP server',
     body:
-      'Run <code>netscli serve</code> when an MCP client needs local network tools. The server exposes structured operations for discovery, scanning, ping, DNS, ARP, inspect, sweep, interfaces, and mDNS, with packet-capture tools available in packet-capture builds.',
+      'Run <code>netscli serve</code> when an MCP client needs local network tools. Every operation the CLI has is exposed as a structured tool, so an agent gets the same discovery, scanning and DNS results you would, in a shape it can parse.',
     codeHtml: `<span style="color:#888">// claude_desktop_config.json</span>
 <span style="color:#7b7b7b">{</span>
   <span style="color:#7c9fc7">"mcpServers"</span>: <span style="color:#7b7b7b">{</span>

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -11,23 +11,23 @@ const description = 'Versioned release notes for shipped NetsCLI changes, fixes,
 
 const releaseSummaries: Record<string, string> = {
   'v0.3.0':
-    'This release ships the redesigned desktop workspace, richer scan status data, probe concurrency controls in interactive interfaces, refreshed public docs, and packaging fixes across release channels.',
+    'The desktop workspace is redesigned, scan results carry richer status data, and interactive interfaces gain probe concurrency controls. Public docs are refreshed and packaging is fixed across release channels.',
   'v0.2.6':
-    'This release fixes desktop version reporting and Windows title-bar controls, so installed GUI builds identify themselves correctly and basic window actions work as expected. It also completes CLI/TUI refactors that make future interface changes easier to review and test.',
+    'Installed GUI builds now identify themselves correctly, and the Windows title-bar controls work. Also completes the CLI/TUI refactors that make future interface changes easier to review and test.',
   'v0.2.5':
-    'This release closes a DNS resolver security advisory, fixes Windows subnet detection so discovery and sweep find real LAN hosts, resets desktop history row styling in WebView2, and extends package publishing for GUI installers.',
+    'Closes a DNS resolver security advisory. Windows subnet detection is fixed, so discovery and sweep find real LAN hosts again, and package publishing now covers GUI installers.',
   'v0.2.4':
-    'This release repairs GUI installer publishing after the previous release built packages but failed to attach them. It also updates the AUR deploy action so Linux package publishing can complete again.',
+    'v0.2.3 built the GUI installers but never attached them. Publishing is repaired here, along with the AUR deploy action that was blocking Linux packages.',
   'v0.2.3':
-    'This release gets GUI installer builds moving again by aligning the Tauri JavaScript and Rust versions, and fixes the AUR packaging handoff. CLI packages were usable from v0.2.2, but GUI artifacts needed these release-pipeline fixes.',
+    'GUI installer builds move again once the Tauri JavaScript and Rust versions agree, and the AUR packaging handoff is fixed. CLI packages were already usable from v0.2.2; the GUI artifacts needed these pipeline fixes.',
   'v0.2.2':
     'This is a release-pipeline recovery build. It refreshes Cargo.lock so locked release builds can run reproducibly after dependency bumps, giving package-manager users a working replacement for the failed v0.2.1 artifacts.',
   'v0.2.1':
-    'This release makes NetsCLI easier to install outside a Rust toolchain by publishing desktop installers and signed release assets. It also adds concurrency tuning for networks that struggle with large parallel scans.',
+    'Desktop installers and signed release assets mean you no longer need a Rust toolchain to install. Adds concurrency tuning for networks that struggle with large parallel scans.',
   'v0.2.0':
-    'This release turns the initial scanner into a more complete distribution: mDNS discovery, shell completions, man pages, package-manager templates, signed artifacts, typed core errors, and leaner optional features make NetsCLI easier to install, automate, and integrate.',
+    'Turns the initial scanner into something distributable. mDNS discovery and typed core errors on the product side; shell completions, man pages, package-manager templates and signed artifacts on the shipping side.',
   'v0.1.1':
-    'This release cleans up the first public version with crate documentation, security notes, a structured changelog, and release workflow fixes so binaries and pcap variants can be produced reliably.',
+    'Cleans up the first public version: crate documentation, security notes and a structured changelog, plus the release workflow fixes that make binaries and pcap variants reproducible.',
   'v0.1.0':
     'This is the first public NetsCLI release: one Rust core powers the CLI, terminal UI, desktop app, and MCP server, with structured output and cross-platform binaries for early users.',
 };

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -77,10 +77,9 @@ const fallbackReleases = parseLocalChangelog(changelogText);
         See what changed in each release, why it matters, and whether there
         are install, compatibility, or security notes before you update.
       </p>
-      <div class="changelog-actions">
-        <a class="external-link" href={`${hero.sourceUrl}/releases`}>GitHub releases</a>
-        <a href="/docs/">Docs</a>
-      </div>
+      <p class="changelog-actions">
+        <a class="external-link" href={`${hero.sourceUrl}/releases`}>All releases on GitHub</a>
+      </p>
     </header>
 
     <div class="changelog-content">
@@ -131,16 +130,20 @@ const fallbackReleases = parseLocalChangelog(changelogText);
 .changelog-hero p{
   margin:12px 0 0;color:#a3a3a3;font-size:.95rem;max-width:680px;
 }
+/* A text link, not a button. Two bordered pills sat under the intro as if
+   they were the page's primary actions; the only one worth keeping is a
+   pointer to the source of the notes, and the Docs link is already in the
+   top bar two lines above it. */
 .changelog-actions{
-  display:flex;gap:10px;flex-wrap:wrap;margin-top:22px;
+  margin:18px 0 0;
+  font-size:.875rem;
 }
 .changelog-actions a{
-  display:inline-flex;align-items:center;min-height:38px;padding:8px 13px;
-  border:1px solid rgba(255,255,255,.12);border-radius:8px;
-  color:#d7d7d7;text-decoration:none;font-size:.83rem;font-weight:600;
-  background:rgba(255,255,255,.035);
+  color:var(--netscli-accent);
+  text-decoration:underline;
+  text-underline-offset:3px;
 }
-.changelog-actions a:hover{border-color:rgba(var(--netscli-accent-rgb),.45);color:#1ec88c}
+.changelog-actions a:hover{color:var(--netscli-accent-bright)}
 .changelog-content{
   display:grid;
   grid-template-columns:minmax(0,1fr) 8.5rem;
@@ -287,11 +290,17 @@ const fallbackReleases = parseLocalChangelog(changelogText);
   line-height:1.65;
   padding:0;
 }
-.release-summary + .release-heading{
-  margin-top:18px;
-}
+/* Both margins, explicitly.
+ *
+ * Only `margin-top` was set, so the bottom fell through to the UA default
+ * for h5 -- 1.67em, which computes to 25.65px against this font-size. A
+ * heading therefore sat 18px below the previous list and 25px above its own,
+ * binding it to the section it had just ended instead of the one it
+ * introduces. More space above than below now, which is the relationship a
+ * section heading is supposed to have. */
 .release-body .release-heading{
-  color:#e5e5e5;font-size:.96rem;line-height:1.35;margin-top:18px;
+  color:#e5e5e5;font-size:.96rem;line-height:1.35;
+  margin:26px 0 9px;
 }
 .release-body .release-heading:first-child{margin-top:0}
 .release-paragraph{margin:0;max-width:none;min-width:0;overflow-wrap:anywhere}

--- a/site/src/pages/llms.txt.ts
+++ b/site/src/pages/llms.txt.ts
@@ -1,0 +1,78 @@
+import { getCollection } from 'astro:content';
+import { site } from '../data/site';
+
+/**
+ * /llms.txt — a curated map of this site for AI answer engines.
+ *
+ * Generated from the same content modules the pages render, not hand-written.
+ * A second hand-maintained description of the product is exactly the thing
+ * that drifts: this repo has already shipped a landing page advertising a
+ * version that was never released, and packaging manifests that read like
+ * shipping manifests and were not. If the hero copy changes, this changes
+ * with it.
+ *
+ * Format follows llmstxt.org: an H1, a blockquote summary, then H2 sections
+ * of `[name](url): description` links.
+ */
+export async function GET() {
+  const { meta, hero, faq, install } = site;
+  const base = meta.domain.replace(/\/$/, '');
+
+  const docs = (await getCollection('docs'))
+    .filter((entry) => entry.id !== 'index')
+    .map((entry) => ({
+      title: entry.data.title,
+      description: entry.data.description ?? '',
+      url: `${base}/${entry.id.replace(/\/?index$/, '')}/`.replace(/\/+$/, '/'),
+    }))
+    .sort((a, b) => a.title.localeCompare(b.title));
+
+  /** The recommended command per platform, from the install content. The
+   *  keys are lowercase identifiers; these are the names people read. */
+  const platformNames: Record<string, string> = {
+    windows: 'Windows',
+    macos: 'macOS',
+    linux: 'Linux',
+  };
+  const quickstart = Object.entries(install.byPlatform).flatMap(([platform, entry]) => {
+    const first = entry.cli?.[0];
+    if (!first?.command) return [];
+    return [`- **${platformNames[platform] ?? platform}**: \`${first.command}\``];
+  });
+
+  const lines = [
+    '# NetsCLI',
+    '',
+    `> ${hero.subhead}`,
+    '',
+    meta.description,
+    '',
+    '## Install',
+    '',
+    ...quickstart,
+    `- **From source**: \`cargo install netscli\``,
+    '',
+    'Packet capture is a compile-time feature. No published desktop installer',
+    'includes it; capture-enabled CLI assets are published separately and also',
+    'need a system capture library (libpcap or Npcap).',
+    '',
+    '## Documentation',
+    '',
+    ...docs.map((d) => `- [${d.title}](${d.url})${d.description ? `: ${d.description}` : ''}`),
+    '',
+    '## Reference',
+    '',
+    `- [Release notes](${base}/changelog/): what changed in each version.`,
+    `- [Source](${hero.sourceUrl}): MIT licensed.`,
+    '',
+    '## Common questions',
+    '',
+    // `a` is the plain-text answer; `aHtml` is the rendered variant, and
+    // markup is not what an answer engine wants.
+    ...faq.flatMap((item) => [`### ${item.q}`, '', item.a, '']),
+  ];
+
+  return new Response(`${lines.join('\n').trimEnd()}\n`, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/site/src/styles/lightbox.css
+++ b/site/src/styles/lightbox.css
@@ -52,7 +52,10 @@ body.lightbox-open{overflow:hidden}
 .image-lightbox-frame img{
   display:block;
   max-width:100%;
-  max-height:calc(100vh - 160px);
+  /* Overlay padding, the close button row, the panel gaps and the
+     caption. Grew by the button's 36px + 12px gap when it moved into
+     the column. */
+  max-height:calc(100vh - 208px);
   margin:0 auto;
   object-fit:contain;
 }
@@ -67,9 +70,16 @@ body.lightbox-open{overflow:hidden}
 .image-lightbox-caption:empty{display:none}
 
 .image-lightbox-close{
-  position:absolute;
-  top:-14px;
-  right:-6px;
+  /* In the panel's flex column, above the frame and right-aligned.
+   *
+   * It used to be absolutely positioned at top:-14px right:-6px against the
+   * panel, which puts a 36px button 30px of the way back over the image: it
+   * straddled the top-right corner rather than clearing it. Nudging the
+   * offsets cannot fix that without pushing the button off-screen on narrow
+   * viewports, where the panel already reaches the overlay's padding. As a
+   * flex item it is simply never over the image, at any size. */
+  align-self:flex-end;
+  flex:0 0 auto;
   width:36px;
   height:36px;
   display:grid;
@@ -101,5 +111,6 @@ body.lightbox-open{overflow:hidden}
 
 @media(max-width:600px){
   .image-lightbox{padding:16px}
-  .image-lightbox-close{top:-10px;right:-2px}
+  /* Less chrome to subtract at this width: 16px overlay padding, not 32. */
+  .image-lightbox-frame img{max-height:calc(100vh - 176px)}
 }


### PR DESCRIPTION
Two gaps found by auditing the built output rather than guessing.

**Every docs page declared a Twitter card with no image.** Starlight emits `twitter:card: summary_large_image` on all 11 docs pages and supplies no `og:image` or `twitter:image` — so a card that promises a large image had none, and sharing any docs link rendered degraded. The landing page and changelog were unaffected. Fixed with the same asset the rest of the site uses, plus alt text.

**`/llms.txt`** is the one GEO item that was missing. The structured data was already there and is the part that matters most — `SoftwareApplication` plus `FAQPage` with 12 Q&A pairs — but there was no curated map for an answer engine to read.

It is **generated, not hand-written**, from the same modules the pages render: hero subhead, meta description, the recommended install command per platform, every docs page's title and description from frontmatter, and all 12 FAQ answers in plain text. A second hand-maintained description of the product is exactly what drifts — this repo has already shipped a landing page advertising a version that was never released. If the hero copy changes, this changes with it.

Also drops "and diagnostics toolkit" from the Starlight description, the last place the product still had a second name.

**On the Lighthouse SEO score of 69 I mentioned:** that was the preview's own `noindex`, both the meta tag from `NETSCLI_PREVIEW=1` and Cloudflare's `x-robots-tag` on `*.pages.dev`. A production build emits zero robots meta — confirmed. Not a real finding.

Verified on the preview: `/llms.txt` returns 200 as `text/plain`, 7.2KB, four sections, 13 doc links, 12 questions; `/docs/mcp/` now has all three image tags. Accessibility 100 and Best Practices 100 in Lighthouse, a11y clean in both themes, dead-CSS budget holds at 126.