### PR TITLE
Enforce five limits in core that only one caller was applying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ further copies in `package.json` and `tauri.conf.json`. See
 
 ## [Unreleased]
 
+### Changed
+
+- **`netscli scan --json` now reports every port, not just the open ones.**
+  Filtering to open ports made "all closed", "all filtered" and "every
+  probe errored" the same empty array, so a script could not tell a clean
+  scan from a host that refused every probe. Each entry carries `open` and
+  `status`, so callers that want only open ports can filter for them.
+
+### Fixed
+
+- **Safety limits that only one caller was applying.** `SweepEngine::sweep`
+  validates its port list instead of trusting the caller and silently
+  returning "no open ports"; mDNS browse duration, `ping -c` and packet
+  captures given a packet count but no duration all gained the core-side
+  ceiling they were documented to have.
+- **`netscli trace` no longer prints router-supplied hostnames unsanitised.**
+  Hop names come from PTR records controlled by whoever runs those routers,
+  and this was the last plain-text output path without the terminal-safety
+  pass every other one had.
+
 ## [0.3.0] — 2026-08-19
 
 ### Added

--- a/apps/netscli-cli/src/cli_dispatch/host.rs
+++ b/apps/netscli-cli/src/cli_dispatch/host.rs
@@ -2,6 +2,7 @@ use super::CommandContext;
 use crate::output::{output_format, print_structured, OutputFormat};
 use crate::trace;
 use anyhow::Result;
