### PR TITLE
Verify all three crates before uploading any of them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,47 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  # Prove the crates still package, long before release day.
+  #
+  # `cargo publish` is the one step of a release that cannot be undone:
+  # crates.io has no unpublish, only yank, and a yanked version still holds
+  # its number forever. Until now nothing exercised packaging until the
+  # release was already public and the upload was running.
+  #
+  # Dry-running all three together is what makes this possible at all. The
+  # dependent crates require `netscli-core = "^0.3.0"`, which does not exist
+  # on the index before release, so packaging them individually fails on
+  # resolution -- with or without `--no-verify`. Passing the whole set lets
+  # cargo resolve them from the workspace instead, and it builds each
+  # packaged copy to confirm it compiles standing alone.
+  #
+  # Push and dispatch only, not pull_request. It compiles the packaged copy
+  # of the workspace from scratch, which is minutes, and a packaging break
+  # caught at merge is still caught a long way from a release.
+  publish-dry-run:
+    name: Crate packaging (publish dry run)
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpcap-dev pkg-config
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.96.0"
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: publish-dry-run
+      # Mirrors the real publish in publish.yml exactly, minus the upload.
+      # If these two ever diverge, this check stops meaning anything.
+      - name: cargo publish --dry-run (all three crates)
+        run: cargo publish --dry-run -p netscli-core -p netscli-mcp -p netscli
+
   # ─── Required status check ────────────────────────────────────────────
   #
   # This is the ONLY job from this workflow that should be marked required
@@ -357,6 +398,7 @@ jobs:
       - test
       - gui-build
       - release-build
+      - publish-dry-run
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,24 +87,30 @@ jobs:
       - name: Install libpcap (workspace builds need pkg-config + libpcap headers)
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev pkg-config
 
-      - name: cargo publish (netscli-core)
-        run: cargo publish -p netscli-core --token "$CARGO_TOKEN"
-        env:
-          CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-      - name: Wait for crates.io index (netscli-core)
-        run: sleep 90
-
-      - name: cargo publish (netscli-mcp)
-        run: cargo publish -p netscli-mcp --token "$CARGO_TOKEN"
-        env:
-          CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-      - name: Wait for crates.io index (netscli-mcp)
-        run: sleep 90
-
-      - name: cargo publish (netscli)
-        run: cargo publish -p netscli --token "$CARGO_TOKEN"
+      # Verify all three before uploading any of them.
+      #
+      # This used to be three sequential `cargo publish` calls with two
+      # hardcoded `sleep 90` index waits between them. The failure that shape
+      # invites is the expensive one: netscli-core uploads, netscli-mcp or
+      # netscli then fails to package, and 0.3.0 of the core crate is public
+      # and permanent -- crates.io has no unpublish -- while the CLI never
+      # ships. The only way out is burning the next patch number across all
+      # three.
+      #
+      # Publishing the set in one command removes that. Cargo resolves the
+      # not-yet-published inter-crate dependencies from the workspace,
+      # packages every member, builds each packaged copy to verify it
+      # compiles standing alone, and only then uploads -- in dependency
+      # order, waiting on the index itself rather than on a guessed sleep.
+      # Anything wrong with packaging or compilation is caught while nothing
+      # has been uploaded.
+      #
+      # What this does NOT make atomic: an upload failing partway through
+      # after an earlier one succeeded. crates.io has no transaction across
+      # crates, so that window cannot be closed from here -- it is just far
+      # narrower than "the CLI does not package".
+      - name: cargo publish (all three crates)
+        run: cargo publish -p netscli-core -p netscli-mcp -p netscli --token "$CARGO_TOKEN"
         env:
           CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
`cargo publish` is the one step of a release that cannot be undone. crates.io has no unpublish — only yank, and a yanked version still holds its number forever.

## The failure this removes

The `crates-io` job ran three sequential publishes with two hardcoded `sleep 90` index waits. That shape invites the expensive failure:

1. `netscli-core` uploads → **permanent**
2. `netscli-mcp` or `netscli` fails to package
3. 0.3.0 of the core crate is public forever, the CLI never ships

The only escape is burning the next patch number across all three.

Publishing the set in one command removes it. Cargo resolves the not-yet-published inter-crate dependencies from the workspace, packages every member, **builds each packaged copy to confirm it compiles standing alone, and only then uploads** — in dependency order, waiting on the index itself rather than a guessed sleep. Anything wrong with packaging or compilation is caught while nothing has been uploaded. The two `sleep 90`s go with it.

## Why this also unlocks a dry run

Worth stating because it isn't obvious. The dependent crates require `netscli-core = "^0.3.0"`, which doesn't exist on the index before release, so packaging them individually fails during resolution — before any build, and **with or without `--no-verify`**:

```
error: failed to prepare local package for uploading
  failed to select a version for the requirement `netscli-core = "^0.3.0"`
  candidate versions found which didn't match: 0.2.6, 0.2.5, 0.2.4, ...
```

Passing the whole set lets cargo resolve them from the workspace instead. So CI now runs *exactly the same command* with `--dry-run`, and packaging is exercised on every push to main rather than for the first time during a release.

The new job is push-and-dispatch only, not `pull_request`: it compiles the packaged workspace from scratch, and a packaging break caught at merge is still caught a long way from a release. A skipped job satisfies the gate, per the existing `ci-gate` design.

## What this does *not* fix

An upload failing partway through after an earlier one succeeded. crates.io has no transaction across crates, so that window can't be closed from here. It's simply far narrower than "the CLI doesn't package".

## Verification

- `cargo publish --dry-run -p netscli-core -p netscli-mcp -p netscli` locally: all three package, all three build, **exit 0** — where each individually fails on resolution.
- The dry-run and real commands were compared programmatically to confirm identical package sets; if they ever diverge the check stops meaning anything.
- Both workflows parse as valid YAML; `publish-dry-run` is in `ci-gate`'s `needs`.