### PR TITLE
Add the gate tests the implementation plan referenced but did not have

### DIFF
--- a/crates/netscli-core/tests/test_discover.rs
+++ b/crates/netscli-core/tests/test_discover.rs
@@ -1,0 +1,123 @@
+//! Gate 3 baseline: discovery and hostname contract.
+//!
+//! Phase 3 of IMPLEMENTATION_PLAN.md replaces single-protocol reverse DNS
+//! with a fused resolver across DNS PTR, mDNS, LLMNR and NetBIOS. `Host`
+//! keeps its shape through that, but `Host.hostname` changes *meaning*: a
+//! NetBIOS name and a DNS PTR name for the same machine are frequently
+//! different strings. These pin what stays true either way.
+//!
+//! Scope note: discovery on a real subnet depends on what is plugged in, so
+//! these use a loopback /30 -- two host addresses, no traffic off the
+//! machine, and a bounded runtime on any runner.
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use ipnet::Ipv4Net;
+use netscli_core::DiscoverEngine;
+
+/// 127.0.0.0/30: hosts .1 and .2, both loopback, neither routed anywhere.
+fn loopback_slash_30() -> Ipv4Net {
+    "127.0.0.0/30".parse().expect("a valid /30")
+}
+
+#[tokio::test]
+async fn a_small_subnet_scan_completes_and_is_bounded() {
+    let engine = DiscoverEngine::new_with_timeouts(8, 300, 300);
+
+    let started = std::time::Instant::now();
+    let hosts = engine
+        .scan_subnet(loopback_slash_30(), false)
+        .await
+        .expect("scanning a /30 must succeed");
+    let elapsed = started.elapsed();
+
+    // Two host addresses at a 300ms ping timeout. A generous ceiling, since
+    // what this catches is a scan that ignores its timeouts entirely.
+    assert!(
+        elapsed.as_secs() < 30,
+        "a /30 scan should not take {elapsed:?}"
+    );
+    // Every returned host must be inside the range that was asked for --
+    // the fused resolver must not widen what gets probed.
+    for host in &hosts {
+        let IpAddr::V4(v4) = host.ip else {
+            panic!("an IPv4 subnet scan returned a non-IPv4 host: {host:?}");
+        };
+        assert!(
+            loopback_slash_30().contains(&v4),
+            "{v4} is outside the scanned range"
+        );
+    }
+}
+
+#[tokio::test]
+async fn resolving_names_does_not_change_which_hosts_are_returned() {
+    // Phase 3 fires four resolvers per host. Name resolution must stay a
+    // decoration on the host list, not something that adds or drops entries.
+    let engine = DiscoverEngine::new_with_timeouts(8, 300, 300);
+
+    let without = engine
+        .scan_subnet(loopback_slash_30(), false)
+        .await
+        .unwrap();
+    let with = engine.scan_subnet(loopback_slash_30(), true).await.unwrap();
+
+    let mut a: Vec<IpAddr> = without.iter().map(|h| h.ip).collect();
+    let mut b: Vec<IpAddr> = with.iter().map(|h| h.ip).collect();
+    a.sort_unstable();
+    b.sort_unstable();
+    assert_eq!(a, b, "resolving names changed the set of hosts found");
+}
+
+#[tokio::test]
+async fn a_hostname_is_never_blank_or_control_laden() {
+    // Names arrive from whatever answers on the link. NetBIOS and LLMNR
+    // (Phase 3) are answered by anything that feels like replying, so a
+    // hostname is attacker-influenced text: it must be either absent or
+    // meaningful, never an empty string or a terminal control sequence.
+    let engine = DiscoverEngine::new_with_timeouts(8, 300, 300);
+    let hosts = engine.scan_subnet(loopback_slash_30(), true).await.unwrap();
+
+    for host in &hosts {
+        let Some(name) = host.hostname.as_deref() else {
+            continue;
+        };
+        assert!(!name.trim().is_empty(), "empty hostname on {}", host.ip);
+        assert!(
+            !name.chars().any(char::is_control),
+            "control character in hostname {name:?} for {}",
+            host.ip
+        );
+    }
+}
+
+#[tokio::test]
+async fn the_engine_refuses_a_subnet_over_the_limit() {
+    // Public API re-exported at the crate root: the /16 cap has to hold here
+    // and not only in `Ops`. Phase 3 touches this function's body.
+    let engine = DiscoverEngine::new_with_timeouts(8, 300, 300);
+    let error = engine
+        .scan_subnet("0.0.0.0/0".parse().unwrap(), false)
+        .await
+        .expect_err("an unbounded subnet must be refused");
+    assert!(
+        error.to_string().contains("subnet too large"),
+        "got: {error}"
+    );
+}
+
+#[tokio::test]
+async fn hosts_serialize_with_the_fields_downstream_reads() {
+    let host = netscli_core::Host {
+        ip: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)),
+        hostname: Some("device.local".to_string()),
+        mac: Some("00:11:22:33:44:55".to_string()),
+        vendor: Some("Example Corp".to_string()),
+        rtt_ms: Some(3),
+    };
+
+    let value = serde_json::to_value(&host).expect("Host serializes");
+    for key in ["ip", "hostname", "mac", "vendor"] {
+        assert!(value.get(key).is_some(), "missing {key}: {value}");
+    }
+}

