### PR TITLE
Drive the app by attaching to it, so the render suite can run at all

### DIFF
--- a/.github/workflows/gui-render.yml
+++ b/.github/workflows/gui-render.yml
@@ -2,11 +2,19 @@ name: GUI Render
 
 # Schedule and manual only — deliberately NOT on pull_request.
 #
-# This suite cannot currently pass. WebView2 Runtime 150+ ignores
-# WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS on an elevated host, which is by
-# design per Microsoft, so tauri-driver can never hand msedgedriver the
-# remote-debugging port it needs. Tracked upstream at wry#1782; there is no
-# change on our side that fixes it.
+# The suite now drives the app by *attaching* to it rather than letting
+# msedgedriver launch it. See e2e/tauri-render/driver.mjs for the full
+# reasoning; briefly: msedgedriver reads the debug port back out of a
+# `DevToolsActivePort` file in the temporary user-data-dir it created, and
+# wry writes that file into Tauri's own WebView2 profile instead, so the
+# driver looked in a directory that never had it.
+#
+# The previous note here blamed WebView2 150+ ignoring
+# WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS on an elevated host and concluded no
+# fix was possible on our side. That was measured and found wrong: the app
+# does honour the variable and does open the port. The elevation caveat may
+# still apply to a hosted runner, which is exactly what a dispatch of this
+# workflow now tells us.
 #
 # Run per-PR it cost ~13 minutes on every PR touching the GUI or core — nine
 # of the last ten runs failed, all at the same step, for that same reason.
@@ -70,19 +78,6 @@ jobs:
         run: npm ci
         working-directory: apps/netscli-gui
 
-      - name: Install tauri-driver
-        # Pinned (B-34). `--locked` honours *that crate's* lockfile but says
-        # nothing about which version gets installed, so this floated to
-        # whatever was newest at job time -- a silent, unreviewed dependency
-        # bump on a job that drives the real app. Dependabot does not watch
-        # `cargo install` lines, so bumping this is a deliberate edit.
-        run: cargo install tauri-driver --locked --version 2.0.6
-
-      # This job has been failing with "session not created:
-      # DevToolsActivePort file doesn't exist", which is msedgedriver's
-      # generic "the thing I launched never came up" error and says
-      # nothing about why. Capture the environment so the next failure is
-      # diagnosable from the log instead of by guesswork.
       - name: Diagnose WebView2 / driver environment
         shell: pwsh
         continue-on-error: true
@@ -112,7 +107,6 @@ jobs:
             Write-Host "msedge.exe      : $((Get-Item $edge).VersionInfo.ProductVersion)"
           } else { Write-Host "msedge.exe      : NOT FOUND" }
 
-          Write-Host "tauri-driver    : $(tauri-driver --version 2>&1)"
           Write-Host "session type    : $([Environment]::UserInteractive)"
 
       - name: Run Tauri render test

--- a/.github/workflows/gui-render.yml
+++ b/.github/workflows/gui-render.yml
@@ -9,12 +9,23 @@ name: GUI Render
 # wry writes that file into Tauri's own WebView2 profile instead, so the
 # driver looked in a directory that never had it.
 #
-# The previous note here blamed WebView2 150+ ignoring
-# WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS on an elevated host and concluded no
-# fix was possible on our side. That was measured and found wrong: the app
-# does honour the variable and does open the port. The elevation caveat may
-# still apply to a hosted runner, which is exactly what a dispatch of this
-# workflow now tells us.
+# That fix is proven on an ordinary non-elevated Windows machine, where the
+# suite now attaches and drives the app through real scenarios.
+#
+# It does NOT make this workflow pass, and the reason is the other half of
+# the original note, which was right: on a hosted runner the app never opens
+# the debug port at all. A dispatch on 2026-08-20 failed with "Timed out
+# waiting for port" after a clean build, with WebView2 and Edge both at
+# 151.0.4129.72, so this is not the version mismatch it can look like.
+#
+# So there were two problems stacked on each other. The port-file location
+# is fixed. WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS being ignored -- which
+# Microsoft documents as intended on an elevated host, and hosted Windows
+# runners are elevated -- is not, and cannot be from our side.
+#
+# The step below now reports elevation, so the next run measures that rather
+# than inferring it. Until it changes, the value of this suite is local and
+# on any non-elevated Windows host, where it does run.
 #
 # Run per-PR it cost ~13 minutes on every PR touching the GUI or core — nine
 # of the last ten runs failed, all at the same step, for that same reason.
@@ -108,6 +119,14 @@ jobs:
           } else { Write-Host "msedge.exe      : NOT FOUND" }
 
           Write-Host "session type    : $([Environment]::UserInteractive)"
