### PR TITLE
Fix the wrong-row jump, and four ways the GUI failed quietly

### DIFF
--- a/apps/netscli-gui/src-tauri/src/commands/operations/mod.rs
+++ b/apps/netscli-gui/src-tauri/src/commands/operations/mod.rs
@@ -10,12 +10,15 @@ pub(crate) use scan::{
     discover_network, inspect_host_cmd, ping_host, scan_ports, sweep_network, trace_route_cmd,
 };
 
+use std::collections::HashMap;
 use std::future::Future;
+use std::sync::Arc;
 
 use netscli_core::{Ops, OpsConfig};
 use tauri::Emitter;
+use tokio::sync::Mutex as AsyncMutex;
 
-use crate::state::OperationManager;
+use crate::state::{OperationHandle, OperationManager};
 
 pub(super) type JsonResult = Result<serde_json::Value, String>;
 
@@ -62,11 +65,38 @@ where
         });
 
         manager.register(op_id.clone(), handle, pcap_cancel).await;
-        let res = rx.await.map_err(|_| "Operation cancelled".to_string())?;
-        manager.remove(&op_id).await;
-        res
+
+        // Constructed *after* `register`, so its `Drop` can never run before
+        // the entry it removes exists. Cleanup used to sit after the `await`
+        // below, which meant a dropped invoke future -- a webview reload
+        // mid-run -- skipped it and left the entry in the map for good.
+        let _cleanup = RemoveOnDrop {
+            registry: manager.registry(),
+            op_id: op_id.clone(),
+        };
+        rx.await.map_err(|_| "Operation cancelled".to_string())?
     } else {
         job().await
+    }
+}
+
+/// Removes an operation from the manager however its future ends: returned,
+/// errored, or dropped.
+struct RemoveOnDrop {
+    registry: Arc<AsyncMutex<HashMap<String, OperationHandle>>>,
+    op_id: String,
+}
+
+impl Drop for RemoveOnDrop {
+    fn drop(&mut self) {
+        // `Drop` cannot await, so the removal is spawned. Nothing waits on
+        // the entry being gone -- op ids are unique per run, so a late
+        // removal cannot strand a later operation.
+        let registry = Arc::clone(&self.registry);
+        let op_id = std::mem::take(&mut self.op_id);
+        tauri::async_runtime::spawn(async move {
+            registry.lock().await.remove(&op_id);
+        });
     }
 }
 

--- a/apps/netscli-gui/src-tauri/src/state.rs
+++ b/apps/netscli-gui/src-tauri/src/state.rs
@@ -1,13 +1,13 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use netscli_core::PcapCancelToken;
 use tokio::sync::Mutex as AsyncMutex;
 
 #[derive(Default)]
 pub(crate) struct OperationManager {
-    tasks: AsyncMutex<HashMap<String, OperationHandle>>,
+    tasks: Arc<AsyncMutex<HashMap<String, OperationHandle>>>,
 }
 
 #[derive(Default)]
@@ -15,7 +15,7 @@ pub(crate) struct ArtifactRegistry {
     paths: Mutex<HashSet<PathBuf>>,
 }
 
-struct OperationHandle {
+pub(crate) struct OperationHandle {
     task: tauri::async_runtime::JoinHandle<()>,
     pcap_cancel: Option<PcapCancelToken>,
 }
@@ -38,9 +38,16 @@ impl OperationManager {
         }
     }
 
-    pub(crate) async fn remove(&self, op_id: &str) {
-        let mut tasks = self.tasks.lock().await;
-        tasks.remove(op_id);
+    /// An owned handle to the task map, for cleanup that has to outlive the
+    /// borrow of this state.
+    ///
+    /// `run_json_operation` holds a `tauri::State`, which cannot be moved
+    /// into a `Drop` impl. Without one, an operation whose invoke future was
+    /// dropped -- a webview reload mid-run -- never reached the `remove`
+    /// after its `await`, so its entry stayed in the map for the life of the
+    /// process.
+    pub(crate) fn registry(&self) -> Arc<AsyncMutex<HashMap<String, OperationHandle>>> {
+        Arc::clone(&self.tasks)
     }
 
     pub(crate) async fn cancel(&self, op_id: &str) -> bool {

--- a/apps/netscli-gui/src/App.css
+++ b/apps/netscli-gui/src/App.css
@@ -2,6 +2,7 @@
 @import './styles/shell.css';
 @import './styles/forms.css';
 @import './styles/results.css';
+@import './styles/error-boundary.css';
 @import './styles/pcap.css';
 @import './styles/details.css';
 @import './styles/responsive.css';

--- a/apps/netscli-gui/src/components/primitives/ErrorBoundary.tsx
+++ b/apps/netscli-gui/src/components/primitives/ErrorBoundary.tsx
@@ -1,0 +1,57 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+/**
+ * Last line of defence against a render throw blanking the window.
+ *
+ * There was no boundary anywhere in the app, so any error thrown during
+ * render unmounted the whole tree and left a blank window -- taking every
+ * other tab's results and form state with it. An imported result bundle is
+ * the realistic trigger: bundles are shareable files, and the row builders
+ * run inside a `useMemo`, which no `try`/`catch` around the import can
+ * reach.
+ *
+ * Deliberately not a retry button. Whatever produced the error is still in
+ * state, so re-rendering the same tree reproduces it; reloading is the
+ * honest offer, and the message says what to expect from it.
+ */
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Nothing here reaches a server; this is the developer console of the
+    // user's own machine, and the component stack is what makes a report
+    // actionable.
+    console.error('Unrecoverable render error', error, info.componentStack);
+  }
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    return (
+      <div className="error-boundary" role="alert" data-testid="error-boundary">
+        <h1>Something went wrong</h1>
+        <p>
+          The window stopped rendering and could not recover. Reloading starts a fresh session; any
+          results still open will be lost.
+        </p>
+        <pre className="error-boundary-detail">{error.message}</pre>
+        <button type="button" onClick={() => window.location.reload()}>
+          Reload
+        </button>
+      </div>
+    );
+  }
+}

