### PR TITLE
Correct the documentation against what the code actually does

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,13 @@ netscli/
       src/              #   React frontend
       src-tauri/        #   Tauri Rust backend
   scripts/              # OUI generator, install scripts (excluded from workspace)
-  data/                 # Static datasets (oui.min.json.gz)
+  site/                 # Astro/Starlight landing page + docs (netscli.com)
+  docs/                 # Repo-internal docs (ARCHITECTURE, PUBLISHING, RELEASE) + assets
+  packaging/            # Distribution manifests and installer templates
 ```
+
+The OUI dataset ships inside the core crate at
+`crates/netscli-core/data/oui.min.json.gz`.
 
 **Dependency flow**: the `netscli` package (at `apps/netscli-cli/`) and `netscli-gui/src-tauri` depend on `netscli-core`. `netscli-mcp` wraps `netscli-core`. The `netscli` package also depends on `netscli-mcp`.
 
@@ -51,6 +56,7 @@ cd apps/netscli-gui && npm run test:tauri-render  # Tauri render automation
 # Linting & formatting
 cargo fmt                                     # apply rustfmt
 cargo clippy --all-targets -- -D warnings     # lint with warnings as errors
+cd apps/netscli-gui && npm run lint            # ESLint for the GUI frontend
 
 # OUI database refresh
 cd scripts && cargo run --bin generate-oui
@@ -76,8 +82,9 @@ cd scripts && cargo run --bin generate-oui
 | `pnet_packet/transport/datalink` | Raw networking |
 | `hickory-resolver` | Async DNS resolution |
 | `pcap` | Packet capture (optional feature) |
-| `clap` 4.4 (derive) | CLI argument parsing |
-| `ratatui` 0.29 + `crossterm` 0.27 | Terminal UI |
+| `clap` 4.6 (derive) | CLI argument parsing |
+| `ratatui` 0.30 + `crossterm` 0.29 | Terminal UI |
+| `ratatui-textarea` 0.9 | TUI input editing (replaced `tui-textarea`) |
 | `tauri` 2.0 | Desktop GUI framework |
 | React 19 + Vite + TypeScript | GUI frontend |
 
@@ -111,7 +118,8 @@ All network operations are async (tokio). Long-running operations accept progres
 
 - Guard with `#[cfg(unix)]` / `#[cfg(windows)]`
 - Windows: `ipconfig` crate for interfaces, `windows-sys` for WinSock, `tracert` command
-- Unix: `pnet_datalink`/`pnet_sys` for raw sockets, manual ICMP TTL probes for traceroute
+- Unix: `pnet_datalink`/`pnet_sys` for raw sockets
+- Traceroute shells out on every platform (`crates/netscli-core/src/trace.rs`): `tracert` on Windows, `traceroute` with a `tracepath` fallback elsewhere. There are no manual ICMP TTL probes.
 
 ## Core Modules (netscli-core/src/)
 
@@ -121,35 +129,41 @@ All network operations are async (tokio). Long-running operations accept progres
 | `ops.rs` | High-level operations facade (used by CLI, TUI, GUI, MCP) |
 | `common.rs` | Default constants (ports, timeouts, concurrency) |
 | `discover.rs` | Subnet host discovery (ping + DNS resolve) |
-| `scan.rs` | TCP port scanning with concurrency |
+| `scan/` | TCP port scanning with concurrency |
 | `ping.rs` | ICMP/TCP ping with dual backends (raw ICMP + TCP fallback) |
 | `arp.rs` | ARP table retrieval + MAC vendor lookup |
 | `oui.rs` | MAC vendor database (compressed gzip JSON) |
 | `dns.rs` | DNS lookup (A, AAAA, CNAME, MX, NS, TXT, SRV, PTR, SOA, CAA) |
 | `inspect.rs` | Combined host analysis (ping + scan + resolve) |
 | `sweep.rs` | Full network sweep (discover + scan all hosts) |
