### PR TITLE
Set the 0.3.0 release date to the day it is tagged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ further copies in `package.json` and `tauri.conf.json`. See
 
 ## [Unreleased]
 
-## [0.3.0] — 2026-08-19
+## [0.3.0] — 2026-08-20
 
 ### Added
 


### PR DESCRIPTION
The 0.3.0 heading carried 2026-08-19, a date chosen before the section existed in its current form and before the audit work was folded into it. Set to 2026-08-20, the day the tag is cut.

The `[0.3.0]` and `[Unreleased]` link references at the foot of the file already point at the right places and need no change.