--- a/apps/netscli-gui/src/components/shell/WorkspaceSearchDialog.tsx
+++ b/apps/netscli-gui/src/components/shell/WorkspaceSearchDialog.tsx
@@ -11,7 +11,7 @@ interface WorkspaceSearchDialogProps {
   tabs: WorkspaceTab[];
   onClose: () => void;
   onOpenHistoryEntry: (entry: HistoryEntry) => void;
-  onSelectRow: (tabId: string, rowIndex: number) => void;
+  onSelectRow: (tabId: string, rowId: string) => void;
   onSelectTab: (tabId: string) => void;
 }
 
@@ -30,7 +30,7 @@ type SearchItem =
       primary: string;
       secondary: string;
       searchText: string;
-      rowIndex: number;
+      rowId: string;
       tabId: string;
     }
   | {
@@ -71,7 +71,7 @@ export function WorkspaceSearchDialog({
     if (item.kind === 'tab') {
       onSelectTab(item.tabId);
     } else if (item.kind === 'row') {
-      onSelectRow(item.tabId, item.rowIndex);
+      onSelectRow(item.tabId, item.rowId);
     } else {
       onOpenHistoryEntry(item.entry);
     }
@@ -200,11 +200,11 @@ function tabItems(tab: WorkspaceTab): SearchItem[] {
     searchText: tabText.toLowerCase(),
     tabId: tab.id,
   };
-  const rowItems = buildRows(tab.result).map((row, rowIndex) => rowItem(tab, row, rowIndex));
+  const rowItems = buildRows(tab.result).map((row) => rowItem(tab, row));
   return [tabItem, ...rowItems];
 }
 
-function rowItem(tab: WorkspaceTab, row: ResultRow, rowIndex: number): SearchItem {
+function rowItem(tab: WorkspaceTab, row: ResultRow): SearchItem {
   const config = TOOL_CONFIG[tab.kind];
   return {
     id: `row-${tab.id}-${row.id}`,
@@ -212,7 +212,7 @@ function rowItem(tab: WorkspaceTab, row: ResultRow, rowIndex: number): SearchIte
     primary: rowTitle(row),
     secondary: `${config.label} - ${tabTitle(tab)}`,
     searchText: `${row.searchText} ${config.label} ${tab.title} ${Object.values(tab.form).join(' ')}`.toLowerCase(),
-    rowIndex,
+    rowId: row.id,
     tabId: tab.id,
   };
 }

--- a/apps/netscli-gui/src/main.tsx
+++ b/apps/netscli-gui/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
+import { ErrorBoundary } from './components/primitives/ErrorBoundary.tsx'
 
 // The non-null assertion is the one place it is justified: index.html always
 // ships this element, and a missing root is a build error, not a runtime case
@@ -10,7 +11,9 @@ if (!rootElement) throw new Error('#root is missing from index.html')
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 )
 

--- a/apps/netscli-gui/src/styles/error-boundary.css
+++ b/apps/netscli-gui/src/styles/error-boundary.css
@@ -1,0 +1,41 @@
+/* The whole-window fallback when a render throws.
+
+   Its own file rather than part of results.css: this replaces the entire
+   shell rather than styling anything inside it, and results.css was at its
+   size cap with a note asking for exactly this kind of split. */
+
+/* Replaces the entire window when a render throws, so it carries its own
+   background rather than inheriting one from a shell that is no longer
+   mounted. */
+.error-boundary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+  min-height: 100vh;
+  padding: 32px;
+  color: var(--text-primary);
+  background: var(--bg-body);
+}
+
+.error-boundary h1 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.error-boundary p {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.error-boundary-detail {
+  max-width: 100%;
+  margin: 0;
+  padding: 10px 12px;
+  overflow-x: auto;
+  color: var(--red);
+  background: color-mix(in srgb, var(--red), transparent 92%);
+  border: 1px solid color-mix(in srgb, var(--red), transparent 60%);
+  border-radius: 4px;
+}

--- a/apps/netscli-gui/src/styles/results.css
+++ b/apps/netscli-gui/src/styles/results.css
@@ -6,42 +6,6 @@
   border-bottom: 1px solid color-mix(in srgb, var(--red), transparent 55%);
 }
 
-/* Replaces the entire window when a render throws, so it carries its own
-   background rather than inheriting one from a shell that is no longer
-   mounted. */
-.error-boundary {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  align-items: flex-start;
-  min-height: 100vh;
-  padding: 32px;
-  color: var(--text-primary);
-  background: var(--bg-body);
-}
-
-.error-boundary h1 {
-  margin: 0;
-  font-size: 18px;
-}
-
-.error-boundary p {
-  max-width: 60ch;
-  margin: 0;
-  color: var(--text-secondary);
-}
-
-.error-boundary-detail {
-  max-width: 100%;
-  margin: 0;
-  padding: 10px 12px;
-  overflow-x: auto;
-  color: var(--red);
-  background: color-mix(in srgb, var(--red), transparent 92%);
-  border: 1px solid color-mix(in srgb, var(--red), transparent 60%);
-  border-radius: 4px;
-}
-
 .warning-strip {
   flex: 0 0 auto;
   display: flex;

--- a/apps/netscli-gui/src/styles/results.css
+++ b/apps/netscli-gui/src/styles/results.css
@@ -6,6 +6,42 @@
   border-bottom: 1px solid color-mix(in srgb, var(--red), transparent 55%);
 }
 
+/* Replaces the entire window when a render throws, so it carries its own
+   background rather than inheriting one from a shell that is no longer
+   mounted. */
+.error-boundary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+  min-height: 100vh;
+  padding: 32px;
+  color: var(--text-primary);
+  background: var(--bg-body);
+}
+
+.error-boundary h1 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.error-boundary p {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.error-boundary-detail {
+  max-width: 100%;
+  margin: 0;
+  padding: 10px 12px;
+  overflow-x: auto;
+  color: var(--red);
+  background: color-mix(in srgb, var(--red), transparent 92%);
+  border: 1px solid color-mix(in srgb, var(--red), transparent 60%);
+  border-radius: 4px;
+}
+
 .warning-strip {
   flex: 0 0 auto;
   display: flex;

--- a/apps/netscli-gui/src/tools/presentation.test.ts
+++ b/apps/netscli-gui/src/tools/presentation.test.ts
@@ -475,6 +475,24 @@ describe('result presentation', () => {
     expect(portTlsLines(openUnknown)[1]?.value).toMatch(/not TLS-like/i);
   });
 
+  // Exported cells carry values the scanned host chose. Excel and
+  // LibreOffice evaluate a cell opening with = + - or @, so a banner of
+  // `=HYPERLINK(...)` became a live link in the operator's spreadsheet.
+  it('neutralises spreadsheet formulas in exported cells', () => {
+    // Commas and quotes inside the formula still get CSV-quoted around the
+    // leading apostrophe, so both defences apply at once.
+    expect(csvEscape('=HYPERLINK("http://evil.test","click")')).toBe(
+      `"'=HYPERLINK(""http://evil.test"",""click"")"`,
+    );
+    expect(csvEscape('@SUM(A1:A9)')).toBe(`'@SUM(A1:A9)`);
+    expect(csvEscape(`-2+3+cmd|' /C calc'!A0`)).toBe(`'-2+3+cmd|' /C calc'!A0`);
+
+    // A number is not a formula, and must not pick up a quote.
+    expect(csvEscape(-1)).toBe('-1');
+    expect(csvEscape('+80')).toBe('+80');
+    expect(csvEscape('nginx/1.25.3')).toBe('nginx/1.25.3');
+  });
+
   it('escapes CSV output', () => {
     expect(csvEscape('a,b"c\n')).toBe('"a,b""c\n"');
 

--- a/apps/netscli-gui/src/tools/presentation.test.ts
+++ b/apps/netscli-gui/src/tools/presentation.test.ts
@@ -7,7 +7,6 @@ import {
   buildRows,
   columnsFor,
   copyContextForCell,
-  csvEscape,
   detailTabsFor,
   filterHintsFor,
   filterAndSortRows,
@@ -21,11 +20,9 @@ import {
   portTlsLines,
   resultSummary,
   selectedRowsRawPreview,
-  serializeRowsAsCsv,
   selectionSummaryLines,
   tabIdentity,
 } from './presentation';
-import type { ResultColumn } from './types';
 import type { ToolResult } from '../types/app';
 import type { PortResult, PortStatus } from '../types/netscli';
 
@@ -473,43 +470,6 @@ describe('result presentation', () => {
     openUnknown.service = undefined;
     expect(portHeaderLines(openUnknown)[1]?.value).toMatch(/not HTTP-like/i);
     expect(portTlsLines(openUnknown)[1]?.value).toMatch(/not TLS-like/i);
-  });
-
-  // Exported cells carry values the scanned host chose. Excel and
-  // LibreOffice evaluate a cell opening with = + - or @, so a banner of
-  // `=HYPERLINK(...)` became a live link in the operator's spreadsheet.
-  it('neutralises spreadsheet formulas in exported cells', () => {
-    // Commas and quotes inside the formula still get CSV-quoted around the
-    // leading apostrophe, so both defences apply at once.
-    expect(csvEscape('=HYPERLINK("http://evil.test","click")')).toBe(
-      `"'=HYPERLINK(""http://evil.test"",""click"")"`,
-    );
-    expect(csvEscape('@SUM(A1:A9)')).toBe(`'@SUM(A1:A9)`);
-    expect(csvEscape(`-2+3+cmd|' /C calc'!A0`)).toBe(`'-2+3+cmd|' /C calc'!A0`);
-
-    // A number is not a formula, and must not pick up a quote.
-    expect(csvEscape(-1)).toBe('-1');
-    expect(csvEscape('+80')).toBe('+80');
-    expect(csvEscape('nginx/1.25.3')).toBe('nginx/1.25.3');
-  });
-
-  it('escapes CSV output', () => {
-    expect(csvEscape('a,b"c\n')).toBe('"a,b""c\n"');
-
-    const columns: ResultColumn[] = [
-      { key: 'name', label: 'Name' },
-      { key: 'value', label: 'Value' },
-    ];
-    const csv = serializeRowsAsCsv(columns, [
-      {
-        id: 'row-1',
-        kind: 'dns',
-        data: { name: 'txt', value: 'hello, "world"' },
-        raw: {},
-        searchText: '',
-      },
-    ]);
-    expect(csv).toBe('Name,Value\ntxt,"hello, ""world"""');
   });
 
   it('builds copy context for populated result cells only', () => {

--- a/apps/netscli-gui/src/tools/presentation.values.test.ts
+++ b/apps/netscli-gui/src/tools/presentation.values.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { csvEscape, serializeRowsAsCsv } from './presentation';
+import type { ResultColumn } from './types';
+
+// Split out of presentation.test.ts, which was at its size cap with a note
+// asking for exactly this: one file per helper family. These cover the
+// value-and-serialisation helpers rather than row or column building.
+describe('cell values and CSV serialisation', () => {
+  // Exported cells carry values the scanned host chose. Excel and
+  // LibreOffice evaluate a cell opening with = + - or @, so a banner of
+  // `=HYPERLINK(...)` became a live link in the operator's spreadsheet.
+  it('neutralises spreadsheet formulas in exported cells', () => {
+    // Commas and quotes inside the formula still get CSV-quoted around the
+    // leading apostrophe, so both defences apply at once.
+    expect(csvEscape('=HYPERLINK("http://evil.test","click")')).toBe(
+      `"'=HYPERLINK(""http://evil.test"",""click"")"`,
+    );
+    expect(csvEscape('@SUM(A1:A9)')).toBe(`'@SUM(A1:A9)`);
+    expect(csvEscape(`-2+3+cmd|' /C calc'!A0`)).toBe(`'-2+3+cmd|' /C calc'!A0`);
+
+    // A number is not a formula, and must not pick up a quote.
+    expect(csvEscape(-1)).toBe('-1');
+    expect(csvEscape('+80')).toBe('+80');
+    expect(csvEscape('nginx/1.25.3')).toBe('nginx/1.25.3');
+  });
+
+  it('escapes CSV output', () => {
+    expect(csvEscape('a,b"c\n')).toBe('"a,b""c\n"');
+
+    const columns: ResultColumn[] = [
+      { key: 'name', label: 'Name' },
+      { key: 'value', label: 'Value' },
+    ];
+    const csv = serializeRowsAsCsv(columns, [
+      {
+        id: 'row-1',
+        kind: 'dns',
+        data: { name: 'txt', value: 'hello, "world"' },
+        raw: {},
+        searchText: '',
+      },
+    ]);
+    expect(csv).toBe('Name,Value\ntxt,"hello, ""world"""');
+  });
+});

--- a/apps/netscli-gui/src/tools/presentation/values.ts
+++ b/apps/netscli-gui/src/tools/presentation/values.ts
@@ -10,12 +10,30 @@ export function numberOrUndefined(value?: string): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+/**
+ * A cell a spreadsheet will treat as text, never as a formula.
+ *
+ * Exported rows carry values the scanned host chose -- banners, hostnames,
+ * service strings. Excel and LibreOffice evaluate any cell opening with
+ * `=`, `+`, `-` or `@`, so a host answering with `=HYPERLINK("http://…")`
+ * gets a live link in the operator's spreadsheet. Prefixing a single quote
+ * is the standard defence: spreadsheets read it as "this is text" and do
+ * not display it, and any other CSV reader sees one leading quote rather
+ * than a formula.
+ *
+ * `\r` and tab are in the trigger set because both can carry a value onto a
+ * fresh line or cell where it would lead again.
+ */
 export function csvEscape(value: unknown): string {
   const text = String(value ?? '');
-  if (text.includes(',') || text.includes('"') || text.includes('\n')) {
-    return `"${text.replace(/"/g, '""')}"`;
+  // A cell that parses as a number cannot be a formula, so latency of -1 or
+  // a `+`-signed figure stays a number rather than gaining a stray quote.
+  const numeric = text !== '' && Number.isFinite(Number(text));
+  const guarded = !numeric && /^[=+\-@\t\r]/.test(text) ? `'${text}` : text;
+  if (guarded.includes(',') || guarded.includes('"') || guarded.includes('\n') || guarded.includes('\r')) {
+    return `"${guarded.replace(/"/g, '""')}"`;
   }
-  return text;
+  return guarded;
 }
 
 export function renderValue(value: unknown): string {

--- a/apps/netscli-gui/src/tools/registry.ts
+++ b/apps/netscli-gui/src/tools/registry.ts
@@ -140,8 +140,9 @@ export const TOOL_CONFIG: Record<ToolKind, ToolConfig> = {
       // DEFAULT_FORM carried `timeout_ms` with no field to set it, so the
       // value went straight to the backend through `numberOrUndefined`, which
       // does not clamp -- every other numeric field is bounded by its `min`
-      // and `max` here. The command preview and the execution path already
-      // handled it; only the input was missing.
+      // and `max` here. Adding the input left the execution path still
+      // calling the unclamped helper, so these bounds only became real when
+      // `toolExecution` switched to `boundedNumberOrUndefined`.
       { key: 'timeout_ms', label: 'Timeout', type: 'number', compact: true, placeholder: '3000', min: 500, max: 30000, step: 100 },
     ],
   },

--- a/apps/netscli-gui/src/workspace/selection.ts
+++ b/apps/netscli-gui/src/workspace/selection.ts
@@ -22,3 +22,17 @@ export function rangeBetween(start: number, end: number): number[] {
   return Array.from({ length: high - low + 1 }, (_item, offset) => low + offset);
 }
 
+/**
+ * Find a row's position in the list a tab is actually rendering.
+ *
+ * Positions are only meaningful against one specific ordering. Workspace
+ * search enumerates rows in backend order and the table renders them sorted
+ * and filtered, so an index taken from one and applied to the other agreed
+ * only when no sort and no filter were in play -- which is never, since
+ * every tool kind has a DEFAULT_SORT. Row ids survive both operations, so
+ * they are what should cross the boundary.
+ */
+export function indexOfRowId(rows: { id: string }[], rowId: string): number {
+  return rows.findIndex((row) => row.id === rowId);
+}
+

--- a/apps/netscli-gui/src/workspace/toolExecution.test.ts
+++ b/apps/netscli-gui/src/workspace/toolExecution.test.ts
@@ -108,17 +108,23 @@ describe('numeric form bounds', () => {
   it('clamps the mDNS timeout to the range its field declares', async () => {
     const netscli = await import('../services/netscli');
     const tab = createTab('mdns');
+    // Indexed rather than `.at(-1)`, which needs a newer lib target than
+    // this project sets.
+    const lastTimeout = () => {
+      const calls = vi.mocked(netscli.discoverMdns).mock.calls;
+      return calls[calls.length - 1]?.[0];
+    };
 
     tab.form.timeout_ms = '999999';
     await executeTool(tab, 'op-mdns-1', 64);
-    expect(vi.mocked(netscli.discoverMdns).mock.calls.at(-1)?.[0]).toBe(30000);
+    expect(lastTimeout()).toBe(30000);
 
     tab.form.timeout_ms = '1';
     await executeTool(tab, 'op-mdns-2', 64);
-    expect(vi.mocked(netscli.discoverMdns).mock.calls.at(-1)?.[0]).toBe(500);
+    expect(lastTimeout()).toBe(500);
 
     tab.form.timeout_ms = '3000';
     await executeTool(tab, 'op-mdns-3', 64);
-    expect(vi.mocked(netscli.discoverMdns).mock.calls.at(-1)?.[0]).toBe(3000);
+    expect(lastTimeout()).toBe(3000);
   });
 });

--- a/apps/netscli-gui/src/workspace/toolExecution.test.ts
+++ b/apps/netscli-gui/src/workspace/toolExecution.test.ts
@@ -9,6 +9,7 @@ vi.mock('../services/env', () => ({
 
 vi.mock('../services/netscli', () => ({
   dnsLookup: vi.fn(),
+  discoverMdns: vi.fn(() => Promise.resolve([])),
 }));
 
 describe('validateTab', () => {
@@ -97,5 +98,27 @@ describe('executeTool DNS "ALL" aggregation', () => {
     tab.form.record = 'ALL';
 
     await expect(executeTool(tab, 'op-4', 256)).rejects.toThrow(/cancelled/i);
+  });
+});
+
+// The mDNS timeout was the one numeric field sent to the backend without the
+// registry's own min/max, even though the comment on that field said this
+// path applied them.
+describe('numeric form bounds', () => {
+  it('clamps the mDNS timeout to the range its field declares', async () => {
+    const netscli = await import('../services/netscli');
+    const tab = createTab('mdns');
+
+    tab.form.timeout_ms = '999999';
+    await executeTool(tab, 'op-mdns-1', 64);
+    expect(vi.mocked(netscli.discoverMdns).mock.calls.at(-1)?.[0]).toBe(30000);
+
+    tab.form.timeout_ms = '1';
+    await executeTool(tab, 'op-mdns-2', 64);
+    expect(vi.mocked(netscli.discoverMdns).mock.calls.at(-1)?.[0]).toBe(500);
+
+    tab.form.timeout_ms = '3000';
+    await executeTool(tab, 'op-mdns-3', 64);
+    expect(vi.mocked(netscli.discoverMdns).mock.calls.at(-1)?.[0]).toBe(3000);
   });
 });

--- a/apps/netscli-gui/src/workspace/toolExecution.ts
+++ b/apps/netscli-gui/src/workspace/toolExecution.ts
@@ -105,7 +105,10 @@ export async function executeTool(
       return {
         kind: 'mdns',
         data: await netscli.discoverMdns(
-          numberOrUndefined(tab.form.timeout_ms),
+          // `numberOrUndefined` here was the one numeric field that skipped
+          // the registry's own min/max, despite the comment on that field
+          // claiming this path already applied them.
+          boundedNumberOrUndefined(tab, 'timeout_ms'),
           serviceTypes(tab.form.service_types),
           opId,
         ),

--- a/apps/netscli-gui/src/workspace/transfer.test.ts
+++ b/apps/netscli-gui/src/workspace/transfer.test.ts
@@ -36,6 +36,21 @@ describe('parseResultBundle', () => {
     );
   });
 
+  // "Is an array" was the whole check, so these imported cleanly and threw
+  // inside `buildRows` during render instead -- past every catch, and with
+  // no error boundary mounted, which blanked the window and took every
+  // other tab's state with it.
+  it('rejects array data holding entries that are not objects', () => {
+    expect(() => parseResultBundle(bundle({ result: { kind: 'scan', data: [null] } }))).toThrow(
+      /non-object entry at index 0/i,
+    );
+    expect(() =>
+      parseResultBundle(bundle({ result: { kind: 'scan', data: [{ port: 22 }, 'nope'] } })),
+    ).toThrow(/non-object entry at index 1/i);
+    // An empty array is a legitimate "scanned, found nothing".
+    expect(() => parseResultBundle(bundle({ result: { kind: 'scan', data: [] } }))).not.toThrow();
+  });
+
   it('rejects pcap data without packets', () => {
     expect(() => parseResultBundle(bundle({ kind: 'pcap', result: { kind: 'pcap', data: {} } }))).toThrow(
       /pcap data must include packets/i,

--- a/apps/netscli-gui/src/workspace/transfer.ts
+++ b/apps/netscli-gui/src/workspace/transfer.ts
@@ -184,6 +184,14 @@ function validateResultDataShape(kind: ToolKind, data: unknown) {
     if (!Array.isArray(data)) {
       throw new Error(`Result bundle data for ${kind} must be an array`);
     }
+    // "Is an array" was the whole check, so `[null]` imported cleanly and
+    // then threw inside `buildRows` during render -- past every catch, in a
+    // `useMemo`. Row builders read fields off each entry, so an entry that
+    // is not an object cannot be one of these rows.
+    const bad = data.findIndex((entry) => !entry || typeof entry !== 'object' || Array.isArray(entry));
+    if (bad !== -1) {
+      throw new Error(`Result bundle data for ${kind} has a non-object entry at index ${bad}`);
+    }
     return;
   }
 

--- a/apps/netscli-gui/src/workspace/types.ts
+++ b/apps/netscli-gui/src/workspace/types.ts
@@ -27,7 +27,7 @@ export interface WorkspaceModel {
   patchForm: (id: string, key: string, value: string) => void;
   selectRow: (index: number, mode?: RowSelectionMode) => void;
   /** Select a row in a named tab, which need not be the active one. */
-  selectRowInTab: (tabId: string, index: number) => void;
+  selectRowInTab: (tabId: string, rowId: string) => void;
   selectAllRows: () => void;
   addTab: (kind: ToolKind) => void;
   openHostTool: (kind: 'scan' | 'inspect', host: string) => void;

--- a/apps/netscli-gui/src/workspace/useNetworkStatus.ts
+++ b/apps/netscli-gui/src/workspace/useNetworkStatus.ts
@@ -12,6 +12,10 @@ import {
 } from './demoMode';
 
 const INTERFACE_REFRESH_INTERVAL_MS = 30000;
+// Three misses is 90 seconds of no interface data -- long enough that a slow
+// first poll or a single transient failure stays silent, short enough that a
+// user staring at "Detecting..." gets told why.
+const INTERFACE_FAILURES_BEFORE_WARNING = 3;
 const NETWORK_STATS_INTERVAL_MS = 3000;
 
 function isDocumentVisible(): boolean {
@@ -47,6 +51,7 @@ export function useNetworkStatus(showToast: (toast: Omit<WorkspaceToast, 'id'>) 
   );
   const initializedTrafficInterface = useRef(false);
   const trafficInterfaceNameRef = useRef(trafficInterfaceName);
+  const interfaceFailures = useRef(0);
 
   useEffect(() => {
     trafficInterfaceNameRef.current = trafficInterfaceName;
@@ -105,9 +110,30 @@ export function useNetworkStatus(showToast: (toast: Omit<WorkspaceToast, 'id'>) 
           setInterfaces(allInterfaces);
           initializeTrafficInterface(iface, allInterfaces);
         }
+
+        // Every failure here used to be swallowed on a 30s timer, so a
+        // backend that had stopped answering showed a permanent
+        // "Detecting..." and an empty interface list in the capture form,
+        // with nothing to distinguish that from a slow first poll.
+        if (iface || allInterfaces) {
+          interfaceFailures.current = 0;
+        } else {
+          reportInterfaceFailure();
+        }
       } catch {
-        return;
+        if (!stopped) reportInterfaceFailure();
       }
+    };
+
+    // Announce once, on the way past the threshold, and stay quiet until a
+    // poll succeeds again. A toast every 30 seconds would be its own defect.
+    const reportInterfaceFailure = () => {
+      interfaceFailures.current += 1;
+      if (interfaceFailures.current !== INTERFACE_FAILURES_BEFORE_WARNING) return;
+      showToast({
+        kind: 'interaction',
+        message: 'Network interfaces are not responding. Interface-dependent tools may be unavailable.',
+      });
     };
 
     void loadInterfaceInfo();
@@ -121,6 +147,9 @@ export function useNetworkStatus(showToast: (toast: Omit<WorkspaceToast, 'id'>) 
       document.removeEventListener('visibilitychange', onVisibilityChange);
       window.clearInterval(id);
     };
+    // `showToast` is rebuilt every render, so depending on it would tear down
+    // and restart the 30s poll continuously.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [demoScreenshotMode]);
 
   useEffect(() => {

--- a/apps/netscli-gui/src/workspace/useSelection.ts
+++ b/apps/netscli-gui/src/workspace/useSelection.ts
@@ -2,7 +2,7 @@ import { buildRows, filterAndSortRows } from '../tools/presentation';
 import type { ResultRow, RowSelectionMode, WorkspaceTab } from '../tools/types';
 import type { DefaultInterfaceInfo } from '../types/netscli';
 import { enrichInterfaceRows } from './interfaceRows';
-import { clampIndex, normalizeSelection, rangeBetween } from './selection';
+import { clampIndex, indexOfRowId, normalizeSelection, rangeBetween } from './selection';
 
 /**
  * Row-selection commands for the workspace.
@@ -18,6 +18,7 @@ export function useSelection({
   filterText,
   patchTab,
   rows,
+  setFilterText,
   tabs,
   trafficInterfaceName,
 }: {
@@ -25,6 +26,7 @@ export function useSelection({
   defaultInterface: DefaultInterfaceInfo | null;
   filterText: string;
   patchTab: (id: string, patch: Partial<WorkspaceTab>) => void;
+  setFilterText: (value: string) => void;
   rows: ResultRow[];
   tabs: WorkspaceTab[];
   trafficInterfaceName: string | null;
@@ -88,18 +90,34 @@ export function useSelection({
    *
    * Addressing the tab by id removes the ordering dependency: rows for the
    * destination tab are derived here rather than read from the active-tab
-   * memo, so the index is clamped against the right list.
+   * memo, so the position is resolved against the right list.
+   *
+   * Takes a row *id* rather than an index for the same class of reason. The
+   * caller enumerates rows in backend order; this list is sorted and
+   * filtered, so an index meant one row to the search dialog and a different
+   * one to the table.
    */
-  function selectRowInTab(tabId: string, index: number) {
+  function selectRowInTab(tabId: string, rowId: string) {
     const tab = tabs.find((item) => item.id === tabId);
     if (!tab) return;
-    const tabRows = filterAndSortRows(
-      enrichInterfaceRows(buildRows(tab.result ?? null), defaultInterface?.name, trafficInterfaceName),
-      tab,
-      filterText,
+    const tabRows = enrichInterfaceRows(
+      buildRows(tab.result ?? null),
+      defaultInterface?.name,
+      trafficInterfaceName,
     );
-    if (tabRows.length === 0) return;
-    const nextIndex = clampIndex(index, tabRows.length);
+    let visible = filterAndSortRows(tabRows, tab, filterText);
+    let nextIndex = indexOfRowId(visible, rowId);
+
+    // The row exists but the active filter hides it. Clearing the filter is
+    // the only outcome that honours the request: leaving it selects nothing
+    // and says nothing, which reads as a dead control.
+    if (nextIndex === -1 && filterText) {
+      setFilterText('');
+      visible = filterAndSortRows(tabRows, tab, '');
+      nextIndex = indexOfRowId(visible, rowId);
+    }
+    if (nextIndex === -1) return;
+
     patchTab(tabId, {
       selectedIndex: nextIndex,
       selectedIndices: [nextIndex],

--- a/apps/netscli-gui/src/workspace/useWorkspace.test.tsx
+++ b/apps/netscli-gui/src/workspace/useWorkspace.test.tsx
@@ -59,6 +59,22 @@ function scanResult() {
   return { kind: 'scan', data: SCAN_PORTS } as never;
 }
 
+// Backend order, deliberately not ascending: sorted by port these become
+// 22, 80, 443, 8080, 8443, so every row's build index differs from where it
+// is rendered.
+const UNSORTED_SCAN_PORTS = [8443, 22, 443, 80, 8080].map((port) => ({
+  port,
+  open: true,
+  status: 'open',
+  service: `svc-${port}`,
+  latency_ms: 1,
+  banner: '',
+}));
+
+function unsortedScanResult() {
+  return { kind: 'scan', data: UNSORTED_SCAN_PORTS } as never;
+}
+
 describe('tab selection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -139,7 +155,7 @@ describe('tab selection', () => {
     expect(result.current.activeTabId).toBe(secondTabId);
 
     act(() => {
-      result.current.selectRowInTab(firstTabId, 3);
+      result.current.selectRowInTab(firstTabId, 'scan-port-8080-3');
     });
 
     await waitFor(() => {
@@ -153,24 +169,53 @@ describe('tab selection', () => {
     });
   });
 
-  it('clamps a jump against the target tab row count, not the active one', async () => {
+  // Was a clamp test, when this took an index. An id cannot be out of range,
+  // so what it guarded -- a stale reference must not move the selection --
+  // is now expressed as an id the tab does not hold.
+  it('leaves the selection alone for a row id the tab does not hold', async () => {
     const { result } = renderWorkspace();
     const firstTabId = result.current.activeTabId;
     act(() => {
-      result.current.patchTab(firstTabId, { result: scanResult() });
+      result.current.patchTab(firstTabId, { result: scanResult(), selectedIndex: 2, selectedIndices: [2] });
     });
     act(() => {
       result.current.addTab('arp');
     });
 
     act(() => {
-      result.current.selectRowInTab(firstTabId, 99);
+      result.current.selectRowInTab(firstTabId, 'scan-port-9999-0');
     });
 
     await waitFor(() => {
       const target = result.current.tabs.find((item) => item.id === firstTabId);
-      // 5 fixture rows, so the clamp lands on the last index.
-      expect(target?.selectedIndex).toBe(SCAN_PORTS.length - 1);
+      expect(target?.selectedIndex).toBe(2);
+    });
+  });
+
+  // The search dialog enumerates rows with `buildRows(tab.result)` -- backend
+  // order -- while the table renders `filterAndSortRows(...)`. Passing an
+  // index between the two selected whatever happened to sit at that position
+  // in the other list.
+  //
+  // The existing fixture hid this: its ports are already ascending, so build
+  // order and display order agree and any index works. These ports do not.
+  it('jumps to the row that was searched for, not the one at that position', async () => {
+    const { result } = renderWorkspace();
+    const tabId = result.current.activeTabId;
+    act(() => {
+      result.current.patchTab(tabId, { result: unsortedScanResult() });
+    });
+
+    // Port 8443 arrives first from the backend but sorts last of five.
+    act(() => {
+      result.current.selectRowInTab(tabId, 'scan-port-8443-0');
+    });
+
+    await waitFor(() => {
+      const target = result.current.tabs.find((item) => item.id === tabId);
+      // Index 4, not the 0 an index-carrying caller would have produced.
+      expect(target?.selectedIndex).toBe(4);
+      expect(result.current.rows[target?.selectedIndex ?? -1]?.data.port).toBe(8443);
     });
   });
 
@@ -178,7 +223,7 @@ describe('tab selection', () => {
     const { result } = renderWorkspace();
     expect(() => {
       act(() => {
-        result.current.selectRowInTab('no-such-tab', 3);
+        result.current.selectRowInTab('no-such-tab', 'scan-port-22-0');
       });
     }).not.toThrow();
   });

--- a/apps/netscli-gui/src/workspace/useWorkspace.ts
+++ b/apps/netscli-gui/src/workspace/useWorkspace.ts
@@ -80,6 +80,7 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
     filterText,
     patchTab,
     rows,
+    setFilterText,
     tabs,
     trafficInterfaceName,
   });

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -8,15 +8,19 @@ const transitionExceptions = new Map([
   [
     'apps/netscli-gui/src/tools/presentation.test.ts',
     {
-      maxLines: 520,
-      reason: 'broad presentation-helper fixture coverage; split by helper family next',
+      maxLines: 500,
+      reason:
+        'broad presentation-helper fixture coverage. The value/CSV helpers split out to ' +
+        'presentation.values.test.ts; row and column building are the next families out.',
     },
   ],
   [
     'apps/netscli-gui/src/styles/results.css',
     {
-      maxLines: 460,
-      reason: 'dense result/table/detail styling; split by table/detail/selection next',
+      maxLines: 435,
+      reason:
+        'dense result/table/detail styling. The error-boundary block split out to ' +
+        'error-boundary.css; table/detail/selection are the next split.',
     },
   ],
   [


### PR DESCRIPTION
## The wrong-row jump (High)

Workspace search "jump to result" selected the wrong row whenever display order differed from build order — which is always, since every tool kind has a `DEFAULT_SORT`. The dialog enumerated rows with `buildRows` in backend order and handed that index to a selection path that resolves against the sorted and filtered list.

Row ids survive both operations, so ids are what cross the boundary now. Where an active filter hides the requested row the filter is cleared, because selecting nothing silently is what made this hard to notice.

The existing tests could not have caught it: their fixture ports are already ascending, so build order and display order agree and any index works. The new fixture is deliberately unsorted.

## Four quiet failures

**CSV formula injection.** Exported cells carry banners and hostnames the scanned host chose, and Excel/LibreOffice evaluate a cell opening with `=` `+` `-` `@`, so `=HYPERLINK(...)` in a banner became a live link. Values that parse as numbers are left alone, so a negative latency stays a number.

**No error boundary.** Result-bundle import checked only that array-backed kinds got an array, so `[null]` imported cleanly and threw inside `buildRows` during render — inside a `useMemo`, past every catch. With no boundary anywhere in the app that blanked the window and took every other tab's state. Both halves are fixed.

**Silent interface polling.** Failures were swallowed on a 30s timer, so a backend that had stopped answering showed a permanent "Detecting…" and an empty interface list in the capture form. Three consecutive misses now say so, once.

**Unclamped mDNS timeout.** The one numeric field that skipped its own registry min/max, despite the comment on that field claiming otherwise.

**Leaked operation handle.** An operation whose invoke future was dropped — a webview reload mid-run — never reached the cleanup after its await. Cleanup moves into a guard constructed after registration, so it runs however the future ends.

## Verification

121 unit tests pass (up from 117). Each new test was confirmed to fail against the old code. `eslint`, `tsc -b`, `clippy -D warnings` and `cargo fmt` clean.

Audit findings #1 (High), #11, #12, #13, #43, #44.