### PR TITLE
Bound the release and publish jobs too

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,25 @@ env:
   TAG: ${{ github.event.inputs.tag || github.ref_name }}
 
 jobs:
+  # Every job below sets `timeout-minutes`; GitHub's default is 360.
+  #
+  # These are sized differently from ci.yml, and the reason matters. These
+  # jobs fire on `release: published` at the same moment release.yml starts
+  # building, so a publish job legitimately spends most of its life *waiting*
+  # for the asset it needs. `wait_for_asset` in scripts/release/lib.sh bounds
+  # that itself: 30 polls at 30s, so 15 minutes, and then it fails with a
+  # message naming the URL that never appeared.
+  #
+  # That graceful failure is worth protecting. A job timeout below ~15
+  # minutes would pre-empt it and replace a clear explanation with an opaque
+  # cancellation, so 30 leaves the designed wait intact plus room to download,
+  # re-hash and push, while still bounding a true hang.
+  #
+  # A timeout mid-publish is recoverable but not free: each registry job is
+  # independent and re-runnable (see the note on the fan-out below), and the
+  # summary job reports which registries actually landed. Publishing is not
+  # transactional across registries either way -- that is a property of the
+  # design, not something a timeout introduces.
   # ─── crates.io ──────────────────────────────────────────────────────
   # Bottom-up publish (netscli-core → netscli-mcp → netscli). Sleep
   # between each to let the index update; downstream crates' resolvers
@@ -54,6 +73,7 @@ jobs:
   crates-io:
     name: crates.io
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -92,6 +112,7 @@ jobs:
   homebrew:
     name: Homebrew tap
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -105,6 +126,7 @@ jobs:
   scoop:
     name: Scoop bucket
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -121,6 +143,7 @@ jobs:
   winget:
     name: Winget
     runs-on: windows-latest
+    timeout-minutes: 30
     steps:
       # The `winget-releaser` action fetches the release's asset list
       # via the GitHub API and bails fast if the matching .exe is not
@@ -166,6 +189,7 @@ jobs:
   aur:
     name: AUR
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -275,6 +299,7 @@ jobs:
   homebrew-cask:
     name: Homebrew Cask
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -291,6 +316,7 @@ jobs:
   scoop-gui:
     name: Scoop bucket (GUI)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -308,6 +334,7 @@ jobs:
   winget-gui:
     name: Winget (GUI)
     runs-on: windows-latest
+    timeout-minutes: 30
     steps:
       # Same wait-then-submit pattern as the CLI Winget job above. The
       # GUI .msi takes longer to build than the CLI .exe (Tauri bundle
@@ -349,6 +376,7 @@ jobs:
   aur-gui:
     name: AUR (GUI)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -459,6 +487,7 @@ jobs:
       - winget-gui
       - aur-gui
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Report each registry's result
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,22 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Both jobs below set `timeout-minutes`; GitHub's default is 360. A stalled
+  # `apt-get` once held CI jobs at that default for six hours (see ci.yml),
+  # and these run the same system-dependency installs.
+  #
+  # A timeout here is safe to recover from: the job uploads assets to an
+  # existing release, so a missed asset is re-uploaded by re-running the job.
+  # Downstream, publish.yml's `wait_for_asset` fails with a clear message
+  # rather than publishing a manifest for something that is not there.
+  #
+  # Sized against measured runs: the slowest observed job is the Windows GUI
+  # installer at ~7 minutes, so 60 leaves ample room for a cold cache,
+  # cross-compilation and bundling while still bounding a genuine hang.
   release:
     name: Build and Release
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     permissions:
       contents: write
       # id-token: write is required for sigstore keyless signing. Cosign
@@ -233,6 +246,7 @@ jobs:
   gui:
     name: Build GUI installer
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Follows #228, which bounded `ci.yml` after a stalled `apt-get` held five CI jobs at GitHub's 360-minute default for a full six hours. These two workflows install the same system dependencies and had the same exposure.

## release.yml — 60 minutes per job

The slowest measured run is the Windows GUI installer at ~7 minutes, so this leaves ample room for a cold cache, cross-compilation and bundling.

| Job | Observed max | Timeout |
|---|---|---|
| Build and Release (matrix) | 5.8 min | 60 |
| Build GUI installer (matrix) | 7.3 min | 60 |

A timeout here is cheap: the job uploads assets to a release that already exists, so a missing asset is fixed by re-running. Downstream, `wait_for_asset` fails with a message naming the URL rather than publishing a manifest pointing at something absent.

## publish.yml — sized around the wait, not the work

This is the part that needed thought rather than a number.

These jobs fire on `release: published` at the same moment `release.yml` starts building, so they legitimately spend most of their life **waiting** for the asset they need. `wait_for_asset` in `scripts/release/lib.sh` already bounds that: 30 polls at 30s — **15 minutes** — then a clear error naming the URL that never appeared.

That graceful failure is worth protecting. Any job timeout at or below 15 minutes would pre-empt it and swap a useful explanation for an opaque cancellation. So:

| Job | Timeout | Why |
|---|---|---|
| registry jobs (homebrew, scoop, winget, aur, and the `-gui` variants) | 30 | 15-min wait intact, plus room to download, re-hash and push |
| `crates-io` | 45 | builds and uploads, and can wait on the index |
| `summary` | 10 | touches no assets |

Verified programmatically that no job's timeout sits at or below the 15-minute wait.

## On partial publishes

A timeout mid-publish is recoverable but not free. Each registry job is independent and re-runnable, and the summary job (added in #227) reports which registries actually landed. Worth stating plainly: publishing was never transactional across registries — that is a property of the fan-out design, not something these timeouts introduce.

## Verification

Both workflows parse as valid YAML; all 12 jobs carry a `timeout-minutes`, checked by parsing the files rather than by eye.