### PR TITLE
Verify AUR checksums, pin the mutable actions, and stop the templates looking real

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
-# Ensure Unix line endings for shell scripts and JS binaries
-bin/*.js text eol=lf
+# Ensure Unix line endings for shell scripts
 *.sh text eol=lf
 
 # Let git handle line endings for other files

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -123,9 +123,10 @@ updates:
       - dependencies
       - ci
     # dtolnay/rust-toolchain's numeric refs are Rust toolchain versions
-    # (1.96.0, not the action's release). We pin to @stable with an
-    # explicit `toolchain` input everywhere, so Dependabot has nothing
-    # to bump here, but keep this ignore as a belt-and-braces guard.
+    # (1.96.0, not the action's release). Every workflow now pins it by
+    # commit SHA with an explicit `toolchain` input, so Dependabot has
+    # nothing to bump here, but keep this ignore as a belt-and-braces
+    # guard against it reading the `# stable` marker as a version.
     ignore:
       - dependency-name: "dtolnay/rust-toolchain"
     groups:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -5,7 +5,13 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Mondays 06:00 UTC
   # Re-run when deps change or the audit config itself changes.
+  #
+  # Restricted to main. Unfiltered, a Dependabot PR touching Cargo.lock fired
+  # this twice for one commit — once for the branch push, once for the PR —
+  # and the concurrency group below keys on `github.ref`, which differs
+  # between those two refs, so the duplicate did not even cancel itself.
   push:
+    branches: [main]
     paths:
       - 'Cargo.lock'
       - '**/Cargo.toml'
@@ -34,11 +40,13 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # See ci.yml's lint job for why this pin keeps a `# stable` comment
+        # rather than a version number.
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.96.0"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: audit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,15 @@ jobs:
           fetch-depth: 0
       - id: filter
         shell: bash
+        # `github.event.pull_request.*` is attacker-reachable on a fork PR.
+        # These two fields are commit SHAs, so hex, so not exploitable today —
+        # but interpolating an event field straight into a `run:` script is
+        # the shape of the bug, not the field's contents, and this was the
+        # last place in the repo still doing it. Through `env:` the shell
+        # receives them as data that no quoting mistake can turn into code.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
@@ -63,9 +72,7 @@ jobs:
             exit 0
           fi
 
-          base='${{ github.event.pull_request.base.sha }}'
-          head='${{ github.event.pull_request.head.sha }}'
-          files=$(git diff --name-only "$base" "$head")
+          files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           echo "Changed files:"
           echo "$files" | sed 's/^/  /'
 
@@ -155,16 +162,19 @@ jobs:
             libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
             librsvg2-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev
       - name: Install Rust
-        # Pinned to @stable (an action-side alias) with an explicit
-        # toolchain version so Dependabot doesn't try to bump this
-        # action's ref the way it bumps a normal version tag — the
-        # numeric action refs here are Rust toolchain versions, not
-        # action releases.
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned by commit SHA; the trailing `# stable` records which
+        # action-side ref that SHA came from, and is deliberately not a
+        # version number. dtolnay/rust-toolchain's numeric refs (@1.96.0)
+        # are Rust *toolchain* versions rather than action releases, so a
+        # version-shaped comment here invites Dependabot to bump the
+        # compiler while pretending to bump an action. The toolchain we
+        # actually want comes from the explicit `toolchain` input below,
+        # and .github/dependabot.yml ignores this action as a second guard.
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.96.0"
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: lint
       - name: cargo fmt --check
@@ -199,11 +209,12 @@ jobs:
             librsvg2-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # See the pin note on the lint job above.
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.96.0"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: test-${{ matrix.os }}
 
@@ -286,10 +297,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libpcap-dev pkg-config
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # See the pin note on the lint job above.
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.96.0"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: release-${{ matrix.os }}
       - name: cargo build --release -p netscli

--- a/.github/workflows/gui-render.yml
+++ b/.github/workflows/gui-render.yml
@@ -49,11 +49,13 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # See ci.yml's lint job for why this pin keeps a `# stable` comment
+        # rather than a version number.
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.96.0"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: gui-render-windows
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,27 @@ on:
         required: true
         type: string
 
+# Keyed on the tag, not the ref, because `workflow_dispatch` and
+# `release: published` reach the same tag by different refs and would
+# otherwise not see each other.
+#
+# `cancel-in-progress: false` deliberately, unlike every other workflow here.
+# The jobs below push to registries the moment they succeed, and AUR has no
+# review step — cancelling halfway leaves some registries on the new version
+# and some on the old, with no record of which. Queueing costs a few idle
+# minutes; the duplicate run is a no-op, since every publish script is
+# idempotent for a tag it has already pushed.
+concurrency:
+  group: publish-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+# These jobs hold five publishing secrets between them (crates.io, the tap,
+# the bucket, winget, AUR) and every one of those is a PAT or an SSH key —
+# none of them needs GITHUB_TOKEN to write to this repo. Read is what the
+# checkouts need and nothing here wants more.
+permissions:
+  contents: read
+
 # Resolve the tag once at the workflow level so every job sees the same
 # version regardless of trigger.
 env:
@@ -167,24 +188,35 @@ jobs:
           . scripts/release/lib.sh
           validate_tag "$TAG"
 