--- a/crates/netscli-core/tests/test_ping.rs
+++ b/crates/netscli-core/tests/test_ping.rs
@@ -1,0 +1,95 @@
+//! Gate 2 baseline: ping contract.
+//!
+//! Phase 2 of IMPLEMENTATION_PLAN.md replaces the probe mechanism entirely --
+//! `IcmpSendEcho2` on Windows, unprivileged ICMP datagram sockets on Unix --
+//! while promising `PingResult`, `PingScanner` and their signatures survive.
+//! These pin that promise.
+//!
+//! What they deliberately do *not* assert is that a ping succeeds. Whether
+//! ICMP is permitted depends on privileges and, on Linux, on
+//! `net.ipv4.ping_group_range`; whether the TCP fallback finds anything
+//! depends on what is listening. A gate that fails because a CI runner
+//! forbids raw sockets is a gate people learn to ignore. So these assert the
+//! shape of the answer and that one always arrives.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::time::Instant;
+
+use netscli_core::PingScanner;
+
+#[tokio::test]
+async fn a_ping_always_answers_with_a_well_formed_result() {
+    let scanner = PingScanner::new(1);
+    let target = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+    let result = scanner.ping(target, 1_000).await;
+
+    assert_eq!(
+        result.ip, target,
+        "the result must name the target it probed"
+    );
+    assert!(
+        result.method.is_some(),
+        "every result must say which mechanism produced it: {result:?}"
+    );
+    // `seq` is drawn from a process-global counter, so its absolute value
+    // depends on what else in this binary has pinged. Only allocation is
+    // assertable -- see the note in config_safety.rs.
+    assert!(result.seq >= 1);
+    if result.alive {
+        assert!(result.rtt_ms.is_some(), "a live host must carry an RTT");
+    }
+}
+
+#[tokio::test]
+async fn an_ipv6_target_is_handled_rather_than_panicking() {
+    // The current backend falls back to TCP for IPv6. Phase 2 adds native
+    // ICMPv6; either way this must return, not panic or hang.
+    let scanner = PingScanner::new(1);
+    let target = IpAddr::V6(Ipv6Addr::LOCALHOST);
+
+    let result = scanner.ping(target, 1_000).await;
+
+    assert_eq!(result.ip, target);
+    assert!(result.method.is_some());
+}
+
+#[tokio::test]
+async fn the_timeout_is_honoured_for_an_unroutable_target() {
+    // TEST-NET-1 (RFC 5737): reserved for documentation, never routed, so
+    // this exercises the timeout path without sending anything anywhere real.
+    let scanner = PingScanner::new(1);
+    let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+
+    let started = Instant::now();
+    let result = scanner.ping(target, 500).await;
+    let elapsed = started.elapsed();
+
+    assert_eq!(result.ip, target);
+    // Generous: the TCP fallback tries several ports in sequence, and CI
+    // runners are slow. This catches a probe that ignores its deadline
+    // entirely, which is the regression that matters.
+    assert!(
+        elapsed.as_secs() < 20,
+        "ping ignored its timeout: took {elapsed:?}"
+    );
+}
+
+#[tokio::test]
+async fn concurrency_zero_does_not_deadlock() {
+    // A zero-capacity semaphore would hang forever rather than fail.
+    let scanner = PingScanner::new(0);
+    let result = scanner.ping(IpAddr::V4(Ipv4Addr::LOCALHOST), 500).await;
+    assert_eq!(result.ip, IpAddr::V4(Ipv4Addr::LOCALHOST));
+}
+
+#[tokio::test]
+async fn results_serialize_with_the_fields_downstream_reads() {
+    let scanner = PingScanner::new(1);
+    let result = scanner.ping(IpAddr::V4(Ipv4Addr::LOCALHOST), 1_000).await;
+
+    let value = serde_json::to_value(&result).expect("PingResult serializes");
+    for key in ["ip", "alive", "seq"] {
+        assert!(value.get(key).is_some(), "missing {key}: {value}");
+    }
+}

