### PR TITLE
Make the e2e suite able to run, and lint it so it stays that way

### DIFF
--- a/apps/netscli-gui/e2e/tauri-render/diagnose-driver.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/diagnose-driver.mjs
@@ -98,7 +98,10 @@ const driver = spawn(
   { stdio: ['ignore', 'inherit', 'inherit'] },
 );
 
-let succeeded = false;
+// No initialiser: the first `trySession` below always assigns before anything
+// reads this, and if `waitForPort` throws first the process exits from the
+// `finally` without reaching the read.
+let succeeded;
 try {
   await waitForPort(port);
 

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/interaction.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/interaction.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { By } from '../../driver.mjs';
-import { clickButtonText, waitForText } from '../../ui.mjs';
-import { getActiveTabText, waitForNoElement } from './menu.mjs';
+import { clickButtonText, waitForNoElement, waitForText } from '../../ui.mjs';
+import { getActiveTabText } from './menu.mjs';
 import { assertAlignment } from './alignment.mjs';
 
 async function assertCommandStatusAlignment(driver) {

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/menu.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/menu.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { By, Key } from '../../driver.mjs';
-import { clickButtonText, waitForText, withElement } from '../../ui.mjs';
+import { clickButtonText, waitForNoElement, waitForText } from '../../ui.mjs';
+import { closeSettingsDialog, openSettingsDialog } from './settingsDialog.mjs';
 
 async function assertMenuItems(driver, menuLabel, expectedItems) {
   await openMenu(driver, menuLabel);
@@ -216,14 +217,6 @@ async function waitForTabCount(driver, expected) {
   );
 }
 
-async function waitForNoElement(driver, selector) {
-  await driver.wait(
-    async () => (await driver.findElements(By.css(selector))).length === 0,
-    5_000,
-    `Expected no elements matching ${selector}`,
-  );
-}
-
 async function assertToolbarButtonDisabled(driver, title, expected) {
   const disabled = await driver
     .findElement(By.css(`.toolbar button[aria-label="${title}"]`))
@@ -245,6 +238,5 @@ export {
   ensureTrafficIndicatorsVisible,
   getActiveTabText,
   openMenu,
-  waitForNoElement,
   waitForTabCount,
 };

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/settingsDialog.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/settingsDialog.mjs
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import { By } from '../../driver.mjs';
-import { clickButtonText, waitForText } from '../../ui.mjs';
-import { waitForNoElement } from './menu.mjs';
+import { clickButtonText, waitForNoElement, waitForText, withElement } from '../../ui.mjs';
 
 /**
  * Settings dialog: opening it, asserting its shape, closing it.

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/shell.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/shell.mjs
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
 import { By, Key } from '../driver.mjs';
-import { assertCommand, assertNoErrorStrip, assertTheme, clickButtonText, replaceInput, waitForText, withElement } from '../ui.mjs';
+import { assertCommand, assertNoErrorStrip, assertTheme, clickButtonText, replaceInput, waitForNoElement, waitForText, withElement } from '../ui.mjs';
 import { assertExportArtifactsCreated, countExportArtifacts } from './helpers/export.mjs';
 import { assertAboutDialogPolish, assertEmptyStateCentered, assertTrafficArrowsAreLedStyle, forceTabOverflow } from './helpers/polish.mjs';
 import { assertCommandStatusAlignment, assertInteractiveCursorTreatment, assertSuppressesNativeContextMenu, assertThemedTooltips, assertToastHasTimeoutBar } from './helpers/interaction.mjs';
-import { assertEmptyWorkspaceState, assertExitMenuItemNeutralUntilHover, assertInterfaceReadinessReflectsSelection, assertMenuIncludes, assertMenuItemDisabled, assertMenuItems, assertMenuKeyboardNavigation, assertToolbarButtonDisabled, clickMenuItem, countTabs, ensureTrafficIndicatorsVisible, getActiveTabText, waitForNoElement, waitForTabCount } from './helpers/menu.mjs';
+import { assertEmptyWorkspaceState, assertExitMenuItemNeutralUntilHover, assertInterfaceReadinessReflectsSelection, assertMenuIncludes, assertMenuItemDisabled, assertMenuItems, assertMenuKeyboardNavigation, assertToolbarButtonDisabled, clickMenuItem, countTabs, ensureTrafficIndicatorsVisible, getActiveTabText, waitForTabCount } from './helpers/menu.mjs';
 import { assertSettingsDialog, closeSettingsDialog, openSettingsDialog } from './helpers/settingsDialog.mjs';
 import { assertActiveTabVisible, assertDetailPaneCanFillWorkspace, assertEmptyToolLauncherVisible, assertOverflowTabClickSelection, assertTabAddControlPlacement, assertTabOverflowTreatment, assertTabToolPopoverTopLayer, assertTabToolPopoverVisible } from './helpers/tabs.mjs';
 

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/tools.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/tools.mjs
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
 import { By } from '../driver.mjs';
-import { addToolTab, assertCommand, assertNoErrorStrip, clickButtonText, replaceInput, runActiveTool, waitForRow, waitForText, withElement } from '../ui.mjs';
+import { addToolTab, assertCommand, assertNoErrorStrip, clickButtonText, replaceInput, runActiveTool, waitForNoElement, waitForRow, waitForText, withElement } from '../ui.mjs';
 import { dismissDnsWarningIfPresent, assertOperationToastReturnsToTab } from './helpers/interaction.mjs';
-import { waitForNoElement } from './helpers/menu.mjs';
 import { assertKeyboardSelection } from './helpers/table.mjs';
 import { assertFieldSelectPopoverVisible, assertFilterPlaceholder } from './helpers/tabs.mjs';
 

--- a/apps/netscli-gui/e2e/tauri-render/ui.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/ui.mjs
@@ -9,6 +9,22 @@ export async function withElement(driver, selector, timeoutMs = 10_000) {
   return driver.wait(until.elementLocated(By.css(selector)), timeoutMs);
 }
 
+/**
+ * The inverse of `withElement`: wait until nothing matches.
+ *
+ * Lives here rather than in `menu.mjs` because putting it there made
+ * `settingsDialog.mjs` import from `menu.mjs` while `menu.mjs` needed the
+ * dialog helpers back — a cycle that was "resolved" by dropping the import
+ * entirely, leaving both modules calling undefined names.
+ */
+export async function waitForNoElement(driver, selector) {
+  await driver.wait(
+    async () => (await driver.findElements(By.css(selector))).length === 0,
+    5_000,
+    `Expected no elements matching ${selector}`,
+  );
+}
+
 export async function replaceInput(driver, selector, value) {
   const input = await withElement(driver, selector);
   await input.click();

--- a/apps/netscli-gui/eslint.config.js
+++ b/apps/netscli-gui/eslint.config.js
@@ -16,7 +16,7 @@ import tseslint from 'typescript-eslint';
  * has actually shipped; style is left to the existing conventions.
  */
 export default tseslint.config(
-  { ignores: ['dist/**', 'node_modules/**', 'src-tauri/**', 'e2e/**'] },
+  { ignores: ['dist/**', 'node_modules/**', 'src-tauri/**'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
@@ -24,8 +24,14 @@ export default tseslint.config(
     plugins: { 'react-hooks': reactHooks },
     rules: {
       // The two that would have caught A-13 and B-18.
+      //
+      // `exhaustive-deps` was a warning, which meant the three deliberate
+      // omissions in this codebase sat in the output indefinitely and a new
+      // accidental one would have been indistinguishable from them. Each of
+      // the three now carries a disable comment saying why, so the rule can
+      // be an error and the next violation fails the build.
       'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'warn',
+      'react-hooks/exhaustive-deps': 'error',
 
       // Unused code is nearly always a leftover from a partial edit, but an
       // underscore prefix is the established way to say "deliberately unused"
@@ -46,6 +52,31 @@ export default tseslint.config(
     files: ['**/*.test.{ts,tsx}'],
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+  {
+    // The e2e suite was excluded from linting entirely, and `no-undef` is
+    // exactly what it needed: two helpers called `withElement`,
+    // `openSettingsDialog` and `closeSettingsDialog` without importing them,
+    // so the suite threw ReferenceError the moment it reached them. Nothing
+    // caught it, because gui-render.yml is schedule-only and was already
+    // failing earlier for an unrelated upstream reason.
+    //
+    // Plain Node ESM, not TypeScript or React, so it gets the base JS rules
+    // plus the globals a WebDriver script actually uses.
+    // Globals are listed rather than pulled from the `globals` package: this
+    // is the whole set a WebDriver script touches, and lint names anything
+    // missing the moment it is used, which is cheaper than a dependency.
+    files: ['e2e/**/*.mjs'],
+    languageOptions: {
+      globals: {
+        Buffer: 'readonly',
+        clearTimeout: 'readonly',
+        console: 'readonly',
+        fetch: 'readonly',
+        process: 'readonly',
+        setTimeout: 'readonly',
+      },
     },
   },
 );

--- a/apps/netscli-gui/src/App.tsx
+++ b/apps/netscli-gui/src/App.tsx
@@ -106,6 +106,11 @@ function App() {
     if (activeTab.busy || activeTab.result) return;
     workspace.clearAutoRun(activeTab.id);
     requestRun(activeTab.id);
+    // `requestRun` and `workspace` are rebuilt every render, so depending on
+    // them would refire this on every render and re-trigger the auto-run.
+    // The three fields listed are the whole trigger: a tab became active,
+    // finished, or produced a result.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab?.id, activeTab?.busy, activeTab?.result]);
 
   useKeyboardShortcuts({

--- a/apps/netscli-gui/src/workspace/useWorkspace.ts
+++ b/apps/netscli-gui/src/workspace/useWorkspace.ts
@@ -149,6 +149,11 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
       selectedIndices: [0],
       selectionAnchor: 0,
     });
+    // Deliberately not the whole `activeTab`: depending on the object would
+    // refire whenever a result arrives and reset the selection under a run
+    // in progress, which is what the sort/filter comparison above exists to
+    // avoid.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab?.id, activeTab?.sortDir, activeTab?.sortKey, filterText]);
 
   useEffect(() => {
@@ -181,6 +186,13 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
       cancelled = true;
       unlisten?.();
     };
+    // Must run exactly once. `showToast` is rebuilt every render, so
+    // depending on it would tear down and re-register the Tauri listener
+    // continuously; `activeOps` is a `useRef` from `useTabLifecycle`, stable
+    // for the component's life, but the rule cannot see that across the hook
+    // boundary. Reading `activeOps.current` inside the callback is what makes
+    // the empty dep list correct rather than merely convenient.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function patchTab(id: string, patch: Partial<WorkspaceTab>) {


### PR DESCRIPTION
Two helpers called identifiers they never imported, so the suite threw `ReferenceError` the moment it reached them. Linting the pre-fix files reports **8 `no-undef` errors**: `settingsDialog.mjs` used `withElement`, and `menu.mjs` used `openSettingsDialog`/`closeSettingsDialog` at six call sites.

The missing import was less an oversight than a dead end. `menu.mjs` needed the dialog helpers, `settingsDialog.mjs` needed `waitForNoElement` back from `menu.mjs`, and the cycle got "resolved" by dropping one side. `waitForNoElement` is a generic waiter with no reason to live in `menu.mjs`, so it moves next to `withElement` in `ui.mjs` and the cycle disappears.

Nothing caught this because eslint ignored `e2e/**` outright, and `gui-render.yml` is schedule-only and currently dies earlier on an upstream wry bug. The ignore is gone, with an e2e block supplying the Node globals a WebDriver script uses. That surfaced two more real errors: an unused import in `menu.mjs` and a dead initialiser in `diagnose-driver.mjs`.

`exhaustive-deps` also moves from warn to error. The three deliberate omissions now carry a comment explaining why each is correct — `showToast` is rebuilt every render, `activeOps` is a ref the rule can't prove stable across a hook boundary — so an accidental fourth fails the build instead of joining a standing pile of warnings.

## Verification

- Every scenario module imports with all exports defined (was: threw on call).
- `eslint .` — 0 errors, 0 warnings.
- 117 unit tests pass; `tsc -b` clean.

Audit findings #2 (High) and #32.