### PR TITLE
Report the devices the OS already knows about

### DIFF
--- a/apps/netscli-cli/src/cli_formatter/tests.rs
+++ b/apps/netscli-cli/src/cli_formatter/tests.rs
@@ -121,6 +121,7 @@ fn hostile_host() -> netscli_core::discover::Host {
         mac: Some("aa:bb:cc:dd:ee:ff".to_string()),
         vendor: None,
         rtt_ms: Some(1),
+        found_by: netscli_core::FoundBy::Probe,
     }
 }
 

--- a/apps/netscli-gui/src/hooks/usePreferences.ts
+++ b/apps/netscli-gui/src/hooks/usePreferences.ts
@@ -51,14 +51,21 @@ function initialCommandBarVisible(): boolean {
   return window.localStorage.getItem('netscli-command-bar') !== 'off';
 }
 
+// Toasts are opt-in. They were opt-out, which meant a new user met the app
+// through a stream of notifications about things they had just done
+// themselves and could already see on screen. Both toggles remain in
+// Settings for anyone who wants the running commentary.
+//
+// Errors are not covered by these: a failure still surfaces, because the
+// alternative is a table that stays empty with no reason given.
 function initialInteractionToasts(): boolean {
-  if (typeof window === 'undefined') return true;
-  return window.localStorage.getItem('netscli-interaction-toasts') !== 'off';
+  if (typeof window === 'undefined') return false;
+  return window.localStorage.getItem('netscli-interaction-toasts') === 'on';
 }
 
 function initialOperationToasts(): boolean {
-  if (typeof window === 'undefined') return true;
-  return window.localStorage.getItem('netscli-operation-toasts') !== 'off';
+  if (typeof window === 'undefined') return false;
+  return window.localStorage.getItem('netscli-operation-toasts') === 'on';
 }
 
 function initialReleaseNotifications(): boolean {

--- a/apps/netscli-gui/src/workspace/operations.ts
+++ b/apps/netscli-gui/src/workspace/operations.ts
@@ -66,11 +66,11 @@ export async function runWorkspaceTab({
       selectionAnchor: 0,
       detailTab: defaultDetailTab(tab.kind),
     });
-    showToast({
-      message: `${TOOL_CONFIG[tab.kind].label} complete`,
-      kind: 'operation',
-      tabId: tab.id,
-    });
+    // No toast for success. The result arriving in the table is the
+    // completion signal, and announcing it again told the user something
+    // they were already looking at -- on a tab that auto-runs, before they
+    // had done anything at all. Failure still toasts below, because there
+    // the table stays empty and the reason would otherwise be invisible.
     if (persistentHistory) {
       setHistory((prev) =>
         compactHistory([

--- a/apps/netscli-gui/src/workspace/useWorkspace.test.tsx
+++ b/apps/netscli-gui/src/workspace/useWorkspace.test.tsx
@@ -11,6 +11,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useWorkspace } from './useWorkspace';
+import type { WorkspaceModel } from './types';
 
 // The hook reaches for Tauri and for persisted history on mount; neither
 // exists under jsdom. Stub them so the tests exercise state logic only.
@@ -55,6 +56,21 @@ const SCAN_PORTS = [22, 80, 443, 8080, 8443].map((port) => ({
   banner: '',
 }));
 
+/**
+ * A scan tab of this test's own.
+ *
+ * These cases patch scan-shaped results in, so they need a scan tab -- not
+ * whatever the app currently opens with. They used to lean on the default
+ * being `scan`; when it became `discover` the rows were built and sorted as
+ * discover rows and a scan-specific index stopped meaning anything.
+ */
+function withScanTab(result: { current: WorkspaceModel }) {
+  act(() => {
+    result.current.addTab('scan');
+  });
+  return result.current.activeTabId;
+}
+
 function scanResult() {
   return { kind: 'scan', data: SCAN_PORTS } as never;
 }
@@ -89,7 +105,7 @@ describe('tab selection', () => {
   it('keeps a tab selection when switching away and back', async () => {
     const { result } = renderWorkspace();
 
-    const firstTabId = result.current.activeTabId;
+    const firstTabId = withScanTab(result);
     act(() => {
       result.current.patchTab(firstTabId, { result: scanResult() });
     });
@@ -174,7 +190,7 @@ describe('tab selection', () => {
   // is now expressed as an id the tab does not hold.
   it('leaves the selection alone for a row id the tab does not hold', async () => {
     const { result } = renderWorkspace();
-    const firstTabId = result.current.activeTabId;
+    const firstTabId = withScanTab(result);
     act(() => {
       result.current.patchTab(firstTabId, { result: scanResult(), selectedIndex: 2, selectedIndices: [2] });
     });
@@ -201,7 +217,7 @@ describe('tab selection', () => {
   // order and display order agree and any index works. These ports do not.
   it('jumps to the row that was searched for, not the one at that position', async () => {
     const { result } = renderWorkspace();
-    const tabId = result.current.activeTabId;
+    const tabId = withScanTab(result);
     act(() => {
       result.current.patchTab(tabId, { result: unsortedScanResult() });
     });

--- a/apps/netscli-gui/src/workspace/useWorkspace.ts
+++ b/apps/netscli-gui/src/workspace/useWorkspace.ts
@@ -22,7 +22,10 @@ import { useWorkspaceToast } from './useWorkspaceToast';
 export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
   const demoScreenshotMode = isDemoScreenshotMode();
   const [tabs, setTabs] = useState<WorkspaceTab[]>(() =>
-    demoScreenshotMode ? createDemoScreenshotTabs() : [createTab('scan')],
+    // Discover, not scan: the first useful question on an unfamiliar
+    // network is "what is on it", and scan needs a host you do not have
+    // yet. Scan remains one click away in the tab strip.
+    demoScreenshotMode ? createDemoScreenshotTabs() : [createTab('discover')],
   );
   const [activeTabId, setActiveTabId] = useState(() => tabs[0]?.id ?? '');
   const [filterText, setFilterText] = useState('');

--- a/crates/netscli-core/src/discover.rs
+++ b/crates/netscli-core/src/discover.rs
@@ -12,6 +12,21 @@ use std::sync::{
     Arc,
 };
 
+/// How a host came to be in the results.
+///
+/// Worth reporting rather than flattening, because the two carry different
+/// confidence. A host that answered a probe is definitely there now; a host
+/// known only from the neighbour table is one the OS has spoken to
+/// recently, which is usually but not always still true.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FoundBy {
+    /// Answered an ICMP or TCP probe during this scan.
+    Probe,
+    /// Did not answer, but is in the ARP/neighbour table.
+    Neighbor,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct Host {
     pub ip: IpAddr,
@@ -19,6 +34,8 @@ pub struct Host {
     pub mac: Option<String>,
     pub vendor: Option<String>,
     pub rtt_ms: Option<u64>,
+    /// Additive field: existing consumers that ignore it are unaffected.
+    pub found_by: FoundBy,
 }
 
 pub struct DiscoverEngine {
@@ -199,23 +216,54 @@ impl DiscoverEngine {
             HashMap::new()
         };
 
-        Ok(alive
-            .into_iter()
-            .map(|r| {
-                let hostname = hostname_map.get(&r.ip).cloned().unwrap_or(None);
-                let mac_entry = arp_map.get(&r.ip);
-                let mac_str = mac_entry.map(|e| e.mac.to_string());
-                let vendor = mac_entry
-                    .and_then(|e| e.vendor.clone())
-                    .or_else(|| mac_str.as_deref().and_then(lookup_vendor));
-                Host {
-                    ip: r.ip,
-                    hostname,
-                    mac: mac_str,
-                    vendor,
-                    rtt_ms: r.rtt_ms,
-                }
+        let build = |ip: IpAddr, rtt_ms: Option<u64>, found_by: FoundBy| {
+            let mac_entry = arp_map.get(&ip);
+            let mac_str = mac_entry.map(|e| e.mac.to_string());
+            let vendor = mac_entry
+                .and_then(|e| e.vendor.clone())
+                .or_else(|| mac_str.as_deref().and_then(lookup_vendor));
+            Host {
+                ip,
+                hostname: hostname_map.get(&ip).cloned().unwrap_or(None),
+                mac: mac_str,
+                vendor,
+                rtt_ms,
+                found_by,
+            }
+        };
+
+        let mut hosts: Vec<Host> = alive
+            .iter()
+            .map(|r| build(r.ip, r.rtt_ms, FoundBy::Probe))
+            .collect();
+
+        // Anything the OS has an ARP entry for is on this link, whether or
+        // not it answered us. Plenty of devices do not: consumer IoT
+        // routinely ignores ICMP, and Windows drops echo requests by
+        // default. Discarding them meant discovery reported a fraction of
+        // the network -- measured at 13 of 25 known devices on one ordinary
+        // LAN -- while the table needed to find them was already loaded, and
+        // used only to decorate the hosts that had replied.
+        let answered: std::collections::HashSet<IpAddr> = alive.iter().map(|r| r.ip).collect();
+        let mut neighbors: Vec<IpAddr> = arp_map
+            .keys()
+            .copied()
+            .filter(|ip| !answered.contains(ip))
+            .filter(|ip| match ip {
+                // Only within the range that was asked for. The neighbour
+                // table spans every interface, so it holds addresses from
+                // other subnets entirely.
+                IpAddr::V4(v4) => subnet.contains(v4),
+                IpAddr::V6(_) => false,
             })
-            .collect())
+            .collect();
+        neighbors.sort_unstable();
+        hosts.extend(
+            neighbors
+                .into_iter()
+                .map(|ip| build(ip, None, FoundBy::Neighbor)),
+        );
+
+        Ok(hosts)
     }
 }

--- a/crates/netscli-core/src/lib.rs
+++ b/crates/netscli-core/src/lib.rs
@@ -29,7 +29,7 @@ pub use common::{
 };
 #[cfg(feature = "db")]
 pub use db::{Database, HostRecord, ScanHistoryRecord};
-pub use discover::{DiscoverEngine, DiscoverPhase, DiscoverProgress, Host};
+pub use discover::{DiscoverEngine, DiscoverPhase, DiscoverProgress, FoundBy, Host};
 pub use dns::{resolve_a, resolve_aaaa};
 pub use inspect::{InspectEngine, InspectResult};
 #[cfg(feature = "mdns")]

--- a/crates/netscli-core/src/sweep.rs
+++ b/crates/netscli-core/src/sweep.rs
@@ -193,6 +193,7 @@ mod tests {
                 mac: Some("00:17:88:6E:6C:5C".to_string()),
                 vendor: Some("Philips Lighting BV".to_string()),
                 rtt_ms: Some(4),
+                found_by: crate::FoundBy::Probe,
             },
             open_ports: vec![PortResult {
                 port: 443,

--- a/crates/netscli-core/tests/test_discover.rs
+++ b/crates/netscli-core/tests/test_discover.rs
@@ -114,10 +114,43 @@ async fn hosts_serialize_with_the_fields_downstream_reads() {
         mac: Some("00:11:22:33:44:55".to_string()),
         vendor: Some("Example Corp".to_string()),
         rtt_ms: Some(3),
+        found_by: netscli_core::FoundBy::Probe,
     };
 
     let value = serde_json::to_value(&host).expect("Host serializes");
-    for key in ["ip", "hostname", "mac", "vendor"] {
+    for key in ["ip", "hostname", "mac", "vendor", "found_by"] {
         assert!(value.get(key).is_some(), "missing {key}: {value}");
+    }
+}
+
+#[tokio::test]
+async fn a_host_that_never_answers_is_still_reported_when_the_os_knows_it() {
+    // Discovery used to keep only hosts that replied to a probe, and drop
+    // everything else -- while already holding the ARP table it needed to
+    // know better, using it merely to decorate the survivors. On one
+    // ordinary LAN that reported 13 of 25 devices: consumer IoT routinely
+    // ignores ICMP, and Windows drops echo requests by default.
+    //
+    // This cannot assert a specific count without a known network, so it
+    // asserts the property that made those devices vanish: every host is
+    // labelled with how it was found, and a host found only in the
+    // neighbour table is a legitimate result rather than something to
+    // discard.
+    let engine = DiscoverEngine::new_with_timeouts(8, 300, 300);
+    let hosts = engine
+        .scan_subnet(loopback_slash_30(), false)
+        .await
+        .unwrap();
+
+    for host in &hosts {
+        match host.found_by {
+            // A probe reply is the only thing that can carry an RTT.
+            netscli_core::FoundBy::Probe => {}
+            // A neighbour did not answer, so it cannot have one.
+            netscli_core::FoundBy::Neighbor => assert!(
+                host.rtt_ms.is_none(),
+                "a neighbour-only host cannot have an RTT: {host:?}"
+            ),
+        }
     }
 }


### PR DESCRIPTION
## Discovery was missing half the network

Reproduced before changing anything, on an ordinary LAN:

```
ARP entries in subnet : 25
discover found        : 13
MISSED by discover    : 12  (48% of known devices)
```

Among the missing: a Raspberry Pi, two Amazon devices, an ASUS box, a Dyson, a Philips Hue bridge.

**Cause.** `scan_subnet_with_progress` kept only hosts that answered a probe. Consumer IoT routinely ignores ICMP and Windows drops echo requests by default, so "didn't reply" says very little about whether something is there. The ARP table was *already being loaded* — and used only to decorate the hosts that had replied, never to find one.

After the fix, same network: **13 → 25**, matching ARP exactly (13 `probe`, 12 `neighbor`).

**`Host` gains `found_by`.** Collapsing the two would be dishonest: a host that answered is definitely present; one known only from the neighbour table is something the OS spoke to recently — usually still true, occasionally stale. The field is additive so existing consumers are unaffected, and only in-subnet IPv4 entries are considered, since the neighbour table spans every interface.

## Opens on Discover, not Scan

Scan needs a host you don't have yet. "What is on this network" is the question you can actually ask first.

That default turned out to be load-bearing in three tests, which patched scan-shaped results into whatever tab the app happened to open with — so they built and sorted as *discover* rows and a scan-specific index stopped meaning anything. They now create a scan tab of their own, so a product decision about the first tab can't break assertions about row ordering again.

## Toasts

Both toggles now default **off**, and a successful operation no longer toasts — the result arriving in the table is the completion signal, and announcing it again is noise about something already on screen. With Discover auto-running on launch, that fired before the user had done anything.

**Failures still toast.** There the table stays empty, so without one the reason would be invisible.

The render harness is unaffected: it already calls `ensureSettingsToggleOn` for both toggles rather than relying on the default, so it still exercises the toast paths.

## Verification

- Discovery measured against the real ARP table before and after.
- `cargo fmt`, `clippy -D warnings`, full workspace tests green.
- 127 GUI tests, `tsc -b`, `eslint` clean.
- The `Host` change was caught by the gate test added in #239, which is what it's for — plus two fixtures in `sweep.rs` and `cli_formatter/tests.rs`.