--- a/crates/netscli-core/tests/test_scan.rs
+++ b/crates/netscli-core/tests/test_scan.rs
@@ -1,0 +1,132 @@
+//! Gate 4 baseline: TCP scanning contract.
+//!
+//! These pin what Phase 4 of IMPLEMENTATION_PLAN.md must not break while it
+//! adds `SO_LINGER=0` and adaptive pacing. They deliberately test the
+//! *current* contract rather than the unbuilt feature: a gate is only useful
+//! if it can run before the phase starts and still passes after it lands.
+//!
+//! Everything here is hermetic. The scanner is pointed at a listener this
+//! test binds itself, so there is no dependence on what happens to be
+//! running on the machine, and no packet leaves loopback.
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use netscli_core::{PortScanner, PortStatus};
+use tokio::net::TcpListener;
+
+const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+/// Bind a listener and return the port it landed on.
+async fn open_port() -> (TcpListener, u16) {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind a loopback listener");
+    let port = listener.local_addr().expect("listener address").port();
+    (listener, port)
+}
+
+/// A port nothing is listening on: bind one, read its number, drop it.
+async fn closed_port() -> u16 {
+    let (listener, port) = open_port().await;
+    drop(listener);
+    port
+}
+
+#[tokio::test]
+async fn an_open_port_is_reported_open() {
+    let (_listener, port) = open_port().await;
+    let scanner = PortScanner::new(8);
+
+    let results = scanner
+        .scan_host(LOCALHOST, vec![port], 2_000)
+        .await
+        .expect("scanning a bound loopback port must succeed");
+
+    assert_eq!(results.len(), 1);
+    let result = &results[0];
+    assert_eq!(result.port, port);
+    assert!(result.open, "a bound port must read as open: {result:?}");
+    assert_eq!(result.status, PortStatus::Open);
+}
+
+#[tokio::test]
+async fn a_closed_port_is_reported_but_not_open() {
+    let port = closed_port().await;
+    let scanner = PortScanner::new(8);
+
+    let results = scanner
+        .scan_host(LOCALHOST, vec![port], 2_000)
+        .await
+        .expect("scanning an unbound loopback port must still succeed");
+
+    // The result must be *present* and not open. This is the distinction
+    // `scan --json` used to erase by filtering to open ports only: a closed
+    // port and a port that was never scanned looked identical downstream.
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].port, port);
+    assert!(!results[0].open);
+    assert_ne!(results[0].status, PortStatus::Open);
+}
+
+#[tokio::test]
+async fn every_requested_port_comes_back() {
+    // Phase 4's pacing must not silently drop probes under concurrency.
+    let (_listener, open) = open_port().await;
+    let mut requested = vec![open];
+    for _ in 0..15 {
+        requested.push(closed_port().await);
+    }
+
+    let scanner = PortScanner::new(16);
+    let results = scanner
+        .scan_host(LOCALHOST, requested.clone(), 2_000)
+        .await
+        .expect("mixed open/closed scan must succeed");
+
+    assert_eq!(
+        results.len(),
+        requested.len(),
+        "every requested port must produce a result"
+    );
+    let mut got: Vec<u16> = results.iter().map(|r| r.port).collect();
+    let mut want = requested;
+    got.sort_unstable();
+    want.sort_unstable();
+    assert_eq!(got, want);
+}
+
+#[tokio::test]
+async fn the_scanner_validates_its_own_port_list() {
+    // Public API on a published crate: a consumer building a Vec<u16> by
+    // hand must not be able to bypass the caps that `Ops` applies.
+    let scanner = PortScanner::new(4);
+
+    assert!(
+        scanner.scan_host(LOCALHOST, vec![0], 500).await.is_err(),
+        "port 0 must be refused by the scanner itself"
+    );
+
+    let too_many: Vec<u16> = (1..=(netscli_core::MAX_PORTS_PER_SCAN as u16 + 1)).collect();
+    assert!(
+        scanner.scan_host(LOCALHOST, too_many, 500).await.is_err(),
+        "a list over MAX_PORTS_PER_SCAN must be refused"
+    );
+}
+
+#[tokio::test]
+async fn results_serialize_with_the_fields_downstream_reads() {
+    // The GUI, the MCP layer and `--json` all read these names. Phase 4 is
+    // free to change how a probe is performed; renaming what it reports is
+    // a breaking change to three surfaces at once.
+    let (_listener, port) = open_port().await;
+    let scanner = PortScanner::new(4);
+    let results = scanner
+        .scan_host(LOCALHOST, vec![port], 2_000)
+        .await
+        .unwrap();
+
+    let value = serde_json::to_value(&results[0]).expect("PortResult serializes");
+    assert!(value.get("port").is_some(), "port field: {value}");
+    assert!(value.get("open").is_some(), "open field: {value}");
+    assert!(value.get("status").is_some(), "status field: {value}");
+}