+| `trace.rs` | Traceroute; shells out to the platform tool |
+| `mdns.rs` | mDNS/DNS-SD device discovery (behind `mdns` feature flag) |
 | `pcap.rs` | Packet capture (behind `pcap` feature flag) |
 | `stats.rs` | Real-time traffic monitoring (sysinfo) |
 | `db.rs` | SQLite persistence (hosts table, scan_history table) |
+| `error.rs` | Typed error enum shared by the core |
 
 ## CLI App Files (apps/netscli-cli/src/)
 
 | File | Purpose |
 |------|---------|
-| `main.rs` | Entry point, subcommand dispatch, TUI launcher |
+| `main.rs` | Entry point and TUI launcher |
 | `args.rs` | Clap argument definitions and subcommand enums |
-| `tui.rs` | Interactive TUI main loop (ratatui) |
-| `formatter.rs` | TUI output formatting (ratatui Spans/Lines) |
-| `cli_formatter.rs` | Plain-text CLI output formatting |
+| `cli_dispatch.rs` + `cli_dispatch/` | Subcommand dispatch and per-command handlers |
+| `commands.rs` | Per-command business logic shared by the CLI and TUI |
+| `output.rs` | `--json`/`--yaml` output-format selection |
+| `tui/` | Interactive TUI (state, events, runtime, widgets, command catalog) |
+| `tui_formatter.rs` + `tui_formatter/` | TUI output formatting (ratatui Spans/Lines) |
+| `cli_formatter.rs` + `cli_formatter/` | Plain-text CLI output formatting |
 | `tui_settings.rs` | TUI config persistence (~/.netscli/tui-settings.json) |
 | `tui_export.rs` | Session export (Markdown/JSON) |
-| `trace.rs` | Traceroute (platform-specific implementations) |
-| `setup.rs` | First-run dependency wizard |
+| `trace.rs` | Re-export of `netscli_core::trace_route`; the implementation lives in the core |
+| `setup.rs` + `setup/` | First-run dependency wizard |
 | `mcp_service.rs` | Systemd service management (Linux) |
 
 ## Safety Limits
 
-Enforced in `ops.rs` and `server.rs`. Do not weaken without discussion.
+Enforced in `ops/validation.rs` (subnet size) and `common/ports/` (port count), and re-checked inside the engines themselves so a direct engine call cannot bypass them. Do not weaken without discussion.
 
 - Max subnet size: /16 (65,536 hosts)
 - Max port count per scan: 4,096
@@ -161,6 +175,9 @@ Enforced in `ops.rs` and `server.rs`. Do not weaken without discussion.
 - `pcap` — Enables packet capture (requires libpcap/Npcap at runtime)
   - Must be enabled on **all three**: `netscli-core`, `netscli-mcp`, `netscli-cli`
   - Chain: `netscli-cli/pcap` → `netscli-core/pcap` + `netscli-mcp/pcap` → `netscli-core/pcap`
+  - Off by default everywhere, including the published installers
+- `mdns` — Enables mDNS/DNS-SD discovery. Pure Rust (`mdns-sd`), no system dependency. Off in `netscli-core`'s defaults, but on in `netscli-mcp`'s and enabled explicitly by `netscli`, so every published build has it
+- `db` — Enables the `db` module and `Database` type (SQLite via sqlx). Off in `netscli-core`'s defaults, enabled by `netscli`
 
 ## Coding Style & Conventions
 
@@ -168,7 +185,7 @@ Enforced in `ops.rs` and `server.rs`. Do not weaken without discussion.
 - Prefer idiomatic Rust naming: `snake_case` modules/functions, `CamelCase` types
 - Crates use `kebab-case` names (e.g., `netscli-core`)
 - GUI frontend: TypeScript with React functional components, no class components
-- No dedicated JS/TS linter configured; keep changes aligned with existing patterns
+- GUI lint: ESLint via `apps/netscli-gui/eslint.config.js` (`npm run lint`)
 - Output formats: CLI subcommands support `--json` and `--yaml` flags
 
 ## Testing
