### PR TITLE
Bound every CI job, so a stall fails in minutes not hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,18 @@ permissions:
   contents: read
 
 jobs:
+  # Every job below sets `timeout-minutes`. GitHub's default is 360, and on
+  # 2026-08-19 a stalled `apt-get` in "Install system dependencies" sat there
+  # for the full six hours on five branches at once, then failed the gate --
+  # burning a day of runner time to report a problem visible in the first
+  # minute.
+  #
+  # The values are sized against measured runs, not guessed: with a warm
+  # cache the slowest job here is ~3 minutes, and a fully cold build of the
+  # workspace (GTK/WebKit + Tauri, release profile with LTO) is well under
+  # 20. Each limit leaves roughly an order of magnitude of headroom over
+  # what the job actually needs, so a timeout means something is wrong
+  # rather than merely slow.
   # Classify the diff so the expensive jobs can skip themselves without
   # the workflow disappearing from the PR's check list. Done with plain
   # git rather than a paths-filter action to avoid adding another
@@ -47,6 +59,7 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
@@ -92,6 +105,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -111,6 +125,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       # install.sh is user-facing; the release/ scripts hold GH_TOKEN and
@@ -149,6 +164,7 @@ jobs:
     needs: [changes, maintainability]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       # libpcap-dev: netscli-core pcap feature. GTK/WebKit: netscli-gui
@@ -189,6 +205,7 @@ jobs:
     needs: [changes, lint]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -234,6 +251,7 @@ jobs:
     needs: [changes, lint]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -285,6 +303,7 @@ jobs:
     needs: [changes, test]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -339,6 +358,7 @@ jobs:
       - gui-build
       - release-build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Verify no upstream job failed
         shell: bash


### PR DESCRIPTION
## Why

GitHub's default job timeout is 360 minutes. On 2026-08-19 a stalled `apt-get` in "Install system dependencies" sat at that default for the full six hours on five branches simultaneously, then failed the gate — roughly a day of runner time spent reporting a problem that was visible in the first minute.

The `CI Gate` behaved exactly right: it allowlists `success`/`skipped`, so a cancelled job correctly went red rather than green. Nothing bounded the job itself.

## The values

Measured, not guessed. Job durations from recent runs:

| Job | Observed max | Timeout |
|---|---|---|
| Detect changes | 0.1 min | 5 |
| Maintainability | 0.2 min | 5 |
| Installer Script Lint | 0.8 min | 10 |
| GUI Build | 0.6 min | 20 |
| Format + Clippy | 2.2 min | 30 |
| Test (3 OS) | 3.2 min | 45 |
| Release build (3 OS) | 2.2 min | 45 |
| CI Gate | 0.1 min | 5 |

Observed figures come from runs with a populated `rust-cache`, so they are not the worst case. The limits are sized for a fully cold build of the workspace — GTK/WebKit plus Tauri, release profile with LTO — which is comfortably under 20 minutes on a hosted runner. Each leaves roughly an order of magnitude of headroom over what the job needs, so hitting one means something is wrong rather than merely slow, and no legitimate cold run is at risk.

## Scope

Only `ci.yml`. `release.yml` and `publish.yml` install the same system dependencies and carry the same exposure, but a timeout firing mid-publish raises a separate question about what a partially-published release leaves behind — that deserves its own change rather than being bundled in here.

## Verification

All 8 jobs carry a `timeout-minutes`; the workflow parses as valid YAML and every value is attached to the job it names (checked by parsing the file, not by eye).