### PR TITLE
Stop the traffic reading vanishing on tunnel and VPN interfaces

### DIFF
--- a/apps/netscli-gui/src-tauri/src/commands/mod.rs
+++ b/apps/netscli-gui/src-tauri/src/commands/mod.rs
@@ -7,7 +7,7 @@ pub(crate) use files::{
     get_file_save_preferences, open_result_bundle, open_saved_artifact, reveal_saved_artifact,
     save_result_bundle, set_file_save_ask_each_time,
 };
-pub(crate) use monitor::{get_default_interface, get_network_stats};
+pub(crate) use monitor::{get_default_interface, get_network_stats, list_monitorable_interfaces};
 pub(crate) use operations::{
     cancel_operation, capture_pcap, discover_mdns, discover_network, dns_lookup, get_arp_table,
     inspect_host_cmd, list_interfaces, mdns_capability, open_pcap_file, pcap_capability, ping_host,

--- a/apps/netscli-gui/src-tauri/src/commands/monitor.rs
+++ b/apps/netscli-gui/src-tauri/src/commands/monitor.rs
@@ -48,3 +48,22 @@ pub(crate) async fn get_default_interface() -> Result<serde_json::Value, String>
         None => Err("No network interface found".to_string()),
     }
 }
+
+/// Interface names the traffic monitor can actually read counters for.
+///
+/// This is deliberately a separate list from `list_interfaces`. The two come
+/// from different enumerations -- interfaces from the platform adapter list,
+/// counters from `sysinfo` -- and they do not agree: tunnel and VPN adapters
+/// routinely appear in the first and not the second. Selecting one of those
+/// leaves the traffic display permanently empty, so the frontend needs to
+/// know which names are monitorable *before* it picks one.
+#[tauri::command]
+pub(crate) async fn list_monitorable_interfaces(
+    monitor: tauri::State<'_, Mutex<Option<NetworkMonitor>>>,
+) -> Result<Vec<String>, String> {
+    let mut monitor = monitor
+        .lock()
+        .map_err(|e| format!("Failed to acquire monitor lock: {e}"))?;
+    let monitor = monitor.get_or_insert_with(NetworkMonitor::new);
+    Ok(monitor.available_interfaces())
+}

--- a/apps/netscli-gui/src-tauri/src/main.rs
+++ b/apps/netscli-gui/src-tauri/src/main.rs
@@ -10,10 +10,10 @@ use commands::{
     cancel_operation, capture_pcap, choose_file_save_default_directory,
     clear_file_save_default_directory, discover_mdns, discover_network, dns_lookup,
     export_text_file, get_arp_table, get_default_interface, get_file_save_preferences,
-    get_network_stats, inspect_host_cmd, list_interfaces, mdns_capability, open_pcap_file,
-    open_result_bundle, open_saved_artifact, pcap_capability, ping_host, reveal_saved_artifact,
-    reverse_dns_lookup, save_result_bundle, scan_ports, set_file_save_ask_each_time, sweep_network,
-    trace_route_cmd,
+    get_network_stats, inspect_host_cmd, list_interfaces, list_monitorable_interfaces,
+    mdns_capability, open_pcap_file, open_result_bundle, open_saved_artifact, pcap_capability,
+    ping_host, reveal_saved_artifact, reverse_dns_lookup, save_result_bundle, scan_ports,
+    set_file_save_ask_each_time, sweep_network, trace_route_cmd,
 };
 use netscli_core::NetworkMonitor;
 use state::{ArtifactRegistry, OperationManager};
@@ -75,6 +75,7 @@ fn main() {
             choose_file_save_default_directory,
             clear_file_save_default_directory,
             get_network_stats,
+            list_monitorable_interfaces,
             get_default_interface
         ])
         .run(tauri::generate_context!())