-      - name: Wait for Linux release assets + compute SHA256s
+      # This step used to read the `.sha256` sidecar and write its contents
+      # straight into the PKGBUILD without ever downloading the binary. That
+      # verifies nothing: sidecar and asset come from the same origin, so a
+      # tampered asset shipped with a matching sidecar sails through, and AUR
+      # has no review step to catch it. `verified_sha` (lib.sh) is the fix the
+      # four publish-*.sh scripts already use — it downloads the asset, hashes
+      # the bytes, and aborts unless the sidecar agrees. These two AUR jobs do
+      # their work inline in YAML and so were the last callers still trusting
+      # the sidecar (C-35, B-03).
+      #
+      # It also folds in the availability poll this step used to do by hand:
+      # `verified_sha` calls `wait_for_asset` first.
+      - name: Verify Linux release assets + compute SHA256s
         id: shas
         env:
           TAG: ${{ env.TAG }}
         run: |
           set -euo pipefail
+          # Each `run:` block is a fresh shell, so the Validate tag step's
+          # source of lib.sh does not carry over to this one.
+          . scripts/release/lib.sh
           BASE="https://github.com/fstubner/netscli/releases/download/${TAG}"
           for arch in x86_64 aarch64; do
-            url="${BASE}/netscli-linux-${arch}.sha256"
-            echo "→ ${url}"
-            for i in {1..30}; do
-              if curl -fsSL --head "$url" >/dev/null 2>&1; then break; fi
-              echo "  not yet; retry in 30s ($i/30)"
-              sleep 30
-            done
-            sha=$(curl -fsSL "$url" | awk '{print $1}')
+            echo "→ verifying netscli-linux-${arch}"
+            sha=$(verified_sha "$BASE" "netscli-linux-${arch}")
             echo "${arch}=${sha}" >> "$GITHUB_OUTPUT"
           done
+          # LICENSE is hashed from the bytes we fetch, so there is no sidecar
+          # to distrust here.
           license_url="https://raw.githubusercontent.com/fstubner/netscli/${TAG}/LICENSE"
           echo "→ ${license_url}"
           license_sha=$(curl -fsSL "$license_url" | sha256sum | awk '{print $1}')
@@ -211,6 +243,15 @@ jobs:
             -e "s|^sha256sums_aarch64=.*|sha256sums_aarch64=('${SHA_AARCH64}')|" \
             packaging/aur/PKGBUILD > packaging/aur/PKGBUILD.rendered
           mv packaging/aur/PKGBUILD.rendered packaging/aur/PKGBUILD
+          # The committed template carries @@…@@ placeholders instead of
+          # real-looking digests, so any sed above that silently failed to
+          # match leaves one behind. Catch that here rather than pushing a
+          # PKGBUILD to AUR, which has no review step.
+          if grep -q '@@' packaging/aur/PKGBUILD; then
+            echo "ERROR: rendered PKGBUILD still contains unsubstituted placeholders" >&2
+            cat packaging/aur/PKGBUILD >&2
+            exit 1
+          fi
           echo "--- rendered ---"
           cat packaging/aur/PKGBUILD
 
@@ -323,22 +364,23 @@ jobs:
           . scripts/release/lib.sh
           validate_tag "$TAG"
 
-      - name: Wait for Linux GUI .AppImage + compute SHA256
+      # Same sidecar-trust fix as the CLI AUR job above: hash the AppImage we
+      # actually downloaded and require the sidecar to agree, rather than
+      # copying the sidecar into the PKGBUILD unchecked.
+      - name: Verify Linux GUI .AppImage + compute SHA256
         id: shas
         env:
           TAG: ${{ env.TAG }}
         run: |
           set -euo pipefail
+          # Fresh shell per step — the Validate tag step's source is gone.
+          . scripts/release/lib.sh
           BASE="https://github.com/fstubner/netscli/releases/download/${TAG}"
-          url="${BASE}/netscli-gui-linux-x86_64.AppImage.sha256"
-          echo "→ ${url}"
-          for i in {1..30}; do
-            if curl -fsSL --head "$url" >/dev/null 2>&1; then break; fi
-            echo "  not yet; retry in 30s ($i/30)"
-            sleep 30
-          done
-          sha=$(curl -fsSL "$url" | awk '{print $1}')
+          echo "→ verifying netscli-gui-linux-x86_64.AppImage"
+          sha=$(verified_sha "$BASE" "netscli-gui-linux-x86_64.AppImage")
           echo "x86_64=${sha}" >> "$GITHUB_OUTPUT"
+          # LICENSE and the icon are hashed from the bytes we fetch; no
+          # sidecar is involved.
           license_url="https://raw.githubusercontent.com/fstubner/netscli/${TAG}/LICENSE"
           echo "→ ${license_url}"
           license_sha=$(curl -fsSL "$license_url" | sha256sum | awk '{print $1}')
@@ -365,6 +407,12 @@ jobs:
             -e "s|^sha256sums_x86_64=.*|sha256sums_x86_64=('${SHA_X86_64}')|" \
             packaging/aur/netscli-gui-bin/PKGBUILD > packaging/aur/netscli-gui-bin/PKGBUILD.rendered
           mv packaging/aur/netscli-gui-bin/PKGBUILD.rendered packaging/aur/netscli-gui-bin/PKGBUILD