+          # Elevation is the documented reason WebView2 ignores
+          # WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS, and it is the remaining
+          # blocker here -- so measure it rather than assume it.
+          $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+          $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+          $elevated = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+          Write-Host "user            : $($identity.Name)"
+          Write-Host "elevated        : $elevated"
 
       - name: Run Tauri render test
         run: npm run test:tauri-render

--- a/apps/netscli-gui/e2e/tauri-render.mjs
+++ b/apps/netscli-gui/e2e/tauri-render.mjs
@@ -1,7 +1,15 @@
 import { artifactsDir, npmBin } from './tauri-render/paths.mjs';
 import { getFreePort, run, stopProcess } from './tauri-render/processes.mjs';
 import { closeServer, startProbeServer } from './tauri-render/probe-server.mjs';
-import { By, createDriver, findApplication, resolveNativeDriverPath, startTauriDriver } from './tauri-render/driver.mjs';
+import {
+  By,
+  createDriver,
+  findApplication,
+  launchApplication,
+  resolveNativeDriverPath,
+  setViewport,
+  startNativeDriver,
+} from './tauri-render/driver.mjs';
 import {
   assertNoHorizontalOverflow,
   assertTheme,
@@ -26,7 +34,8 @@ import { alignmentReport } from './tauri-render/scenarios/helpers/alignment.mjs'
 const DESKTOP_WINDOW = { x: 0, y: 0, width: 1000, height: 970 };
 const NARROW_WINDOW = { width: 520, height: 720 };
 
-let tauriDriverProcess;
+let nativeDriverProcess;
+let appProcess;
 let probeServer;
 
 async function main() {
@@ -54,26 +63,31 @@ async function main() {
   const nativeDriverPath = await resolveNativeDriverPath();
   const application = findApplication();
   process.env.NETSCLI_EXPORT_DIR = artifactsDir;
-  tauriDriverProcess = await startTauriDriver(nativeDriverPath, webdriverPort);
+  // We start the app, so we choose its debug port; the driver then attaches
+  // to it rather than launching anything. See driver.mjs for why.
+  const debugPort = await getFreePort();
+  appProcess = await launchApplication(application, debugPort);
+  nativeDriverProcess = await startNativeDriver(nativeDriverPath, webdriverPort);
 
   let driver;
   try {
-    driver = await createDriver(webdriverPort, application);
+    driver = await createDriver(webdriverPort, debugPort);
   } catch (error) {
     // Session creation is where this harness fails most often, and the
     // WebDriver error alone ("session not created: DevToolsActivePort
     // file doesn't exist") says nothing about the cause. Everything
     // useful is in the native driver's own output.
-    const driverLog = tauriDriverProcess?.getDriverOutput?.() ?? '';
+    const driverLog = nativeDriverProcess?.getDriverOutput?.() ?? '';
     console.error('\n--- tauri-driver / native driver output ---');
     console.error(driverLog.trim() || '(no output captured)');
     console.error('--- end driver output ---');
-    console.error(`app under test: ${application}`);
+    console.error((appProcess?.getOutput?.() ?? '').trim() || '(no app output captured)');
+    console.error(`app under test: ${application} (debug port ${debugPort})`);
     throw error;
   }
 
   try {
-    await driver.manage().window().setRect(DESKTOP_WINDOW);
+    await setViewport(debugPort, DESKTOP_WINDOW);
     await withElement(driver, '[data-testid="app-shell"]', 20_000);
 
     const shell = await withElement(driver, '[data-testid="app-shell"]');
@@ -136,7 +150,7 @@ async function main() {
     await assertTheme(driver, 'light');
     await saveScreenshot(driver, 'tauri-render-light.png');
 
-    await driver.manage().window().setRect(NARROW_WINDOW);
+    await setViewport(debugPort, NARROW_WINDOW);
     await assertNoHorizontalOverflow(driver);
     await withElement(driver, '[data-testid="run-active-tab"]');
     await withElement(driver, '.workspace');
@@ -152,9 +166,13 @@ async function main() {
   }
 }
 
-process.on('exit', () => stopProcess(tauriDriverProcess));
+process.on('exit', () => {
+  stopProcess(nativeDriverProcess);
+  stopProcess(appProcess);
+});
 process.on('SIGINT', () => {
-  stopProcess(tauriDriverProcess);
+  stopProcess(nativeDriverProcess);
+  stopProcess(appProcess);
   process.exit(130);
 });
 
@@ -175,7 +193,8 @@ ${drifts.length} alignment drift(s) within tolerance of failing:`);
       }
     }
     await closeServer(probeServer).catch(() => undefined);
-    stopProcess(tauriDriverProcess);
+    stopProcess(nativeDriverProcess);
+    stopProcess(appProcess);
   });
 
 async function ensureSettingsToggleOn(driver, testId) {

--- a/apps/netscli-gui/e2e/tauri-render/driver.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/driver.mjs
@@ -1,13 +1,40 @@
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { download as downloadEdgeDriver } from 'edgedriver';
 import webdriver from 'selenium-webdriver';
 
-import { guiRoot, repoRoot, tauriDriverBin } from './paths.mjs';
+import { guiRoot, repoRoot } from './paths.mjs';
 import { waitForPort } from './processes.mjs';
 
 export const { Builder, By, Key, until } = webdriver;
+
+/**
+ * Why this harness attaches instead of letting the driver launch the app.
+ *
+ * `tauri-driver` asks msedgedriver to start the app as if it were Edge.
+ * msedgedriver passes `--remote-debugging-port=0`, then reads the port it
+ * was given back out of a `DevToolsActivePort` file inside the temporary
+ * `--user-data-dir` it created for the session.
+ *
+ * wry does not use that directory. It puts the WebView2 profile in Tauri's
+ * own folder, keyed on the app identifier -- on Windows
+ * `%LOCALAPPDATA%\<identifier>\EBWebView\` -- and writes `DevToolsActivePort`
+ * there. The driver looks in its own directory, finds nothing, and after 60
+ * seconds reports "session not created: DevToolsActivePort file doesn't
+ * exist". The file exists; it is simply somewhere the driver never looks.
+ * That is why every run of this suite has failed, and why the error never
+ * pointed anywhere useful.
+ *
+ * Attaching sidesteps the whole exchange: we start the app ourselves on a
+ * port we chose, and hand the driver `debuggerAddress`, which tells it to
+ * connect to something already running rather than launch anything. No
+ * DevToolsActivePort lookup happens at all.
+ *
+ * The cost is that an attached session reports `setWindowRect: false`, so
+ * `driver.manage().window().setRect()` is unavailable -- see `setViewport`.
+ */
 
 export async function resolveNativeDriverPath() {
   return process.env.TAURI_NATIVE_DRIVER ?? (await downloadEdgeDriver());
@@ -31,58 +58,136 @@ export function findApplication() {
   return application;
 }
 
-export async function startTauriDriver(nativeDriverPath, webdriverPort) {
-  if (!fs.existsSync(tauriDriverBin)) {
-    throw new Error(`tauri-driver was not found at ${tauriDriverBin}. Install it with: cargo install tauri-driver --locked`);
-  }
+/**
+ * Start the app under test with a remote debugging port we control.
+ *
+ * wry forwards `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` into the WebView2
+ * host, which is how a fixed port gets requested. A fixed port is the point:
+ * it removes any need to discover one from a file.
+ */
+export async function launchApplication(application, debugPort) {
+  // A profile of its own, per run. WebView2 otherwise reuses one folder for
+  // the identifier, so `localStorage` -- and with it the app's saved history
+  // and preferences -- survives between runs and leaks in from any ordinary
+  // use of the app on the same machine. The first real run of this suite
+  // failed on exactly that: the History menu held nine entries from earlier
+  // manual launches where the assertion expected the one scan it had just
+  // performed.
+  const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'netscli-e2e-profile-'));
 
-  const args = ['--port', String(webdriverPort), '--native-driver', nativeDriverPath];
-  let output = '';
-  const child = spawn(tauriDriverBin, args, {
+  const child = spawn(application, [], {
     cwd: guiRoot,
+    env: {
+      ...process.env,
+      WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS: `--remote-debugging-port=${debugPort}`,
+      WEBVIEW2_USER_DATA_FOLDER: profileDir,
+    },
     stdio: ['ignore', 'pipe', 'pipe'],
     shell: false,
-    // Its own process group, so `stopProcess` can signal the whole tree.
-    // tauri-driver spawns the platform WebDriver, which spawns the browser;
-    // without this those grandchildren outlive the run and hold their ports
-    // (M-13). No-op on Windows, which uses taskkill /T instead.
     detached: process.platform !== 'win32',
   });
 
-  child.stdout.on('data', (chunk) => {
-    output += chunk.toString();
-  });
-  child.stderr.on('data', (chunk) => {
-    output += chunk.toString();
-  });
+  let output = '';
+  child.stdout.on('data', (chunk) => { output += chunk.toString(); });
+  child.stderr.on('data', (chunk) => { output += chunk.toString(); });
+  child.getOutput = () => output;
+  child.profileDir = profileDir;
+
+  await Promise.race([
+    waitForPort(debugPort, 60_000),
+    new Promise((_, reject) => {
+      child.once('exit', (code, signal) => {
+        reject(new Error(`app exited before opening its debug port (${code ?? signal})\n${output}`));
+      });
+    }),
+  ]);
+
+  return child;
+}
+
+/** Run the platform WebDriver directly; `tauri-driver` is not in the path. */
+export async function startNativeDriver(nativeDriverPath, webdriverPort) {
+  let output = '';
+  const child = spawn(
+    nativeDriverPath,
+    [`--port=${webdriverPort}`, '--allowed-ips=', '--allowed-origins=*'],
+    { cwd: guiRoot, stdio: ['ignore', 'pipe', 'pipe'], shell: false, detached: process.platform !== 'win32' },
+  );
+
+  child.stdout.on('data', (chunk) => { output += chunk.toString(); });
+  child.stderr.on('data', (chunk) => { output += chunk.toString(); });
+  child.getDriverOutput = () => output;
 
   await Promise.race([
     waitForPort(webdriverPort),
     new Promise((_, reject) => {
       child.once('exit', (code, signal) => {
-        reject(new Error(`tauri-driver exited early with ${code ?? signal}\n${output}`));
+        reject(new Error(`native driver exited early with ${code ?? signal}\n${output}`));
       });
     }),
   ]);
 
-  // tauri-driver proxies to the native driver (msedgedriver on Windows)
-  // and relays its diagnostics here. Previously this buffer was only
-  // ever read if tauri-driver exited *early* — so when the far more
-  // common failure happened instead (the session failing to start, e.g.
-  // "DevToolsActivePort file doesn't exist"), everything the native
-  // driver said about why was silently discarded. Expose it so the
-  // caller can print it on any failure.
-  child.getDriverOutput = () => output;
-
   return child;
 }
 
-export async function createDriver(webdriverPort, application) {
+export async function createDriver(webdriverPort, debugPort) {
   return new Builder()
     .usingServer(`http://127.0.0.1:${webdriverPort}/`)
     .withCapabilities({
-      browserName: 'wry',
-      'tauri:options': { application },
+      browserName: 'webview2',
+      'ms:edgeOptions': { debuggerAddress: `127.0.0.1:${debugPort}` },
     })
     .build();
+}
+
+/**
+ * Resize the page's viewport.
+ *
+ * The replacement for `driver.manage().window().setRect()`, which an
+ * attached session refuses (`setWindowRect: false`). Selenium's own CDP
+ * passthrough is not available either -- `sendDevToolsCommand` is undefined
+ * on the generic driver this returns -- so this speaks CDP directly over the
+ * debug port we already have.
+ *
+ * `Emulation.setDeviceMetricsOverride` changes what the page believes its
+ * viewport is, which is what the responsive assertions actually test. It
+ * does not move the OS window, so a screenshot still shows the real frame.
+ */
+export async function setViewport(debugPort, { width, height }) {
+  if (typeof WebSocket === 'undefined') {
+    throw new Error('Global WebSocket is required to resize the viewport; use Node 22.4 or newer.');
+  }
+
+  const targets = await fetch(`http://127.0.0.1:${debugPort}/json/list`).then((r) => r.json());
+  const page = targets.find((target) => target.type === 'page' && target.webSocketDebuggerUrl);
+  if (!page) {
+    throw new Error(`No CDP page target on port ${debugPort}; found: ${JSON.stringify(targets.map((t) => t.type))}`);
+  }
+
+  const socket = new WebSocket(page.webSocketDebuggerUrl);
+  try {
+    await new Promise((resolve, reject) => {
+      socket.onopen = resolve;
+      socket.onerror = () => reject(new Error('CDP websocket failed to open'));
+    });
+    const reply = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('CDP setDeviceMetricsOverride timed out')), 10_000);
+      socket.onmessage = (message) => {
+        const data = JSON.parse(message.data);
+        if (data.id !== 1) return;
+        clearTimeout(timer);
+        resolve(data);
+      };
+      socket.send(JSON.stringify({
+        id: 1,
+        method: 'Emulation.setDeviceMetricsOverride',
+        params: { width, height, deviceScaleFactor: 1, mobile: false },
+      }));
+    });
+    if (reply.error) {
+      throw new Error(`CDP setDeviceMetricsOverride failed: ${JSON.stringify(reply.error)}`);
+    }
+  } finally {
+    socket.close();
+  }
 }