@@ -181,7 +198,9 @@ Enforced in `ops.rs` and `server.rs`. Do not weaken without discussion.
 
 ## CLI Subcommands
 
-`discover`, `scan`, `inspect`, `sweep`, `ping`, `trace`, `dns`, `reverse`, `arp`, `interfaces`, `mdns`, `pcap`, `serve` (MCP server), `mcp-service`, `config`, `export`, `setup`, `doctor`
+`discover`, `scan`, `inspect`, `sweep`, `ping`, `trace`, `dns`, `reverse`, `arp`, `interfaces`, `mdns`, `serve` (MCP server), `mcp-service`, `completions`, `man`, `setup`, `doctor` — plus `pcap` when built with the `pcap` feature
+
+`config` and `export` are TUI slash-commands only (`/config`, `/export`); they are not CLI subcommands. The authoritative list is the `Commands` enum in `apps/netscli-cli/src/args.rs`.
 
 ## MCP Tools (9 default, 13 with `pcap` feature)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ cd apps/netscli-gui && npm run test:tauri-render  # Tauri render automation
 # Linting & formatting
 cargo fmt                                     # apply rustfmt
 cargo clippy --all-targets -- -D warnings     # lint with warnings as errors
-cd apps/netscli-gui && npm run lint            # ESLint for the GUI frontend
+cd apps/netscli-gui && npm run lint           # ESLint for the GUI frontend
 
 # OUI database refresh
 cd scripts && cargo run --bin generate-oui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,18 @@ further copies in `package.json` and `tauri.conf.json`. See
 - **Linux/macOS install docs clarified.** mDNS is documented as the default
   pure-Rust capability in published builds, while packet capture remains
   the optional workflow that depends on libpcap/Npcap support.