+use netscli_core::sanitize_for_terminal;
 
 pub(super) async fn run_ping(
     ctx: CommandContext<'_>,
@@ -44,8 +45,11 @@ pub(super) async fn run_trace(
     match format {
         OutputFormat::Json | OutputFormat::Yaml => print_structured(format, &res)?,
         OutputFormat::Text => {
+            // Hop names come from PTR records of routers on the path, which
+            // whoever runs those routers controls. This was the one plain-text
+            // path still printing remote strings unsanitised.
             for line in res.lines {
-                println!("{line}");
+                println!("{}", sanitize_for_terminal(&line));
             }
         }
     }

--- a/apps/netscli-cli/src/cli_dispatch/scan.rs
+++ b/apps/netscli-cli/src/cli_dispatch/scan.rs
@@ -42,8 +42,13 @@ pub(super) async fn run_scan(
     let results = commands::run_scan(ctx.ops, ctx.db, host, ports).await?;
     match format {
         OutputFormat::Json | OutputFormat::Yaml => {
-            let open: Vec<_> = results.iter().filter(|p| p.open).cloned().collect();
-            print_structured(format, &open)?;
+            // Every port, not just the open ones. Filtering here made "all
+            // closed", "all filtered" and "every probe errored" the same
+            // empty array, so a script could not tell a clean scan from a
+            // host that refused every probe -- a distinction the text
+            // formatter has always shown. Each entry carries `open` and
+            // `status`, so callers that want only open ports still can.
+            print_structured(format, &results)?;
         }
         OutputFormat::Text => {
             println!(

--- a/apps/netscli-cli/src/tui/runtime.rs
+++ b/apps/netscli-cli/src/tui/runtime.rs
@@ -17,7 +17,9 @@ pub async fn run_tui(concurrency: Option<usize>) -> Result<()> {
     let mut app = TuiApp::new();
     app.settings = crate::tui_settings::load_settings();
     if let Some(concurrency) = concurrency {
-        app.concurrency_override = Some(concurrency.clamp(1, 1024));
+        app.concurrency_override = Some(crate::tui_settings::clamp_max_concurrent_probes(
+            concurrency,
+        ));
     }
     app.apply_settings();
     let mut tasks = TaskRuntime::new();

--- a/apps/netscli-cli/src/tui_settings.rs
+++ b/apps/netscli-cli/src/tui_settings.rs
@@ -47,7 +47,11 @@ pub struct TuiSettings {
 }
 
 pub fn clamp_max_concurrent_probes(value: usize) -> usize {
-    value.clamp(1, 1024)
+    // Derived, not repeated. A literal here matched `MAX_CONCURRENCY` by
+    // coincidence, and C-10 was exactly that coincidence lapsing: the MCP
+    // server clamped to 4096 while `Ops` clamped to 1024, so values in
+    // between were accepted at the boundary and silently reduced.
+    value.clamp(1, netscli_core::MAX_CONCURRENCY)
 }
 
 fn normalize_settings(mut settings: TuiSettings) -> TuiSettings {

--- a/crates/netscli-core/src/common.rs
+++ b/crates/netscli-core/src/common.rs
@@ -5,7 +5,7 @@ mod terminal;
 
 pub use constants::{
     DEFAULT_CONCURRENCY, DEFAULT_DNS_TIMEOUT_MS, DEFAULT_PING_TIMEOUT_MS, DEFAULT_PORTS,
-    DEFAULT_SCAN_TIMEOUT_MS, DEFAULT_SUBNET,
+    DEFAULT_SCAN_TIMEOUT_MS, DEFAULT_SUBNET, MAX_MDNS_TIMEOUT_MS, MAX_PING_COUNT,
 };
 pub use network::{
     default_ipv4_subnet_string, detect_default_ipv4_addr, detect_default_ipv4_subnet,

--- a/crates/netscli-core/src/common/constants.rs
+++ b/crates/netscli-core/src/common/constants.rs
@@ -4,3 +4,19 @@ pub const DEFAULT_CONCURRENCY: usize = 256;
 pub const DEFAULT_SCAN_TIMEOUT_MS: u64 = 500;
 pub const DEFAULT_PING_TIMEOUT_MS: u64 = 1000;
 pub const DEFAULT_DNS_TIMEOUT_MS: u64 = 1500;
+
+/// Longest an mDNS browse will run.
+///
+/// This was the one engine knob with no core-side ceiling: `netscli mdns
+/// --timeout-ms 86400000` blocked for a day. The TUI clamped to this value
+/// itself, which is exactly the per-surface divergence the limits in this
+/// crate exist to prevent.
+pub const MAX_MDNS_TIMEOUT_MS: u64 = 30_000;
+
+/// Most pings a single `ping_host_summary` call will send.
+///
+/// The loop is sequential and each iteration waits up to `ping_timeout_ms`,
+/// so an unbounded count multiplies straight into wall-clock time: 256 pings
+/// at the 10-minute ceiling is roughly 42 hours. Every other engine knob is
+/// clamped in core; this one was not.
+pub const MAX_PING_COUNT: u32 = 256;

--- a/crates/netscli-core/src/lib.rs
+++ b/crates/netscli-core/src/lib.rs
@@ -24,7 +24,8 @@ pub use common::{
     default_ipv4_subnet_string, default_ports, detect_default_ipv4_addr,
     detect_default_ipv4_subnet, parse_ports, parse_ports_checked, sanitize_for_terminal,
     validate_ports, DEFAULT_CONCURRENCY, DEFAULT_DNS_TIMEOUT_MS, DEFAULT_PING_TIMEOUT_MS,
-    DEFAULT_PORTS, DEFAULT_SCAN_TIMEOUT_MS, DEFAULT_SUBNET, MAX_PORTS_PER_SCAN,
+    DEFAULT_PORTS, DEFAULT_SCAN_TIMEOUT_MS, DEFAULT_SUBNET, MAX_MDNS_TIMEOUT_MS, MAX_PING_COUNT,
+    MAX_PORTS_PER_SCAN,
 };
 #[cfg(feature = "db")]
 pub use db::{Database, HostRecord, ScanHistoryRecord};

--- a/crates/netscli-core/src/ops/host.rs
+++ b/crates/netscli-core/src/ops/host.rs
@@ -12,6 +12,10 @@ impl Ops {
     }
 
     pub async fn ping_host_summary(&self, host: &str, count: u32) -> Result<PingSummary> {
+        // Clamped, not rejected: asking for more pings than the cap is a
+        // request for "a lot", and the loop below is sequential, so the count
+        // multiplies directly into how long this call blocks.
+        let count = count.min(crate::MAX_PING_COUNT);
         let ip = self.resolve_host_ip(host).await?;
         let scanner = PingScanner::new(1);
         let mut sent: u32 = 0;

--- a/crates/netscli-core/src/ops/network.rs
+++ b/crates/netscli-core/src/ops/network.rs
@@ -18,6 +18,12 @@ impl Ops {
         service_types: &[String],
         timeout: std::time::Duration,
     ) -> Result<Vec<crate::mdns::MdnsService>> {
+        // Clamp rather than reject: a browse is a "wait this long" request,
+        // not an addressing mistake, so trimming an over-long wait gives the
+        // caller results instead of an error. The engines are the authority
+        // on their own limits -- `Ops` used to pass this straight through,
+        // leaving the TUI as the only surface that bounded it.
+        let timeout = timeout.min(std::time::Duration::from_millis(crate::MAX_MDNS_TIMEOUT_MS));
         if service_types.is_empty() {
             crate::mdns::MdnsEngine::discover_common(timeout).await
         } else {

--- a/crates/netscli-core/src/ops/pcap.rs
+++ b/crates/netscli-core/src/ops/pcap.rs
@@ -115,7 +115,12 @@ fn normalize_capture_limits(
         None if max_packets.is_none() => {
             Some(std::time::Duration::from_secs(DEFAULT_PCAP_CAPTURE_SECONDS))
         }
-        None => None,
+        // A packet count with no duration used to mean "no time limit at
+        // all", so a capture waiting for packets that never arrive on a quiet
+        // interface ran until something else stopped it -- past the very
+        // ceiling this function enforces when a duration *is* given. The cap
+        // is the cap either way.
+        None => Some(std::time::Duration::from_secs(MAX_PCAP_CAPTURE_SECONDS)),
     };
 
     Ok((duration, max_packets))

--- a/crates/netscli-core/src/oui.rs
+++ b/crates/netscli-core/src/oui.rs
@@ -81,15 +81,31 @@ fn read_map(path: &Path) -> Option<HashMap<String, String>> {
         let bytes = fs::read(path).ok()?;
         parse_gz(&bytes)
     } else {
-        let data = fs::read_to_string(path).ok()?;
+        let file = fs::File::open(path).ok()?;
+        let mut data = String::new();
+        std::io::Read::take(file, MAX_OUI_BYTES)
+            .read_to_string(&mut data)
+            .ok()?;
         parse_json(&data)
     }
 }
 
+/// Ceiling on the OUI dataset, compressed or not.
+///
+/// The bundled file is 1.3 MB decompressed, so this leaves room for a much
+/// larger vendor list while refusing an implausible one. `NETSCLI_OUI_PATH`
+/// points this at an arbitrary file, and the gzip path amplifies: a few
+/// hundred KB on disk can decompress without limit into a `String`.
+const MAX_OUI_BYTES: u64 = 32 * 1024 * 1024;
+
 fn parse_gz(bytes: &[u8]) -> Option<HashMap<String, String>> {
-    let mut decoder = flate2::read::GzDecoder::new(bytes);
+    let decoder = flate2::read::GzDecoder::new(bytes);
     let mut buf = String::new();
-    decoder.read_to_string(&mut buf).ok()?;
+    // Bounded read: a truncated result fails `parse_json` rather than being
+    // silently accepted as a short vendor list.
+    std::io::Read::take(decoder, MAX_OUI_BYTES)
+        .read_to_string(&mut buf)
+        .ok()?;
     parse_json(&buf)
 }
 

--- a/crates/netscli-core/src/sweep.rs
+++ b/crates/netscli-core/src/sweep.rs
@@ -87,6 +87,13 @@ impl SweepEngine {
         resolve_hostnames: bool,
         progress: Option<Arc<dyn Fn(SweepProgress) + Send + Sync>>,
     ) -> Result<Vec<SweepEntry>> {
+        // Validate before the ping phase, not after it. This is public API
+        // re-exported at the crate root, and it used to trust the caller: a
+        // library caller passing port 0 got a full slow ping sweep and then a
+        // plausible result where every host had no open ports, because the
+        // per-host error below is deliberately swallowed. The comment there
+        // claiming the caller had already validated is only true now.
+        crate::validate_ports(&ports)?;
         let discover_progress = progress.clone().map(|cb| {
             Arc::new(move |p: crate::discover::DiscoverProgress| {
                 let phase = match p.phase {

--- a/crates/netscli-core/tests/config_safety.rs
+++ b/crates/netscli-core/tests/config_safety.rs
@@ -173,3 +173,47 @@ async fn engines_clamp_absurd_concurrency_instead_of_panicking() {
     let _ = netscli_core::SweepEngine::new(usize::MAX);
     let _ = netscli_core::InspectEngine::new(usize::MAX);
 }
+
+// Each case below reached a real engine before this: the limits existed in
+// the crate's documentation and in one caller, but not in the code path a
+// library consumer or another surface actually took.
+
+#[tokio::test]
+async fn sweep_engine_rejects_bad_ports_before_the_ping_phase() {
+    // Port 0 used to survive all the way through: `sweep_with_progress` is
+    // public API and trusted its caller, then swallowed the per-host scan
+    // error, so this produced a full slow ping sweep and a plausible result
+    // where every host simply had no open ports.
+    let engine = netscli_core::SweepEngine::new(64);
+    let err = engine
+        .sweep("192.168.1.0/30".parse().unwrap(), vec![0], false)
+        .await
+        .expect_err("port 0 must be refused by the engine");
+    assert!(
+        err.to_string().contains("port") || err.to_string().contains("0"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn mdns_timeout_has_a_core_side_ceiling() {
+    // The TUI clamped this itself, which left `netscli mdns --timeout-ms
+    // 86400000` blocking for a day on every other surface.
+    assert_eq!(netscli_core::MAX_MDNS_TIMEOUT_MS, 30_000);
+}
+
+#[tokio::test]
+async fn ping_count_is_clamped_rather_than_unbounded() {
+    // The loop is sequential, so the count multiplies straight into
+    // wall-clock time. Only the summary's `sent` reveals the clamp.
+    let ops = netscli_core::Ops::new(netscli_core::OpsConfig {
+        ping_timeout_ms: 1,
+        dns_timeout_ms: 200,
+        ..Default::default()
+    });
+    let summary = ops
+        .ping_host_summary("127.0.0.1", netscli_core::MAX_PING_COUNT + 500)
+        .await
+        .expect("loopback ping summary");
+    assert_eq!(summary.sent, netscli_core::MAX_PING_COUNT);
+}

--- a/crates/netscli-core/tests/config_safety.rs
+++ b/crates/netscli-core/tests/config_safety.rs
@@ -81,7 +81,13 @@ async fn ping_scanner_concurrency_zero_returns_result() {
     let res = scanner.ping(IpAddr::V4(Ipv4Addr::LOCALHOST), 10).await;
 
     assert_eq!(res.ip, IpAddr::V4(Ipv4Addr::LOCALHOST));
-    assert_eq!(res.seq, 1);
+    // `PING_SEQ` is a process-global counter and cargo runs every test in one
+    // process, so the old `seq == 1` held only while this happened to be the
+    // first ping in the binary. Any later test that pings -- and one now does
+    // -- reorders that by thread scheduling alone. What this test is actually
+    // about is that concurrency 0 returns a usable result instead of hanging,
+    // so assert the sequence is allocated, not that it is first.
+    assert!(res.seq >= 1);
     assert!(res.method.is_some());
 }
 


### PR DESCRIPTION
Each of these existed as a documented limit, or as a clamp in exactly one surface, but not in the code path a library consumer or another surface actually took.

- **`SweepEngine::sweep*` trusted its caller's port list**, then swallowed the per-host scan error — so passing port 0 produced a full slow ping sweep and a plausible result where every host had no open ports. The comment claiming the caller had already validated is only true now.
- **mDNS browse duration had no core-side ceiling.** The TUI clamped it to 30s itself, leaving `netscli mdns --timeout-ms 86400000` to block for a day everywhere else — the per-surface divergence these limits exist to prevent.
- **`ping -c` had no upper bound**, and the loop is sequential, so the count multiplies straight into wall-clock time. Without the clamp the new test sends 756 probes and the suite takes 35s instead of 12s.
- **A capture given a max-packet count but no duration had no time limit at all**, so on a quiet interface it ran past the very ceiling `normalize_capture_limits` enforces when a duration is supplied.
- **The TUI repeated `1024` as a literal** where `MAX_CONCURRENCY` was meant. It agreed by coincidence, and C-10 was that coincidence lapsing.

Two things that are not limits, in the same area:

- **`netscli trace` printed hop lines straight to the terminal.** Hop names come from PTR records of routers on the path, so they are chosen by whoever runs those routers. This was the last plain-text path still unsanitised.
- **`netscli scan --json` filtered to open ports**, making "all closed", "all filtered" and "every probe errored" the same empty array. It now emits every result, as the text formatter always has. Each entry carries `open` and `status`, so callers wanting only open ports still can. **This is a user-visible output change** and is recorded in the changelog.

The OUI dataset is also read through a bounded reader — `NETSCLI_OUI_PATH` points it at an arbitrary file and the gzip path amplifies. The bundled file is 1.3 MB decompressed against a 32 MB ceiling.

## Verification

15 config-safety tests pass (up from 12). The two behavioural additions were confirmed to fail against the old code. Full workspace: `cargo fmt`, `clippy -D warnings`, all tests green.

Audit findings #8, #9, #10, #34, #35, #36, #37, #42.