### PR TITLE
Announce a finished run only when its tab is out of sight

### DIFF
--- a/apps/netscli-gui/src/workspace/operations.test.ts
+++ b/apps/netscli-gui/src/workspace/operations.test.ts
@@ -39,6 +39,7 @@ describe('runWorkspaceTab op-id race guard', () => {
 
     const firstRun = runWorkspaceTab({
       activeOps,
+      isTabActive: () => true,
       maxConcurrentProbes: 256,
       patchTab,
       persistentHistory: false,
@@ -52,6 +53,7 @@ describe('runWorkspaceTab op-id race guard', () => {
     // racing a manual run). This overwrites activeOps.current[tab.id].
     const secondRun = runWorkspaceTab({
       activeOps,
+      isTabActive: () => true,
       maxConcurrentProbes: 256,
       patchTab,
       persistentHistory: false,
@@ -86,6 +88,7 @@ describe('runWorkspaceTab op-id race guard', () => {
 
     await runWorkspaceTab({
       activeOps,
+      isTabActive: () => true,
       maxConcurrentProbes: 256,
       patchTab,
       persistentHistory: false,
@@ -111,6 +114,7 @@ describe('runWorkspaceTab op-id race guard', () => {
 
     await runWorkspaceTab({
       activeOps,
+      isTabActive: () => true,
       maxConcurrentProbes: 256,
       patchTab,
       persistentHistory: false,
@@ -126,5 +130,75 @@ describe('runWorkspaceTab op-id race guard', () => {
     expect(showToast).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining('failed: boom') }),
     );
+  });
+});
+
+// Completion toasts are scoped to tabs the user is not looking at.
+//
+// The rule: on the visible tab the result landing in the table already says
+// the run finished, so a toast repeats what is on screen. On a background
+// tab nothing else says so, and a long scan finishing unannounced is the
+// case worth reporting. Failure is not subject to this -- covered above,
+// where the table stays empty and the reason has to surface either way.
+describe('completion toasts', () => {
+  async function runScan(isTabActive: (tabId: string) => boolean) {
+    const tab = createTab('scan');
+    tab.form.host = '127.0.0.1';
+    const showToast = vi.fn();
+
+    await runWorkspaceTab({
+      activeOps: { current: {} as Record<string, string> },
+      isTabActive,
+      maxConcurrentProbes: 256,
+      patchTab: vi.fn(),
+      persistentHistory: false,
+      setHistory: vi.fn(),
+      showToast,
+      tab,
+    });
+
+    return { showToast, tabId: tab.id };
+  }
+
+  it('stays quiet when the finished tab is the one on screen', async () => {
+    const { executeTool } = await import('./toolExecution');
+    vi.mocked(executeTool).mockResolvedValue(scanResult());
+
+    const { showToast } = await runScan(() => true);
+
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('announces a run that finished on a tab the user had switched away from', async () => {
+    const { executeTool } = await import('./toolExecution');
+    vi.mocked(executeTool).mockResolvedValue(scanResult());
+
+    const { showToast, tabId } = await runScan(() => false);
+
+    // `tabId` is what gives the toast its "Open tab" action in ToastHost.
+    // Without it the toast names a tab the user cannot reach from it.
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('complete'),
+        kind: 'operation',
+        tabId,
+      }),
+    );
+  });
+
+  it('reads the active tab at completion, not when the run started', async () => {
+    // The case the ref in useWorkspace exists for: the user starts a scan
+    // and switches away while it runs. A value captured when the run began
+    // would still see the tab as active and say nothing.
+    const { executeTool } = await import('./toolExecution');
+    let active = true;
+    vi.mocked(executeTool).mockImplementation(async () => {
+      active = false;
+      return scanResult();
+    });
+
+    const { showToast } = await runScan(() => active);
+
+    expect(showToast).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/netscli-gui/src/workspace/operations.ts
+++ b/apps/netscli-gui/src/workspace/operations.ts
@@ -11,6 +11,10 @@ import type { WorkspaceToast } from './types';
 
 interface RunWorkspaceTabArgs {
   activeOps: RefObject<Record<string, string>>;
+  /** Whether the user is looking at this tab *right now*. Must be read at
+   *  completion, not when the run started: the point of the check is that
+   *  they may have switched away during a long scan. */
+  isTabActive: (tabId: string) => boolean;
   maxConcurrentProbes: number;
   patchTab: (id: string, patch: Partial<WorkspaceTab>) => void;
   persistentHistory: boolean;
@@ -21,6 +25,7 @@ interface RunWorkspaceTabArgs {
 
 export async function runWorkspaceTab({
   activeOps,
+  isTabActive,
   maxConcurrentProbes,
   patchTab,
   persistentHistory,
@@ -66,11 +71,21 @@ export async function runWorkspaceTab({
       selectionAnchor: 0,
       detailTab: defaultDetailTab(tab.kind),
     });
-    // No toast for success. The result arriving in the table is the
-    // completion signal, and announcing it again told the user something
-    // they were already looking at -- on a tab that auto-runs, before they
-    // had done anything at all. Failure still toasts below, because there
-    // the table stays empty and the reason would otherwise be invisible.
+    // Success toasts only for a tab the user is not looking at. On the
+    // visible tab the result arriving in the table is itself the completion
+    // signal, and announcing it again said something they could already see
+    // -- on a tab that auto-runs, before they had done anything at all. On
+    // a background tab there is no such signal, so the toast is the only
+    // way to learn a long scan finished; `tabId` gives it an "Open tab"
+    // action. Failure toasts unconditionally below: there the table stays
+    // empty and the reason would otherwise be invisible either way.
+    if (!isTabActive(tab.id)) {
+      showToast({
+        message: `${TOOL_CONFIG[tab.kind].label} complete`,
+        kind: 'operation',
+        tabId: tab.id,
+      });
+    }
     if (persistentHistory) {
       setHistory((prev) =>
         compactHistory([

--- a/apps/netscli-gui/src/workspace/useTabLifecycle.ts
+++ b/apps/netscli-gui/src/workspace/useTabLifecycle.ts
@@ -33,6 +33,11 @@ export function useTabLifecycle({
   interfaces,
 }: UseTabLifecycleArgs) {
   const activeOps = useRef<Record<string, string>>({});
+  // Read at operation completion, not when the run started: a caller's
+  // closure captures `activeTabId` as it was minutes earlier, and the
+  // question "is the user looking at this tab" is only meaningful now.
+  const activeTabIdRef = useRef(activeTabId);
+  activeTabIdRef.current = activeTabId;
   const autoRunTabIds = useRef<Set<string>>(new Set());
 
   function addTab(kind: ToolKind) {
@@ -96,6 +101,10 @@ export function useTabLifecycle({
     setActiveTabId(activeTab.id);
   }
 
+  function isTabActive(tabId: string): boolean {
+    return activeTabIdRef.current === tabId;
+  }
+
   function needsAutoRun(tabId: string): boolean {
     return autoRunTabIds.current.has(tabId);
   }
@@ -112,6 +121,7 @@ export function useTabLifecycle({
     closeTab,
     closeAllTabs,
     closeOtherTabs,
+    isTabActive,
     needsAutoRun,
     clearAutoRun,
   };

--- a/apps/netscli-gui/src/workspace/useWorkspace.ts
+++ b/apps/netscli-gui/src/workspace/useWorkspace.ts
@@ -64,6 +64,7 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
     closeTab,
     closeAllTabs,
     closeOtherTabs: closeOtherTabsFor,
+    isTabActive,
     needsAutoRun,
     clearAutoRun,
   } = useTabLifecycle({
@@ -199,13 +200,6 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // `runTab`'s closure captures `activeTabId` as it was when the run
-  // started, which is exactly the wrong value: the completion toast asks
-  // whether the user is looking at the tab *now*, after a scan that may
-  // have taken a minute. A ref reads the current value at completion.
-  const activeTabIdRef = useRef(activeTabId);
-  activeTabIdRef.current = activeTabId;
-
   function patchTab(id: string, patch: Partial<WorkspaceTab>) {
     setTabs((prev) => prev.map((tab) => (tab.id === id ? { ...tab, ...patch } : tab)));
   }
@@ -239,7 +233,7 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
     }
     await runWorkspaceTab({
       activeOps,
-      isTabActive: (id) => activeTabIdRef.current === id,
+      isTabActive,
       maxConcurrentProbes: options.maxConcurrentProbes,
       patchTab,
       persistentHistory: options.persistentHistory,

--- a/apps/netscli-gui/src/workspace/useWorkspace.ts
+++ b/apps/netscli-gui/src/workspace/useWorkspace.ts
@@ -199,6 +199,13 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // `runTab`'s closure captures `activeTabId` as it was when the run
+  // started, which is exactly the wrong value: the completion toast asks
+  // whether the user is looking at the tab *now*, after a scan that may
+  // have taken a minute. A ref reads the current value at completion.
+  const activeTabIdRef = useRef(activeTabId);
+  activeTabIdRef.current = activeTabId;
+
   function patchTab(id: string, patch: Partial<WorkspaceTab>) {
     setTabs((prev) => prev.map((tab) => (tab.id === id ? { ...tab, ...patch } : tab)));
   }
@@ -232,6 +239,7 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
     }
     await runWorkspaceTab({
       activeOps,
+      isTabActive: (id) => activeTabIdRef.current === id,
       maxConcurrentProbes: options.maxConcurrentProbes,
       patchTab,
       persistentHistory: options.persistentHistory,


### PR DESCRIPTION
Follow-up to #243, which removed the success toast outright. That was too blunt: the toast is redundant on the tab you are watching, but on a background tab it is the only thing that tells you a long scan finished.

So the rule is now **success toasts only for a tab that is not on screen**, carrying the `tabId` that makes ToastHost render its "Open tab" action.

The active tab is read at completion rather than at run start, via a ref in `useWorkspace`. `runTab`'s closure captures the id as it was when the run began, which is precisely the wrong value — the case this exists for is a user who started a scan and then switched away.

Failure toasts are untouched and stay unconditional. A failed run leaves the table empty, so there is no on-screen signal for the toast to duplicate, visible tab or not.

## Tests

Three added to `operations.test.ts`, alongside the existing op-id race-guard cases:

- quiet when the finished tab is on screen
- announces, with `tabId`, when it is not
- reads the active tab at completion, not at run start

The middle two were confirmed to fail against the previous behaviour before being kept. Full GUI suite 130 passed, `tsc -b` and `eslint` clean.