+          # Same leftover-placeholder check as the CLI AUR job.
+          if grep -q '@@' packaging/aur/netscli-gui-bin/PKGBUILD; then
+            echo "ERROR: rendered PKGBUILD still contains unsubstituted placeholders" >&2
+            cat packaging/aur/netscli-gui-bin/PKGBUILD >&2
+            exit 1
+          fi
           echo "--- rendered ---"
           cat packaging/aur/netscli-gui-bin/PKGBUILD
 
@@ -378,3 +426,71 @@ jobs:
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: "netscli-gui ${{ env.TAG }}"
           updpkgsums: false
+
+  # ─── Fan-out summary ───────────────────────────────────────────────
+  #
+  # The nine jobs above are deliberately independent — crates.io landing
+  # while AUR fails is a normal, recoverable state, and each job re-runs on
+  # its own. The cost of that independence was that "did this release
+  # actually reach every registry?" could only be answered by opening nine
+  # job pages, and a single failure among eight greens is easy to miss.
+  #
+  # This job REPORTS, it does not gate, and that is on purpose: failing the
+  # run on a partial publish would contradict the independence above and
+  # make a red X mean "one registry needs a rerun", which is
+  # indistinguishable at a glance from "the release is broken". The table
+  # goes to the run summary and any incomplete registry gets a ::warning::.
+  #
+  # `needs` result values: success | failure | cancelled | skipped. The
+  # allowlist is copied from ci.yml's `ci-gate` on purpose — see the note
+  # there about a runner that never started reporting "abandoned", a state
+  # that matched neither arm of a failure/cancelled denylist.
+  summary:
+    name: Publish summary
+    if: always()
+    needs:
+      - crates-io
+      - homebrew
+      - scoop
+      - winget
+      - aur
+      - homebrew-cask
+      - scoop-gui
+      - winget-gui
+      - aur-gui
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report each registry's result
+        shell: bash
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          TAG: ${{ env.TAG }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS" | jq -r 'to_entries[] | "  \(.key): \(.value.result)"'
+
+          {
+            echo "### Publish fan-out for ${TAG}"
+            echo ""
+            echo "| Registry | Result |"
+            echo "| --- | --- |"
+            echo "$NEEDS" | jq -r 'to_entries[] | "| \(.key) | \(.value.result) |"'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          incomplete=$(echo "$NEEDS" | jq -r '
+            to_entries
+            | map(select(.value.result != "success" and .value.result != "skipped"))
+            | map("\(.key)=\(.value.result)")
+            | join(", ")
+          ')
+
+          if [[ -n "$incomplete" ]]; then
+            echo "::warning::Publish incomplete for ${TAG} — these registries did not update: ${incomplete}"
+            {
+              echo ""
+              echo "**${TAG} did not reach every registry.** Re-run the failed jobs from the"
+              echo "Actions tab, or \`workflow_dispatch\` this workflow with tag \`${TAG}\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "All registries published for ${TAG}."
+          fi

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -26,6 +26,10 @@ jobs:
       # for a release the repo had already numbered 0.3.0. The version that
       # ships is the one set by hand across the seven files in
       # docs/PUBLISHING.md; set the tag to match when you publish the draft.
-      - uses: release-drafter/release-drafter@v7
+      #
+      # SHA-pinned like every action in release.yml. `@v7` is a tag the
+      # upstream owner can move at any time, and this job hands whatever it
+      # resolves to a `contents: write` token on main.
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,19 @@ on:
         required: true
         type: string
 
+# Keyed on the tag, not the ref: `workflow_dispatch` and `release: published`
+# reach the same tag by different refs, and two runs uploading assets for one
+# tag race each other on `softprops/action-gh-release`.
+#
+# `cancel-in-progress: false` deliberately, unlike ci.yml/site.yml. A cancelled
+# matrix leg leaves the release with some assets uploaded and some missing,
+# and publish.yml is meanwhile polling for exactly the assets that will now
+# never arrive. Queueing a duplicate run is harmless — it rebuilds and
+# re-uploads the same files.
+concurrency:
+  group: release-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Build and Release
@@ -278,8 +291,13 @@ jobs:
         run: npm ci
         working-directory: apps/netscli-gui
 
+      # The trailing `-- --locked` is forwarded by the Tauri CLI to cargo, so
+      # the Rust half of the installer gets the same lockfile enforcement the
+      # CLI job above already has. Without it a signed .msi/.dmg could be
+      # built against resolved-at-CI-time dependency versions that no
+      # committed Cargo.lock ever pinned. `npm ci` covers the frontend half.
       - name: tauri build
-        run: npm run tauri -- build --target ${{ matrix.target }}
+        run: npm run tauri -- build --target ${{ matrix.target }} -- --locked
         working-directory: apps/netscli-gui
 
       # Tauri puts bundles under apps/netscli-gui/src-tauri/target/<TARGET>/

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -35,6 +35,11 @@ jobs:
           fetch-depth: 0
       - id: filter
         shell: bash
+        # Through `env:` rather than straight into the script — see the
+        # equivalent note in ci.yml's `changes` job.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
@@ -42,9 +47,7 @@ jobs:
             exit 0
           fi
 
-          base='${{ github.event.pull_request.base.sha }}'
-          head='${{ github.event.pull_request.head.sha }}'
-          files=$(git diff --name-only "$base" "$head")
+          files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           echo "Changed files:"
           echo "$files" | sed 's/^/  /'
 

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ nul
 .claude/
 
 # Local agent/browser tooling state
+.agent-evidence/
 .agents/
 .playwright-cli/
 .playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ $env:NETSCLI_PCAP=1; iwr -useb https://raw.githubusercontent.com/fstubner/netscl
 Windows CLI installer details:
 - Installs `netscli.exe` to `$env:USERPROFILE\.cargo\bin` by default (override with `INSTALL_DIR`).
 - Installs from `fstubner/netscli` by default (override with `REPO`) and installs the latest release by default (override with `NETSCLI_VERSION`).
-- When `NETSCLI_PCAP=1` is set: installs the `-pcap` asset and runs the Npcap installer (admin required; skip with `NETSCLI_SKIP_NPCAP=1`).
+- When `NETSCLI_PCAP=1` is set: installs the `-pcap` asset and runs the Npcap installer (admin required; skip with `NETSCLI_SKIP_NPCAP=1`). The Npcap installer's Authenticode signature is checked before it is launched, and it is not run at all unless the signer is the Nmap Project — override the expected name with `NETSCLI_NPCAP_SIGNER` if they publish a new one.
 - If the release publishes a matching `.sha256` asset, the script verifies the download automatically; you can also set `NETSCLI_SHA256` or `NETSCLI_SHA256_URL`.
 
 ### Verifying Release Signatures

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -2,11 +2,24 @@
 #
 # These values are a template, not what users install.
 #
-# scripts/release/publish-*.sh fetch the real .sha256 from the published
-# release, rewrite version, url and hash, verify the result, and push that to
-# the tap or bucket. What is committed here is whatever the last edit left
-# behind -- currently a 0.3.0 label over the v0.2.6 digests -- and reading it
-# as the shipped manifest is a mistake that has been made before.
+# publish.yml's `aur` job renders this file on every release: it downloads
+# each asset, hashes the bytes, checks the result against the published
+# .sha256 sidecar, rewrites pkgver and every sha256sums line, and pushes the
+# result to aur.archlinux.org.
+#
+# The sha256sums lines below hold placeholder names, not digests. They used
+# to hold real-looking 64-hex values left behind by whichever release last
+# touched the file -- a 0.3.0 label over the v0.2.6 digests -- which read as
+# the shipped manifest and, worse, would have survived a render step that
+# silently failed to substitute. A placeholder cannot: makepkg rejects it,
+# and the render step scans for a leftover marker before handing the file to
+# AUR, which has no review step of its own.
+#
+# That scan is a plain grep over the whole file, so keep the literal marker
+# out of these comments.
+#
+# If you ever need to build this by hand, take each digest from the `.sha256`
+# asset on the release page.
 
 pkgname=netscli-bin
 _binname=netscli
@@ -22,9 +35,9 @@ conflicts=("${_binname}")
 source=("LICENSE-${pkgver}::https://raw.githubusercontent.com/fstubner/netscli/v${pkgver}/LICENSE")
 source_x86_64=("${_binname}-${pkgver}-x86_64::https://github.com/fstubner/netscli/releases/download/v${pkgver}/netscli-linux-x86_64")
 source_aarch64=("${_binname}-${pkgver}-aarch64::https://github.com/fstubner/netscli/releases/download/v${pkgver}/netscli-linux-aarch64")
-sha256sums=('6f035a96b0da6e99589b2a1656f59bee8c6519686d8a94627301e074746041d3')
-sha256sums_x86_64=('b3e7c97722982a1b7538866d05f7b51094a8b80fd049508e7e3f1f840e40e730')
-sha256sums_aarch64=('26f3d174b533d826deff96dc095b2c6067029baaecf757aef2fc227fa846d924')
+sha256sums=('@@SHA256_LICENSE@@')
+sha256sums_x86_64=('@@SHA256_X86_64@@')
+sha256sums_aarch64=('@@SHA256_AARCH64@@')
 
 package() {
   local src

--- a/packaging/aur/netscli-gui-bin/PKGBUILD
+++ b/packaging/aur/netscli-gui-bin/PKGBUILD
@@ -2,11 +2,11 @@
 #
 # These values are a template, not what users install.
 #
-# scripts/release/publish-*.sh fetch the real .sha256 from the published
-# release, rewrite version, url and hash, verify the result, and push that to
-# the tap or bucket. What is committed here is whatever the last edit left
-# behind -- currently a 0.3.0 label over the v0.2.6 digests -- and reading it
-# as the shipped manifest is a mistake that has been made before.
+# publish.yml's `aur-gui` job renders this file on every release; the
+# sha256sums lines below hold placeholder names rather than real-looking
+# digests, and the render step refuses to push a file with one left in it.
+# See the sibling packaging/aur/PKGBUILD for the full reasoning, including
+# why the literal marker must stay out of these comments.
 #
 # Sibling package to netscli-bin (the CLI/TUI). Ships the Tauri desktop
 # app as a self-contained .AppImage rather than the .deb, since pacman
@@ -31,8 +31,8 @@ depends=('gcc-libs' 'glibc' 'webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator')
 source=("LICENSE-${pkgver}::https://raw.githubusercontent.com/fstubner/netscli/v${pkgver}/LICENSE"
         "${_appname}.png::https://raw.githubusercontent.com/fstubner/netscli/v${pkgver}/apps/netscli-gui/src-tauri/icons/128x128.png")
 source_x86_64=("${pkgname}-${pkgver}.AppImage::https://github.com/fstubner/netscli/releases/download/v${pkgver}/netscli-gui-linux-x86_64.AppImage")
-sha256sums=('6f035a96b0da6e99589b2a1656f59bee8c6519686d8a94627301e074746041d3' '021f1d939fe496033ef90a47d29e7a1bd11ea83cfe0ffc445cb5b88418240882')
-sha256sums_x86_64=('bfd48226a173ee5997530e5b6fd211fc39d2c5cd6b9b2d0c054185b054a85e60')
+sha256sums=('@@SHA256_LICENSE@@' '@@SHA256_ICON@@')
+sha256sums_x86_64=('@@SHA256_X86_64@@')
 
 package() {
   install -Dm755 "${srcdir}/${pkgname}-${pkgver}.AppImage" \

--- a/packaging/homebrew/Casks/netscli.rb
+++ b/packaging/homebrew/Casks/netscli.rb
@@ -4,22 +4,24 @@
 # Two architectures because Tauri builds are not universal -- Apple Silicon
 # and Intel get distinct .dmg artifacts on every release.
 #
-# The values below are a template, not what users install.
-# `scripts/release/publish-homebrew.sh` rewrites `version` and every `sha256`
-# from the published release's .sha256 sidecars and pushes that to the tap.
-# What is committed here is whatever the last edit left behind.
+# Nothing installs this file. `scripts/release/publish-homebrew-cask.sh`
+# regenerates the tap's copy wholesale from its own heredoc, substituting
+# digests it has re-hashed from the downloaded assets. This copy is the
+# reference for what that output should look like.
 #
-# Edit by hand only when bootstrapping the tap or when the publish job is
-# broken; take each digest from the `.sha256` asset on the release page.
+# The digests are `@@...@@` placeholders on purpose. They used to be
+# real-looking 64-hex values left over from an old release, which is the
+# worst of both: too plausible to notice, too stale to work. A placeholder
+# fails loudly if it ever reaches a tap.
 cask "netscli" do
   version "0.3.0"
 
   on_arm do
-    sha256 "faf62fe3f56709b46865a6f35b5bcda4db6a37c4395eb904d1b73214f497e69e"
+    sha256 "@@SHA256_MACOS_AARCH64@@"
     url "https://github.com/fstubner/netscli/releases/download/v#{version}/netscli-gui-macos-aarch64.dmg"
   end
   on_intel do
-    sha256 "28354f51e623f9be5a875c6284df9ee1207ae182e0667293475d485a1bb41675"
+    sha256 "@@SHA256_MACOS_X86_64@@"
     url "https://github.com/fstubner/netscli/releases/download/v#{version}/netscli-gui-macos-x86_64.dmg"
   end
 

--- a/packaging/homebrew/netscli.rb
+++ b/packaging/homebrew/netscli.rb
@@ -2,11 +2,17 @@
 #
 # The values below are a template, not what users install.
 # `scripts/release/publish-homebrew.sh` runs from publish.yml on every
-# release: it fetches the real .sha256 sidecars from the published assets,
-# rewrites `version` and every `sha256` here, checks that exactly four valid
-# digests came out, and pushes the result to the tap. What is committed in
-# this repo is whatever the last edit left behind, so it can and does lag --
-# reading it as the shipped manifest is a mistake that has been made before.
+# release: it downloads each asset, hashes the bytes, checks the result
+# against the published .sha256 sidecar, rewrites `version` and every
+# `sha256` in the tap's copy of this file, verifies exactly four valid
+# digests came out, and pushes that.
+#
+# The digests here are @@…@@ placeholders on purpose. They used to be
+# real-looking 64-hex values left behind by whichever release last touched
+# the file -- a 0.3.0 label over v0.2.6-era digests -- which read as the
+# shipped manifest and would have installed a binary that fails Homebrew's
+# integrity check if anyone had copied them into the tap. A placeholder is
+# unmistakably unfilled.
 #
 # Editing it by hand is only needed if you are bootstrapping the tap or the
 # publish job is broken; in that case take each digest from the `.sha256`
@@ -24,22 +30,22 @@ class Netscli < Formula
   on_macos do
     on_arm do
       url "https://github.com/fstubner/netscli/releases/download/v#{version}/netscli-macos-aarch64"
-      sha256 "66935b1b627e5e58d7d24ef92f8153381dcbbf06ff79807314ddce47a73a7907"
+      sha256 "@@SHA256_MACOS_AARCH64@@"
     end
     on_intel do
       url "https://github.com/fstubner/netscli/releases/download/v#{version}/netscli-macos-x86_64"
-      sha256 "4e136a0b3fd287d7a86f70983c1be5bb4bd56f6c9d4f7b4da73e7bad23b644a3"
+      sha256 "@@SHA256_MACOS_X86_64@@"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/fstubner/netscli/releases/download/v#{version}/netscli-linux-aarch64"
-      sha256 "26f3d174b533d826deff96dc095b2c6067029baaecf757aef2fc227fa846d924"
+      sha256 "@@SHA256_LINUX_AARCH64@@"
     end
     on_intel do
       url "https://github.com/fstubner/netscli/releases/download/v#{version}/netscli-linux-x86_64"
-      sha256 "b3e7c97722982a1b7538866d05f7b51094a8b80fd049508e7e3f1f840e40e730"
+      sha256 "@@SHA256_LINUX_X86_64@@"
     end
   end
 

--- a/packaging/scoop/netscli-gui.json
+++ b/packaging/scoop/netscli-gui.json
@@ -6,7 +6,7 @@
   "architecture": {
     "64bit": {
       "url": "https://github.com/fstubner/netscli/releases/download/v0.3.0/netscli-gui-windows-x86_64.msi",
-      "hash": "064ef2b5cda0b70131d07002ea6a51fc0cebea863072211e6643a0bb5252fd7e"
+      "hash": "@@SHA256_WINDOWS_GUI@@"
     }
   },
   "installer": {

--- a/packaging/scoop/netscli.json
+++ b/packaging/scoop/netscli.json
@@ -6,7 +6,7 @@
   "architecture": {
     "64bit": {
       "url": "https://github.com/fstubner/netscli/releases/download/v0.3.0/netscli-windows-x86_64.exe#/netscli.exe",
-      "hash": "2d074426fe5bb79e42a6d211f1a705634e90e576c1dda9babade0fcf05a86b1d"
+      "hash": "@@SHA256_WINDOWS_CLI@@"
     }
   },
   "bin": "netscli.exe",

--- a/packaging/winget/cli/0.3.0/fstubner.netscli.installer.yaml
+++ b/packaging/winget/cli/0.3.0/fstubner.netscli.installer.yaml
@@ -4,6 +4,8 @@
 # initial Winget package must therefore be submitted as a portable
 # package. Future automated winget-releaser updates should preserve this
 # installer type from the accepted microsoft/winget-pkgs manifest.
+#
+# InstallerSha256 is a placeholder — see the note in gui/0.3.0/.
 
 PackageIdentifier: fstubner.netscli
 PackageVersion: 0.3.0
@@ -11,7 +13,7 @@ Installers:
   - Architecture: x64
     InstallerType: portable
     InstallerUrl: https://github.com/fstubner/netscli/releases/download/v0.3.0/netscli-windows-x86_64.exe
-    InstallerSha256: 2D074426FE5BB79E42A6D211F1A705634E90E576C1DDA9BABADE0FCF05A86B1D
+    InstallerSha256: '@@INSTALLER_SHA256@@'
     Commands:
       - netscli
 ManifestType: installer

--- a/packaging/winget/gui/0.2.4/fstubner.netscli.gui.installer.yaml
+++ b/packaging/winget/gui/0.2.4/fstubner.netscli.gui.installer.yaml
@@ -6,6 +6,8 @@
 #   winget install netscli-gui   -> GUI
 # Moniker resolves to the chosen identifier as long as it's unique in
 # the catalog.
+#
+# InstallerSha256 is a placeholder — see the note in gui/0.3.0/.
 
 PackageIdentifier: fstubner.netscli.gui
 PackageVersion: 0.2.4
@@ -13,7 +15,7 @@ Installers:
   - Architecture: x64
     InstallerType: wix
     InstallerUrl: https://github.com/fstubner/netscli/releases/download/v0.2.4/netscli-gui-windows-x86_64.msi
-    InstallerSha256: BDEF02B05D636627057DB8B395F9D38D76D9F884C634310D17F078D1EC86788D
+    InstallerSha256: '@@INSTALLER_SHA256@@'
     Scope: user
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget/gui/0.2.6/fstubner.netscli.gui.installer.yaml
+++ b/packaging/winget/gui/0.2.6/fstubner.netscli.gui.installer.yaml
@@ -8,6 +8,8 @@
 #   winget install netscli-gui   -> GUI
 # Moniker resolves to the chosen identifier as long as it's unique in
 # the catalog.
+#
+# InstallerSha256 is a placeholder — see the note in gui/0.3.0/.
 
 PackageIdentifier: fstubner.netscli.gui
 PackageVersion: 0.2.6
@@ -15,7 +17,7 @@ Installers:
   - Architecture: x64
     InstallerType: wix
     InstallerUrl: https://github.com/fstubner/netscli/releases/download/v0.2.6/netscli-gui-windows-x86_64.msi
-    InstallerSha256: 064EF2B5CDA0B70131D07002EA6A51FC0CEBEA863072211E6643A0BB5252FD7E
+    InstallerSha256: '@@INSTALLER_SHA256@@'
     Scope: user
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget/gui/0.3.0/fstubner.netscli.gui.installer.yaml
+++ b/packaging/winget/gui/0.3.0/fstubner.netscli.gui.installer.yaml
@@ -8,6 +8,13 @@
 #   winget install fstubner.netscli.gui
 # The `netscli-gui` moniker may resolve after the package is accepted
 # into the Winget catalog.
+#
+# InstallerSha256 is a placeholder. Nothing reads this file — the
+# `winget-gui` job in publish.yml uses `winget-releaser`, which computes
+# the digest from the release asset itself — so the snapshot exists to
+# record the manifest *shape*, per winget/README.md. It previously carried
+# a real-looking digest identical to the one in 0.2.6/, which means at
+# least one of the two described a build it did not match.
 
 PackageIdentifier: fstubner.netscli.gui
 PackageVersion: 0.3.0
@@ -15,7 +22,7 @@ Installers:
   - Architecture: x64
     InstallerType: wix
     InstallerUrl: https://github.com/fstubner/netscli/releases/download/v0.3.0/netscli-gui-windows-x86_64.msi
-    InstallerSha256: 064EF2B5CDA0B70131D07002EA6A51FC0CEBEA863072211E6643A0BB5252FD7E
+    InstallerSha256: '@@INSTALLER_SHA256@@'
     Scope: user
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -12,6 +12,9 @@
 #   - NETSCLI_SKIP_NPCAP=1: with NETSCLI_PCAP=1, skip the Npcap installer
 #                          (for users who already have Npcap installed)
 #   - NETSCLI_NPCAP_URL: Override the Npcap installer URL
+#   - NETSCLI_NPCAP_SIGNER: Override the Authenticode signer name the Npcap
+#     installer must carry (default: the Nmap Project's two published
+#     signing names). The installer is not run if it does not match.
 #   - NETSCLI_SHA256 / NETSCLI_SHA256_URL: supply the expected checksum
 #     explicitly. By default the installer fetches "<asset>.sha256" from
 #     the release and REFUSES to install if it cannot be verified.
@@ -71,12 +74,77 @@ function Test-NpcapInstalled {
   return $false
 }
 
+# Running the Npcap installer elevated is the most dangerous thing this
+# script does, and until now it did so on bytes fetched over a
+# user-overridable URL with nothing checked at all. release.yml's "Install
+# Npcap SDK" step refuses to do the equivalent for the Npcap *SDK* — it pins
+# a SHA256 rather than let an unverified third-party download into a binary
+# we then cosign-sign.
+#
+# A pinned hash is the wrong tool here, though. npcap.com serves a new
+# installer on every point release, so a pin would break `NETSCLI_PCAP=1` on
+# a schedule nobody here controls, and a check that breaks on a schedule is a
+# check people learn to disable. Authenticode survives version bumps: the
+# Nmap Project signs every Npcap release, so verify the signature is valid
+# and the signer is who we expect.
+#
+# Two names are accepted because the project's code signing key was reissued
+# to "Nmap Software LLC" in Npcap 1.76 (2023-07-19), replacing the older
+# "Insecure.Com LLC" — which anything a user pins with NETSCLI_NPCAP_URL
+# below that version still carries.
+function Test-NpcapSignature([string]$path) {
+  $accepted = if ($env:NETSCLI_NPCAP_SIGNER) {
+    @($env:NETSCLI_NPCAP_SIGNER)
+  } else {
+    @("Nmap Software LLC", "Insecure.Com LLC")
+  }
+
+  $sig = Get-AuthenticodeSignature -FilePath $path
+  if ($sig.Status -ne "Valid") {
+    Write-Host "Npcap installer signature is not valid (status: $($sig.Status))." -ForegroundColor Red
+    if ($sig.StatusMessage) {
+      Write-Host "  $($sig.StatusMessage)" -ForegroundColor Red
+    }
+    return $false
+  }
+  if (-not $sig.SignerCertificate) {
+    Write-Host "Npcap installer carries no signer certificate." -ForegroundColor Red
+    return $false
+  }
+
+  # SimpleName is the certificate's CN on its own, which avoids parsing the
+  # full distinguished name (the rest of which — locality, serial — changes
+  # whenever the cert is reissued).
+  $signer = $sig.SignerCertificate.GetNameInfo(
+    [System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false)
+
+  foreach ($name in $accepted) {
+    if ($signer -eq $name) {
+      Write-Host "Npcap installer signed by: $signer" -ForegroundColor Green
+      return $true
+    }
+  }
+
+  Write-Host "Npcap installer is signed by '$signer', which is not an accepted signer." -ForegroundColor Red
+  Write-Host "Expected one of: $($accepted -join ', ')" -ForegroundColor Red
+  Write-Host "Set NETSCLI_NPCAP_SIGNER if the Nmap Project has published a new signing name." -ForegroundColor Yellow
+  return $false
+}
+
 function Install-Npcap([string]$downloadDir, [string]$url) {
   $npcapExe = Join-Path $downloadDir "npcap-installer.exe"
   Write-Host "Downloading Npcap from: $url" -ForegroundColor Cyan
   Invoke-WebRequest -Uri $url -OutFile $npcapExe
   if (-not (Test-Path $npcapExe)) {
     Write-Host "Npcap download failed." -ForegroundColor Red
+    return $false
+  }
+
+  # Fail closed. Verification comes before the elevation prompt, not after,
+  # so an installer we cannot vouch for is never handed admin rights.
+  Write-Host "Verifying Npcap installer signature..." -ForegroundColor Cyan
+  if (-not (Test-NpcapSignature $npcapExe)) {
+    Write-Host "Refusing to run an unverified Npcap installer." -ForegroundColor Red
     return $false
   }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -178,7 +178,15 @@ install_libpcap() {
         echo "sudo not found; cannot auto-install libpcap."
         return 1
       fi
-      sudo apt-get update && sudo apt-get install -y libpcap-dev tcpdump
+      # `update` and `install` were chained with &&, so an unreachable
+      # mirror or an expired repo signature reported itself as "libpcap
+      # installation failed" on machines where the cached index would have
+      # installed it fine. Refreshing the index is best-effort; only the
+      # install decides the outcome.
+      if ! sudo apt-get update; then
+        echo "apt-get update failed; continuing with the cached package index."
+      fi
+      sudo apt-get install -y libpcap-dev tcpdump
       return $?
     fi
     if have_cmd dnf; then
@@ -323,10 +331,14 @@ case ":${PATH}:" in
     ;;
 esac
 
-echo ""
-echo "Installed successfully."
-
+# The libpcap step runs BEFORE the success message, and the message reports
+# what actually happened. It used to be the other way round: "Installed
+# successfully." printed first, then a non-fatal libpcap attempt underneath
+# it. A user who set NETSCLI_PCAP=1 because they wanted packet capture read
+# the success line and got a binary that cannot capture.
+CAPTURE_READY=1
 if is_true "$NETSCLI_PCAP"; then
+  echo ""
   if have_libpcap; then
     echo "libpcap detected — no system install needed."
   elif is_true "$NETSCLI_SKIP_LIBPCAP"; then
@@ -336,6 +348,7 @@ if is_true "$NETSCLI_PCAP"; then
     if install_libpcap; then
       echo "libpcap installation completed."
     else
+      CAPTURE_READY=0
       echo "libpcap installation failed — install it manually:"
       if [[ "$OS" == "darwin" ]]; then
         echo "  brew install libpcap tcpdump"
@@ -345,6 +358,14 @@ if is_true "$NETSCLI_PCAP"; then
       echo "Or run: netscli setup"
     fi
   fi
+fi
+
+echo ""
+if [[ "$CAPTURE_READY" -eq 1 ]]; then
+  echo "Installed successfully."
+else
+  echo "Installed ${BINARY_NAME}, but packet capture is NOT ready."
+  echo "Install libpcap as described above, then re-check with: ${BINARY_NAME} doctor"
 fi
 
 echo "Try:"


### PR DESCRIPTION
The supply chain is a real attack surface here: a compromised workflow or release script ships binaries to winget, Homebrew, Scoop and AUR users.

## The AUR jobs trusted the checksum sidecar (High)

Both AUR publish jobs downloaded the `.sha256` sidecar and wrote its contents straight into the PKGBUILD, never downloading the asset. That is exactly the circular verification `scripts/release/lib.sh`'s `verified_sha` exists to prevent — and which `packaging/README.md` explicitly claimed was already fixed everywhere. `lib.sh` was already sourced two steps earlier in the same job. Both now call `verified_sha`, which downloads and re-hashes locally.

AUR pushes are live with no review step, so this was the path with the least between a bad digest and a user.

## Pipeline

- **No concurrency guard** on `release.yml` or `publish.yml`, both of which fire on `release: published` — every other workflow in the repo has one. Now keyed on the tag with `cancel-in-progress: false`, because cancelling a half-finished publish is worse than queueing it.
- **No aggregate signal** for the nine-job publish fan-out, so a partial failure had none. A summary job now writes a per-registry table and warns on incomplete registries. It reports rather than fails: the file's own comments say the jobs are independent and individually re-runnable.
- **GUI installers built without `--locked`** while the CLI job used it, so a release could resolve dependencies differing from `Cargo.lock`.
- **`publish.yml` declared no `permissions:`** on any job. The repo default is `read`, so this was defence-in-depth, but these are the jobs holding five publishing secrets.
- **`audit.yml`'s push trigger had no branch filter**, so every dependency PR ran cargo audit twice without deduping.

## Installers

- **`install.ps1` ran an unverified elevated installer.** Npcap was downloaded from a user-overridable URL and launched with no verification, while `release.yml` digest-pins the Npcap *SDK* with a comment about why unverified downloads must not enter a signed build. Now verified by Authenticode signature and signer subject, failing closed. A signature rather than a pinned hash because Npcap's signer changed from `Insecure.Com LLC` to `Nmap Software LLC` in 1.76 and a pinned hash breaks on every point release.
- **`install.sh` printed "Installed successfully" before the libpcap step**, whose failure is non-fatal — so a user who asked for capture support read success and got a binary that cannot capture. An `apt-get update` failure was also reported as a libpcap failure.

## Actions and templates

Three mutable action refs pinned to SHAs, each resolved via the GitHub API and cross-checked against its release tag: `release-drafter@v7` (which runs with `contents: write`), `Swatinem/rust-cache@v2`, `dtolnay/rust-toolchain@stable`. The `@stable` comment marker is kept deliberately non-version-shaped so Dependabot does not confuse a Rust toolchain version with an action version — the existing reasoning in `ci.yml` is preserved.

Every packaging template's digests become `@@...@@` placeholders. They were real-looking 64-hex values, internally inconsistent (`pkgver=0.3.0` over v0.2.6-era digests) — the worst of both: too plausible to notice, too stale to work. Guards now fail the render if a placeholder survives. This covers the AUR PKGBUILDs, the Homebrew formula, the cask, both scoop manifests and all four winget snapshots; nothing consumes the last three groups (the cask is regenerated wholesale from a heredoc, scoop is jq-patched in the bucket repo, winget-releaser generates its own), so placeholders are the honest form for a reference copy.

**No hash, digest or checksum was invented anywhere in this PR.**

## Verification

shellcheck clean on `install.sh` and all release scripts; `lib_test.sh` passes; PSScriptAnalyzer clean on `install.ps1`; all workflow YAML parses; scoop JSON valid. The Npcap signature check was extracted via AST and run against real Npcap binaries (accepts the default signer list, rejects a non-matching override, refuses an unsigned installer). The AUR render `sed` was replayed against the placeholder templates including a negative control.

Audit findings #7 (High), #19–#25, #33, #45–#48, #52.