+- **Website rebuilt for every screen width.** The landing page and docs were
+  swept across six widths and both themes, and the shell, navigation, contents
+  list, colour and typography were reworked to hold up at all of them. The
+  brand accent moved from a teal-green that read blue in small text to one that
+  reads green at any size, and contrast improved with it.
+  ([#190](https://github.com/fstubner/netscli/pull/190)–[#209](https://github.com/fstubner/netscli/pull/209))
+- **Search, head metadata and page titles rewritten** so the site describes
+  what it is rather than repeating adjectives.
+  ([#204](https://github.com/fstubner/netscli/pull/204))
+- **Per-PR site previews on Cloudflare Pages**, and GitHub Pages deploys are
+  manual-only. ([#165](https://github.com/fstubner/netscli/pull/165),
+  [#136](https://github.com/fstubner/netscli/pull/136))
 
 ### Changed (internal)
 
@@ -84,6 +96,23 @@ further copies in `package.json` and `tauri.conf.json`. See
   and license installation, Winget/Scoop/Homebrew reference manifests were
   refreshed, and packaging validation commands were added to the release
   checklist.
+- **CI gates report unconditionally**, so branch protection can require them,
+  and both required checks were closed against a job that fails without
+  failing the gate. ([#161](https://github.com/fstubner/netscli/pull/161),
+  [#187](https://github.com/fstubner/netscli/pull/187))
+- **The end-to-end suite can now fail.** Several scenarios were structurally
+  incapable of it. ([#199](https://github.com/fstubner/netscli/pull/199))
+- **The Tauri render suite is schedule-only** and no longer gates releases.
+  ([#178](https://github.com/fstubner/netscli/pull/178))
+- **A dead-CSS budget runs in CI**, holding the docs override stack at its
+  current 126 provably shadowed declarations.
+  ([#207](https://github.com/fstubner/netscli/pull/207))
+- **Node 22, jsdom 30, ESLint 10, react-hooks 7**, and three Rust dependency
+  bumps. ([#187](https://github.com/fstubner/netscli/pull/187)–[#189](https://github.com/fstubner/netscli/pull/189))
+- **Release pipeline hardened**: tag validation on the AUR jobs, a checksum
+  that could be contaminated by progress output, and the publish long tail.
+  ([#158](https://github.com/fstubner/netscli/pull/158),
+  [#200](https://github.com/fstubner/netscli/pull/200))
 
 ### Fixed
 
@@ -122,41 +151,6 @@ further copies in `package.json` and `tauri.conf.json`. See
   advertised a version that was never released.
   ([#194](https://github.com/fstubner/netscli/pull/194),
   [#208](https://github.com/fstubner/netscli/pull/208))
-
-### Changed
-
-- **Website rebuilt for every screen width.** The landing page and docs were
-  swept across six widths and both themes, and the shell, navigation, contents
-  list, colour and typography were reworked to hold up at all of them. The
-  brand accent moved from a teal-green that read blue in small text to one that
-  reads green at any size, and contrast improved with it.
-  ([#190](https://github.com/fstubner/netscli/pull/190)–[#209](https://github.com/fstubner/netscli/pull/209))
-- **Search, head metadata and page titles rewritten** so the site describes
-  what it is rather than repeating adjectives.
-  ([#204](https://github.com/fstubner/netscli/pull/204))
-- **Per-PR site previews on Cloudflare Pages**, and GitHub Pages deploys are
-  manual-only. ([#165](https://github.com/fstubner/netscli/pull/165),
-  [#136](https://github.com/fstubner/netscli/pull/136))
-
-### Changed (internal)
-
-- **CI gates report unconditionally**, so branch protection can require them,
-  and both required checks were closed against a job that fails without
-  failing the gate. ([#161](https://github.com/fstubner/netscli/pull/161),
-  [#187](https://github.com/fstubner/netscli/pull/187))
-- **The end-to-end suite can now fail.** Several scenarios were structurally
-  incapable of it. ([#199](https://github.com/fstubner/netscli/pull/199))
-- **The Tauri render suite is schedule-only** and no longer gates releases.
-  ([#178](https://github.com/fstubner/netscli/pull/178))
-- **A dead-CSS budget runs in CI**, holding the docs override stack at its
-  current 210 provably shadowed declarations.
-  ([#207](https://github.com/fstubner/netscli/pull/207))
-- **Node 22, jsdom 30, ESLint 10, react-hooks 7**, and three Rust dependency
-  bumps. ([#187](https://github.com/fstubner/netscli/pull/187)–[#189](https://github.com/fstubner/netscli/pull/189))
-- **Release pipeline hardened**: tag validation on the AUR jobs, a checksum
-  that could be contaminated by progress output, and the publish long tail.
-  ([#158](https://github.com/fstubner/netscli/pull/158),
-  [#200](https://github.com/fstubner/netscli/pull/200))
 
 ## [0.2.6] — 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ like "what's the IP of the device that just joined" or "is port 22 open
 on 192.168.1.42". Existing tools work but they aren't great to drive from
 an agent. Half a dozen CLI invocations, brittle output parsing, no shared
 context. So I built an MCP server first. `netscli serve`, nine tools by
-default (ten in the `-pcap` build), JSON-RPC over stdio, structured results.
+default (13 in the `-pcap` build), JSON-RPC over stdio, structured results.
 
 Then the TUI. Coding agents like Claude Code have put real work into
 autocomplete, command history, in-place progress, and mouse selection
@@ -505,7 +505,7 @@ The MCP server exposes 9 tools by default (13 in `-pcap` builds, which add `capt
 1. `discover_network` - Discover live hosts on a network subnet
 2. `scan_ports` - Scan TCP ports on a host
 3. `ping_host` - Ping a host with statistics
-4. `dns_lookup` - DNS lookup (forward or reverse)
+4. `dns_lookup` - Forward DNS lookup, all record types (reverse lookups are not exposed over MCP)
 5. `get_arp_table` - Get ARP/neighbor table with vendor information
 6. `inspect_host` - Comprehensive host inspection
 7. `sweep_network` - Sweep a network (discover hosts then scan ports)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,6 +70,13 @@ Dependency scanning also has a blind spot worth naming: `npm audit
 --omit=dev` excludes the build toolchain that produces the shipped bundle,
 so a compromised bundler is not something the current checks would catch.
 
+Packet capture on Windows is covered by no test at all. The
+`--features pcap` test steps in `.github/workflows/ci.yml` are gated
+`if: runner.os == 'Linux'`, and the feature cannot even be built on Windows
+without the Npcap SDK installed — without it the link step fails with
+`LNK1181: cannot open input file 'wpcap.lib'`. So the Npcap paths, which are
+the reason the feature matters on Windows, are exercised by nothing anywhere.
+
 If you are picking this up, treat those four areas as unaudited rather than
 as reviewed and clean.
 

--- a/crates/netscli-mcp/README.md
+++ b/crates/netscli-mcp/README.md
@@ -14,7 +14,8 @@ same MCP surface inside a different host process.
 - `discover_network` — live hosts on a subnet.
 - `scan_ports` — TCP port scan on a host.
 - `ping_host` — ping with packet-loss and RTT statistics.
-- `dns_lookup` — forward or reverse DNS, all record types.
+- `dns_lookup` — forward DNS, all record types. Reverse lookups are
+  not exposed over MCP.
 - `get_arp_table` — ARP/neighbour table with vendor resolution.
 - `inspect_host` — comprehensive host inspection (ping + scan + DNS).
 - `sweep_network` — discovery + port scan in one call.

--- a/site/README.md
+++ b/site/README.md
@@ -3,22 +3,27 @@
 Astro site that GitHub Pages serves for this project. The deploy
 workflow lives at `.github/workflows/pages.yml`.
 
-Everything project-specific lives in `src/data/site.ts`. Fork the site
-into another repo and that's the one file you edit to retarget the
-landing at a different product — title, description, install commands,
-FAQ, surface cards, screenshots, built-with stack, version.
+Everything project-specific lives in `src/data/site-content/`. Fork the
+site into another repo and that's the one directory you edit to retarget
+the landing at a different product — title, description, install commands,
+FAQ, surface cards, screenshots, built-with stack, version. `src/data/site.ts`
+assembles those files into the single `site` export every component reads.
 
 ## Layout
 
 ```
 site/
-├── astro.config.mjs          — canonical site URL
-├── package.json              — astro dep, npm scripts
+├── astro.config.mjs          — canonical site URL, Starlight docs config
+├── package.json              — astro + starlight deps, npm scripts
 ├── tsconfig.json             — extends astro/tsconfigs/strict
+├── scripts/                  — a11y, file-size and dead-CSS checks run in CI
 ├── public/                   — static passthrough (favicon, CNAME, images…)
 ├── src/
-│   ├── data/site.ts          — all project-specific content
-│   ├── styles/global.css     — theme + layout + section styles
+│   ├── data/site-content/    — all project-specific content
+│   ├── data/site.ts          — assembles site-content into the `site` export
+│   ├── content/docs/         — Starlight docs pages (Markdown)
+│   ├── styles/               — tokens, global styles, Starlight overrides
+│   ├── scripts/              — client-side TypeScript for the landing + docs
 │   ├── layouts/Page.astro    — meta, OG, JSON-LD schema
 │   ├── components/*.astro    — Nav, Hero, Surfaces, Install, Faq, Footer
 │   └── pages/index.astro     — page composition + client script
@@ -35,7 +40,7 @@ npm run build      # static output into dist/
 npm run preview    # serve dist/
 ```
 
-Node 22+ is required. Astro 6.
+Node 22+ is required. Astro 7 with Starlight.
 
 ## How the download count works
 
@@ -46,17 +51,19 @@ the public GitHub REST API on page load:
 - `GET /repos/{owner}/{repo}/releases` → sums `download_count` across
   all release assets.
 
-The repo slug comes from `site.social.repo` in `src/data/site.ts`.
+The repo slug comes from `site.social.repo`, set in
+`src/data/site-content/footer.ts`.
 
-If the user is rate-limited (unauthenticated API calls get 60/hour per
-IP), the requests fail silently and the em-dash placeholders stay
-visible. We never show "0 downloads" — it's always either a real
-number or a dash.
+Each metric starts hidden and is only revealed once a request confirms
+it. If the user is rate-limited (unauthenticated API calls get 60/hour
+per IP), the requests fail silently and the metric stays hidden, along
+with the separator beside it. We never show "0 downloads" or a stale
+placeholder — it's a real number or nothing.
 
 ## Analytics
 
-`src/data/site.ts` → `analytics.cloudflareToken` controls the
-Cloudflare Web Analytics beacon. Set to a string token to enable, or
+`src/data/site-content/footer.ts` → `analytics.cloudflareToken` controls
+the Cloudflare Web Analytics beacon. Set to a string token to enable, or
 remove the property to disable.
 
 Cloudflare Web Analytics is free with unlimited pageviews, sets no
@@ -84,7 +91,7 @@ reason.
 The Astro scaffold was designed to be trivially retargetable:
 
 1. Copy the entire `site/` directory to the new repo.
-2. Edit `src/data/site.ts` — name, description, install commands,
+2. Edit `src/data/site-content/` — name, description, install commands,
    FAQ items, surface cards, built-with list, GitHub repo slug.
 3. Replace the images the site actually renders: `public/gui-scan.png`
    and its `.webp`, `public/assets/tui-discover.png` and its `.webp`,

--- a/site/src/content/docs/docs/desktop.md
+++ b/site/src/content/docs/docs/desktop.md
@@ -47,7 +47,7 @@ Supported operations include:
 - mDNS Discovery
 - Interfaces
 - ARP Table
-- Packet Capture when packet-capture support is enabled
+- Packet Capture, which is always listed but only runs on a capture-enabled build
 
 ## Filters
 
@@ -119,7 +119,7 @@ Settings control:
 
 Most desktop tools are available in the standard desktop build. Packet capture is handled explicitly:
 
-- Packet Capture appears only in builds that include packet-capture support. Capturing packets also needs Npcap on Windows or libpcap on Linux/macOS.
+- Packet Capture stays in the tool list in every build. Running a capture needs a build that includes packet-capture support, plus Npcap on Windows or libpcap on Linux/macOS. Without those, the tab opens and shows setup guidance instead of running.
 - mDNS Discovery is included in the standard published desktop build.
-- If a feature is not available in the current build, the desktop app hides that tool.
+- A tool whose feature is genuinely absent from the build is hidden. That applies to mDNS Discovery; Packet Capture is the deliberate exception, because the published installers ship without it and a hidden tab explained nothing.
 - If a required runtime library is missing, only that feature is unavailable. The rest of the desktop app keeps working and shows setup guidance for the missing dependency.

--- a/site/src/content/docs/docs/interface-coverage.md
+++ b/site/src/content/docs/docs/interface-coverage.md
@@ -55,7 +55,7 @@ The MCP server exposes shared network operations to AI-agent clients. It does no
 
 Most NetsCLI operations work in the standard published builds. A few capabilities depend on how the app was packaged or what is installed on the machine:
 
-- Packet Capture appears only in builds that include packet-capture support. Capturing packets also needs Npcap on Windows or libpcap on Linux/macOS.
+- Packet capture runs only on builds that include packet-capture support, and also needs Npcap on Windows or libpcap on Linux/macOS. On the CLI the `pcap` subcommand is absent from standard builds.
 - mDNS discovery is included in the published CLI, desktop app, and MCP server. Library consumers can still build `netscli-core` without the `mdns` feature if they need a leaner dependency set.
 - The desktop app keeps Packet Capture visible even in builds without capture support, and shows setup guidance in place of results. Tools whose feature is genuinely absent from the build, such as mDNS discovery, are hidden.
 - If a runtime dependency is missing, NetsCLI keeps the rest of the app usable and explains what to install for that feature.

--- a/site/src/content/docs/docs/tui.md
+++ b/site/src/content/docs/docs/tui.md
@@ -30,7 +30,7 @@ Common interactive commands mirror the CLI operations:
 
 ```text
 /discover 192.168.1.0/24
-/scan 192.168.1.1 -p 22,80,443
+/scan 192.168.1.1 22,80,443
 /sweep 192.168.1.0/24 22,80,443
 /dns netscli.com
 /reverse 192.168.1.1

--- a/site/src/data/site-content/surfaces.ts
+++ b/site/src/data/site-content/surfaces.ts
@@ -52,7 +52,7 @@ export const surfaces: SurfaceCard[] = [
   {
     title: 'MCP server',
     body:
-      'Run <code>netscli serve</code> when an MCP client needs local network tools. Every operation the CLI has is exposed as a structured tool, so an agent gets the same discovery, scanning and DNS results you would, in a shape it can parse.',
+      'Run <code>netscli serve</code> when an MCP client needs local network tools. Discovery, scanning, ping, DNS, ARP and interfaces are all exposed as structured tools, so an agent gets the same results you would, in a shape it can parse.',
     codeHtml: `<span style="color:#888">// claude_desktop_config.json</span>
 <span style="color:#7b7b7b">{</span>
   <span style="color:#7c9fc7">"mcpServers"</span>: <span style="color:#7b7b7b">{</span>


### PR DESCRIPTION
Nine documentation claims that had drifted from the code. Every one was checked against the source before editing; the fix is always to the doc, never the code.

- **`AGENTS.md` was stale in nine places**, which matters because it is what an agent reads first. Dependency versions (clap 4.4→4.6, ratatui 0.29→0.30, crossterm 0.27→0.29, `tui-textarea`→`ratatui-textarea`); a subcommand list that invented `config` and `export` while omitting `completions` and `man`; a claim that traceroute uses manual ICMP TTL probes on Unix when every platform shells out. Six further drifts were found while checking and are listed in the commits: an invented root `data/` directory, safety limits attributed to files that no longer hold them, a CLI file table naming `tui.rs` and `formatter.rs` after both moved, missing core modules, "no JS/TS linter configured" when `eslint.config.js` exists, and a feature-flag list missing `mdns` and `db`.
- **`desktop.md` documented packet-capture behaviour the code deliberately removed.** The tool stays visible with setup guidance in every build; only mDNS is hidden. `interface-coverage.md` contradicted itself on the same point two lines apart.
- **The landing page claimed every CLI operation is exposed as an MCP tool.** There is no trace tool and no reverse tool, and the site's own matrix says so.
- **`README.md` said nine tools in one place and 13 in another.** Reality is 13.
- **`tui.md` showed `/scan HOST -p PORTS`**; the TUI takes positional ports and errors on `-p`. Every other example on that page was checked against `command_catalog.rs`.
- **`dns_lookup` was documented as doing reverse lookups** in two READMEs. It passes the host through without arpa conversion, so a PTR query on a bare IP returns nothing.
- **`site/README.md`** said Astro 6 (it's 7.2), described metric placeholders that no longer exist, and pointed at `src/data/site.ts` after the content moved to `src/data/site-content/`.
- **`CHANGELOG.md`** had duplicate `### Changed` and `### Changed (internal)` headings in a file declaring Keep-a-Changelog conformance, and cited a dead-CSS budget of 210 where CI enforces 126. Entry text was preserved verbatim through the merge — verified by sorting and diffing the block before and after.
- **`SECURITY.md`** gains the pcap test-coverage gap: `--features pcap` runs on Linux only in CI and cannot build on Windows without the Npcap SDK, so the Windows/Npcap paths are exercised by no test anywhere.

## Verification

`npm run build` in `site/` — 14 pages, no warnings. `npm run check:css` confirms 126 is the enforced figure.

Audit findings #26–#31, #49–#51.