--- a/crates/netscli-core/tests/test_trace.rs
+++ b/crates/netscli-core/tests/test_trace.rs
@@ -1,0 +1,89 @@
+//! Gate 1 baseline: traceroute contract.
+//!
+//! Phase 1 of IMPLEMENTATION_PLAN.md replaces the subprocess shell-out with
+//! an in-process Paris tracer. The plan promises `TraceResult` and its
+//! `lines: Vec<String>` output survive that. This pins the promise.
+//!
+//! Two things worth knowing before adding to this file.
+//!
+//! `lines` is currently the external tool's own stdout, accumulated in
+//! `trace.rs`. Synthesising it in-process will produce *different text* even
+//! though the type is unchanged, so anything asserting exact line format
+//! here would have to be rewritten by Phase 1 -- which would make it a
+//! ratchet, not a gate. These assert invariants that should hold for either
+//! implementation.
+//!
+//! And the tool is not guaranteed to exist: GitHub's Ubuntu runners ship
+//! neither `traceroute` nor `tracepath`. A test that requires a successful
+//! trace would fail there for a reason unrelated to netscli, so these accept
+//! a clean error as a valid outcome. Phase 1 removes that caveat by removing
+//! the dependency -- at which point the `is_err()` arms become dead and
+//! should be tightened.
+
+use netscli_core::trace::trace_route;
+
+#[tokio::test]
+async fn a_trace_returns_a_result_or_a_clean_error_never_a_panic() {
+    // Loopback: at most one hop, and no packet leaves the machine.
+    let outcome = trace_route("127.0.0.1", 3, false, None).await;
+
+    match outcome {
+        Ok(result) => {
+            assert_eq!(result.host, "127.0.0.1", "the result must name its target");
+            assert!(
+                !result.tool.is_empty(),
+                "the result must say what produced it"
+            );
+        }
+        Err(error) => {
+            // Acceptable only while this shells out. See the module note.
+            let message = error.to_string();
+            assert!(!message.is_empty(), "an error must explain itself");
+        }
+    }
+}
+
+#[tokio::test]
+async fn trace_output_carries_no_terminal_control_sequences() {
+    // Hop names come from PTR records of routers on the path, which whoever
+    // runs those routers controls. An ESC reaching a terminal can repaint
+    // the screen and forge the output above it, so nothing in `lines` may
+    // carry one -- whoever produces those lines.
+    let Ok(result) = trace_route("127.0.0.1", 3, false, None).await else {
+        // No tracer available; nothing to inspect.
+        return;
+    };
+
+    for line in &result.lines {
+        assert!(
+            !line.chars().any(|c| c.is_control() && c != '\t'),
+            "control character in trace output: {line:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_trace_result_serializes_with_the_fields_downstream_reads() {
+    // `--json`, the MCP layer and the GUI all read these names.
+    let Ok(result) = trace_route("127.0.0.1", 2, false, None).await else {
+        return;
+    };
+
+    let value = serde_json::to_value(&result).expect("TraceResult serializes");
+    for key in ["host", "tool", "lines"] {
+        assert!(value.get(key).is_some(), "missing {key}: {value}");
+    }
+    assert!(value["lines"].is_array(), "lines must stay an array");
+}
+
+#[tokio::test]
+async fn an_unresolvable_host_fails_instead_of_hanging() {
+    // `.invalid` is reserved by RFC 2606 and never resolves.
+    let started = std::time::Instant::now();
+    let _ = trace_route("no-such-host.invalid", 2, false, None).await;
+    assert!(
+        started.elapsed().as_secs() < 60,
+        "an unresolvable target should not hang: {:?}",
+        started.elapsed()
+    );
+}


### PR DESCRIPTION
`IMPLEMENTATION_PLAN.md`'s verification gates run `test_trace`, `test_ping`, `test_discover` and `test_scan`. **None existed** — the only integration tests were `config_safety`, `mcp_stdio` and `tools_list` — so an agent executing the plan sequentially would have stalled at Gate 1 before writing a line of code.

## What these test, and why that choice

They pin the **current** contract, not the unbuilt feature. That's what makes them usable as gates: they pass today, and each phase must keep them passing. It turns the backward-compatibility guarantee the plan opens with into something checkable — result types, their serialized field names, and the invariants that hold however a probe is performed.

Assertions about a new mechanism belong to the phase that builds it.

Everything is hermetic: the scanner is pointed at a listener the test binds itself, discovery uses a loopback `/30`, and the unroutable target is TEST-NET-1 (RFC 5737, never routed). Nothing leaves the machine. 19 tests, all under 4 seconds.

## Two things I could not assert honestly

Both are recorded in the files rather than papered over.

**`traceroute` is not installed on GitHub's Ubuntu runners.** Requiring a successful trace would fail there for a reason unrelated to netscli, so `test_trace` accepts a clean error as a valid outcome. Phase 1 removes the dependency entirely, at which point those `is_err()` arms are dead and should be tightened into hard assertions.

**A successful ping is not assertable either.** Whether ICMP is permitted depends on privileges and, on Linux, on `net.ipv4.ping_group_range`. So `test_ping` asserts a well-formed answer always arrives and names the mechanism that produced it, rather than that the host replied. A gate that fails because a runner forbids raw sockets is one people learn to ignore.

## Plan corrections (local, since the file is gitignored)

Writing these surfaced things worth fixing in the plan itself:

- **`SO_REUSEADDR = 1` "for rapid ephemeral port recycling" is wrong** — it governs *bind* semantics and does nothing for ephemeral exhaustion on an outbound `connect()`. Dropped, with `SO_LINGER = 0` noted as the option actually doing the work — and its cost noted too, since RST-on-close is more conspicuous to a target's logs than the current polite close.
- **The traceroute target contradicted itself**: `<100ms` in the roadmap box, "under 1 second" in Gate 1. A trace cannot outrun its own timeouts — a silent hop must be waited out before it can be reported as silent. Reconciled to under 1 second for a responsive path.
- **Gate 3 gained the open design question**: "synthesize the first valid responding name" is a race, not a policy — four resolvers answering at different speeds means the same host gets different names between runs. Needs a fixed precedence order.
- **Gate 3 also gained a safety note**: this crate currently has zero panics on untrusted input. Hand-written NetBIOS and LLMNR decoders parsing hostile UDP are exactly where that property gets lost.
- **Gate 5 gained its inherited obligations**: new MCP tools need the target policy, the result caps and schema annotations. `get_topology_diff` also introduces persistent state to a server that has none today, which is a decision rather than an implementation detail.