--- a/apps/netscli-gui/e2e/tauri-render/paths.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/paths.mjs
@@ -1,4 +1,3 @@
-import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -9,6 +8,3 @@ export const guiRoot = path.resolve(e2eRoot, '..');
 export const repoRoot = path.resolve(guiRoot, '..', '..');
 export const artifactsDir = path.join(e2eRoot, 'artifacts');
 export const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-export const tauriDriverBin =
-  process.env.TAURI_DRIVER ??
-  path.join(os.homedir(), '.cargo', 'bin', process.platform === 'win32' ? 'tauri-driver.exe' : 'tauri-driver');

--- a/apps/netscli-gui/e2e/tauri-render/processes.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/processes.mjs
@@ -71,7 +71,7 @@ export function waitForPort(port, timeoutMs = 20_000) {
  * Kill a spawned process *and everything it spawned*.
  *
  * `child.kill()` alone signals only the direct child (M-13). The processes
- * this suite starts are supervisors — `tauri-driver` spawns the platform
+ * this suite starts are supervisors — msedgedriver spawns the platform
  * WebDriver, which spawns the browser — so the grandchildren survived, kept
  * holding their ports, and the next run failed to bind or attached to a stale
  * session. On CI the job simply hung until its timeout.

--- a/apps/netscli-gui/eslint.config.js
+++ b/apps/netscli-gui/eslint.config.js
@@ -76,6 +76,9 @@ export default tseslint.config(
         fetch: 'readonly',
         process: 'readonly',
         setTimeout: 'readonly',
+        // Used to speak CDP directly for viewport resizing, which an
+        // attached WebDriver session cannot do. Global since Node 22.4.
+        WebSocket: 'readonly',
       },
     },
   },