--- a/apps/netscli-gui/src/components/shell/StatusBar.tsx
+++ b/apps/netscli-gui/src/components/shell/StatusBar.tsx
@@ -34,7 +34,16 @@ export function StatusBar({
   const interfaceAddress = preferredStatusAddress(interfaceInfo?.ips ?? [], addressPreference);
   const resultText = activeTab ? footerResultText(activeTab, rowCount, selectedCount) : null;
   const operationText = activeTab?.busy ? `Running ${TOOL_CONFIG[activeTab.kind].label}` : null;
+  // Three states, not two. `null` is "no answer yet", which is momentary and
+  // correctly shows nothing. `available: false` is the backend saying it
+  // cannot read counters for this interface -- which is not momentary, and
+  // used to render as an absent element, so the traffic display simply
+  // vanished with no way to tell a broken feature from a missing one. It is
+  // permanent for anyone whose interface is a tunnel or VPN adapter, because
+  // traffic counters come from a different enumeration than the interface
+  // list and those adapters appear in only one of them.
   const showTrafficStats = Boolean(networkStats?.available);
+  const trafficUnavailable = Boolean(networkStats && !networkStats.available);
 
   return (
     <footer className="statusbar" data-testid="statusbar">
@@ -62,6 +71,18 @@ export function StatusBar({
               stats={networkStats}
               unit={trafficDisplayUnit}
             />
+          </>
+        )}
+        {trafficUnavailable && (
+          <>
+            <span className="divider" />
+            <span
+              className="traffic-unavailable"
+              data-testid="traffic-unavailable"
+              data-tooltip={`No traffic counters for ${interfaceInfo?.name ?? 'this interface'}. Pick another interface in Settings to see throughput.`}
+            >
+              no traffic data
+            </span>
           </>
         )}
         {operationText && (

--- a/apps/netscli-gui/src/services/netscli.ts
+++ b/apps/netscli-gui/src/services/netscli.ts
@@ -169,6 +169,12 @@ export async function getNetworkStats(interfaceName?: string | null): Promise<Ne
   return invoke<NetworkStats>('get_network_stats', { interface: interfaceName?.trim() || null });
 }
 
+/** Interfaces the traffic monitor can read counters for -- a different, and
+ *  usually smaller, set than `listInterfaces`. See the Rust command. */
+export async function listMonitorableInterfaces(): Promise<string[]> {
+  return invoke<string[]>('list_monitorable_interfaces');
+}
+
 export async function getDefaultInterface(): Promise<DefaultInterfaceInfo> {
   return invoke<DefaultInterfaceInfo>('get_default_interface');
 }

--- a/apps/netscli-gui/src/styles/shell/command-status.css
+++ b/apps/netscli-gui/src/styles/shell/command-status.css
@@ -64,6 +64,15 @@
   white-space: nowrap;
 }
 
+/* Shown when the backend reports no traffic counters for the selected
+   interface. Muted rather than styled as an error: it is a limitation of
+   which adapters expose counters, not a fault the user caused. */
+.traffic-unavailable {
+  min-width: 0;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
 .traffic-rate {
   display: inline-flex;
   align-items: center;

--- a/apps/netscli-gui/src/workspace/trafficInterface.test.ts
+++ b/apps/netscli-gui/src/workspace/trafficInterface.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { pickTrafficInterface } from './useNetworkStatus';
+import type { DefaultInterfaceInfo, InterfaceInfo } from '../types/netscli';
+
+/**
+ * The status bar showed no throughput at all, permanently, on any machine
+ * whose default interface was a tunnel or VPN adapter.
+ *
+ * Traffic counters come from a different enumeration than the interface
+ * list, and the two disagree. Measured on one Windows machine: twelve
+ * interfaces listed, five with counters, and seven -- including the
+ * Tailscale adapter that was up and was chosen first -- present in the list
+ * and absent from the counters. Selecting one of those left the traffic
+ * display empty with nothing to explain it.
+ *
+ * The fixture below is that machine.
+ */
+const iface = (name: string, is_up = true, is_loopback = false): InterfaceInfo =>
+  ({ name, ips: [], is_up, is_loopback }) as unknown as InterfaceInfo;
+
+const LISTED: InterfaceInfo[] = [
+  iface('Eth 1G', false),
+  iface('Tailscale'),
+  iface('Eth 2.5G'),
+  iface('WiFi', false),
+  iface('VMware Network Adapter VMnet1'),
+  iface('Loopback Pseudo-Interface 1', true, true),
+];
+
+// What `sysinfo` reports counters for: no Tailscale, no WiFi, no loopback.
+const MONITORABLE = ['Eth 2.5G', 'VMware Network Adapter VMnet1'];
+
+const asDefault = (name: string): DefaultInterfaceInfo =>
+  ({ name, ips: [], is_up: true }) as unknown as DefaultInterfaceInfo;
+
+describe('pickTrafficInterface', () => {
+  it('does not pick the platform default when its throughput cannot be read', () => {
+    // The regression. The platform default here is Tailscale, which has no
+    // counters; the old order took it unconditionally and the traffic
+    // display went blank for good.
+    const picked = pickTrafficInterface(asDefault('Tailscale'), LISTED, MONITORABLE);
+
+    expect(picked).not.toBe('Tailscale');
+    expect(MONITORABLE).toContain(picked);
+    expect(picked).toBe('Eth 2.5G');
+  });
+
+  it('keeps the platform default when it can be read', () => {
+    // The fix must not override a perfectly good default.
+    expect(pickTrafficInterface(asDefault('Eth 2.5G'), LISTED, MONITORABLE)).toBe('Eth 2.5G');
+  });
+
+  it('prefers an interface that is up over one that merely has counters', () => {
+    const listed = [iface('Eth 1G', false), iface('Eth 2.5G')];
+    expect(pickTrafficInterface(null, listed, ['Eth 1G', 'Eth 2.5G'])).toBe('Eth 2.5G');
+  });
+
+  it('still returns something when nothing is monitorable', () => {
+    // An honest "no traffic data" against a named interface beats an empty
+    // status bar, so the old ordering remains the fallback.
+    expect(pickTrafficInterface(asDefault('Tailscale'), LISTED, [])).toBe('Tailscale');
+    expect(pickTrafficInterface(null, LISTED, [])).toBe('Tailscale');
+  });
+
+  it('falls back to a down interface with counters rather than nothing', () => {
+    const listed = [iface('Eth 1G', false)];
+    expect(pickTrafficInterface(null, listed, ['Eth 1G'])).toBe('Eth 1G');
+  });
+
+  it('returns null when there are no interfaces at all', () => {
+    expect(pickTrafficInterface(null, [], [])).toBeNull();
+  });
+});

--- a/apps/netscli-gui/src/workspace/useNetworkStatus.ts
+++ b/apps/netscli-gui/src/workspace/useNetworkStatus.ts
@@ -35,6 +35,43 @@ function toStatusInterface(iface: InterfaceInfo): DefaultInterfaceInfo {
   };
 }
 
+/**
+ * Choose the interface whose throughput to display.
+ *
+ * Preferring a monitorable name is the whole point. Traffic counters come
+ * from a different enumeration than the interface list, and tunnel and VPN
+ * adapters routinely appear in the list without appearing in the counters --
+ * on one machine, seven of twelve interfaces had no counterpart, including
+ * the Tailscale adapter that was up and was what the old order selected
+ * first. The result was a status bar that silently showed no throughput at
+ * all, permanently.
+ *
+ * The previous order is kept as the fallback rather than replaced: if
+ * nothing is monitorable, showing the platform's default interface and an
+ * honest "no traffic data" beats showing nothing at all.
+ */
+export function pickTrafficInterface(
+  iface: DefaultInterfaceInfo | null,
+  allInterfaces: InterfaceInfo[],
+  monitorable: string[],
+): string | null {
+  const canMonitor = (name: string | undefined | null): name is string =>
+    Boolean(name) && monitorable.includes(name as string);
+
+  const usable = allInterfaces.filter((item) => item.is_up && !item.is_loopback);
+  return (
+    // The platform default, but only if its throughput can actually be read.
+    (canMonitor(iface?.name) ? iface?.name : undefined) ??
+    usable.find((item) => canMonitor(item.name))?.name ??
+    allInterfaces.find((item) => canMonitor(item.name))?.name ??
+    // Nothing monitorable: fall back to what this always did.
+    iface?.name ??
+    usable[0]?.name ??
+    allInterfaces[0]?.name ??
+    null
+  );
+}
+
 export function useNetworkStatus(showToast: (toast: Omit<WorkspaceToast, 'id'>) => void) {
   const demoScreenshotMode = isDemoScreenshotMode();
   const [networkStats, setNetworkStats] = useState<NetworkStats | null>(
@@ -100,15 +137,18 @@ export function useNetworkStatus(showToast: (toast: Omit<WorkspaceToast, 'id'>) 
     const loadInterfaceInfo = async () => {
       if (!isDocumentVisible()) return;
       try {
-        const [iface, allInterfaces] = await Promise.all([
+        const [iface, allInterfaces, monitorable] = await Promise.all([
           netscli.getDefaultInterface().catch(() => null),
           netscli.listInterfaces().catch(() => null),
+          // Failure here is not fatal: an empty list simply means selection
+          // falls back to the order it always used.
+          netscli.listMonitorableInterfaces().catch(() => []),
         ]);
         if (stopped) return;
         if (iface) setDefaultInterface(iface);
         if (allInterfaces) {
           setInterfaces(allInterfaces);
-          initializeTrafficInterface(iface, allInterfaces);
+          initializeTrafficInterface(iface, allInterfaces, monitorable ?? []);
         }
 
         // Every failure here used to be swallowed on a 30s timer, so a
@@ -180,16 +220,15 @@ export function useNetworkStatus(showToast: (toast: Omit<WorkspaceToast, 'id'>) 
     };
   }, [demoScreenshotMode, trafficInterfaceName]);
 
-  function initializeTrafficInterface(iface: DefaultInterfaceInfo | null, allInterfaces: InterfaceInfo[]) {
+  function initializeTrafficInterface(
+    iface: DefaultInterfaceInfo | null,
+    allInterfaces: InterfaceInfo[],
+    monitorable: string[],
+  ) {
     if (initializedTrafficInterface.current) return;
     const saved = initialTrafficInterfaceName();
     const savedExists = saved && allInterfaces.some((item) => item.name === saved);
-    const fallback =
-      iface?.name ??
-      allInterfaces.find((item) => item.is_up && !item.is_loopback)?.name ??
-      allInterfaces[0]?.name ??
-      null;
-    const next = savedExists ? saved : fallback;
+    const next = savedExists ? saved : pickTrafficInterface(iface, allInterfaces, monitorable);
     if (next) {
       setTrafficInterfaceNameState(next);
       window.localStorage.setItem('netscli-traffic-interface', next);


### PR DESCRIPTION
The status bar's throughput display disappeared entirely — numbers, unit and divider — leaving a silently shorter bar with nothing to explain it. Not a flicker: **permanent**, for anyone whose default interface is a tunnel or VPN adapter.

Found by the reworked render suite (#233) on its first real run, which is roughly the point of getting that suite working.

## Why

Two enumerations disagree, and nothing reconciles them:

| Source | Feeds | Count on one Windows machine |
|---|---|---|
| platform adapter list | the interface picker and auto-selection | 12 |
| `sysinfo` | traffic counters | 5 |
| **listed but no counters** | | **7** |

`sum_traffic` ([stats.rs:197](crates/netscli-core/src/stats.rs:197)) matches the selected interface by exact name and returns `available: false` when there is no match. `available: false` then made [StatusBar.tsx](apps/netscli-gui/src/components/shell/StatusBar.tsx) drop the whole block.

Among those seven was the **Tailscale adapter — up, and exactly what selection chose first**, because `defaultInterface` comes from the same platform enumeration.

That also explains why it looked intermittent. Before an interface is chosen, `sum_traffic` sums every adapter and reports available, so the reading appears. The moment selection lands on an unmonitorable name, it stops matching and the block is gone for the session.

## Two faults, two changes

**The status bar now has three states, not two.** `null` still renders nothing — that's momentary, and flashing a message during startup would be its own defect. `available: false` renders `no traffic data` with a tooltip naming the interface, because that is the backend saying it cannot read counters, and a user deserves to tell a broken feature from a missing one.

**Selection no longer picks an interface whose throughput can never be read.** A new `list_monitorable_interfaces` command exposes the names the monitor actually knows about — deliberately a *separate* list, since the mismatch between the two enumerations is the whole problem — and the platform default is taken only if it appears there. The previous ordering stays as the fallback: where nothing is monitorable, a named interface plus an honest "no traffic data" beats an empty status bar.

## Verification

The regression test fixture is the machine described above. Confirmed it **fails against the old ordering** (`expected 'Tailscale' not to be 'Tailscale'`) and passes with the fix.

127 GUI tests pass (up from 121), `tsc -b`, `eslint`, the size guard, `cargo fmt` and `clippy -D warnings` all clean.

## Not done here

The interface picker still *offers* interfaces that cannot report throughput; it just no longer selects one for you. Marking them in the picker is a further step and a design question, so it is not bundled in.