### PR DESCRIPTION
This suite has never passed. Every run ended at session creation with `session not created: DevToolsActivePort file doesn't exist`, and the note in `gui-render.yml` concluded no fix was possible on our side.

**There were two problems stacked on each other. This fixes one of them.**

## The one that's fixed

The app *does* honour `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` and *does* open the port it's asked for — I verified that directly. What actually happened is that msedgedriver reads the chosen port back out of a `DevToolsActivePort` file inside the temporary `--user-data-dir` it created, while wry writes that file into Tauri's own WebView2 profile at `%LOCALAPPDATA%\<identifier>\EBWebView\`. The file exists; the driver looks somewhere it never is, waits 60 seconds, and gives up. The error was true from the driver's point of view and useless from ours.

The harness now starts the app itself on a port of its choosing and hands the driver `debuggerAddress` to attach to something already running. No port-file lookup happens, and `tauri-driver` drops out of the path entirely — its one job was the launch that breaks.

Two consequences:

- An attached session reports `setWindowRect: false`, so the two window resizes become viewport overrides sent over CDP. Arguably the more honest tool anyway: the responsive assertions care what the page thinks its viewport is, not where the OS window sits. (`sendDevToolsCommand` is undefined on this driver, so it speaks CDP directly.)
- The first run that got far enough to assert anything failed on a stale History menu — nine entries where it expected the one scan it had just performed. WebView2 keeps one profile per identifier, so `localStorage` survived between runs and leaked in from ordinary use of the app on the same machine. Each run now gets a fresh profile directory.

**Locally this works.** The suite attaches, drives a live port scan against the probe server, and captures screenshots of the real app. It does not pass yet — the remaining failures are assertions to triage, at least one of which encodes an assumption about which interface the host picks. That's ordinary test work, and it was impossible to even begin while no session could be created.

## The one that isn't

A dispatch of this workflow on this branch failed with `Timed out waiting for port` after a clean build, with WebView2 and Edge both at 151.0.4129.72 — ruling out the version mismatch this can look like. On a hosted runner the app never opens the debug port at all.

That is the *original* documented failure, and it is not fixable from here: Microsoft documents `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` as ignored on an elevated host, and hosted Windows runners are elevated.

My first commit here claimed the old diagnosis "was measured and found wrong". That was too strong and the second commit corrects it. The old note was wrong that no fix existed on our side, and right about the elevation. The diagnostic step now prints elevation so the next run measures the remaining blocker rather than inferring it — I have strong evidence the port doesn't open and a documented explanation, but had not directly measured elevation on the runner.

## What this is worth

The suite becomes usable locally and on any non-elevated Windows host, which is the first time it has been usable anywhere. Given the audit found no user journey has ever been walked automatically against the desktop app, that matters more than the CI status does.

`gui-render.yml` stays schedule-and-dispatch only. Nothing about this makes it a PR gate yet.