### PR TITLE
Open a scan tab in the scan scenario instead of assuming one

### DIFF
--- a/apps/netscli-gui/e2e/tauri-render/scenarios/scan.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/scan.mjs
@@ -1,9 +1,15 @@
 import assert from 'node:assert/strict';
 import { By } from '../driver.mjs';
-import { assertCommand, assertNoErrorStrip, clickButtonText, replaceInput, runActiveTool, waitForRow, waitForText } from '../ui.mjs';
+import { addToolTab, assertCommand, assertNoErrorStrip, clickButtonText, replaceInput, runActiveTool, waitForRow, waitForText } from '../ui.mjs';
 import { assertAdvancedFilterTopLayer } from './helpers/tabs.mjs';
 
 export async function exerciseScan(driver, port) {
+  // Open a scan tab rather than assuming the app starts on one. It starts
+  // on Discover -- "what is on this network" needs no host, a scan does --
+  // so the scan inputs this reaches for do not exist until we ask for them.
+  // Every other scenario here already opens its own tab; scan was the one
+  // exception, and only because it happened to match the startup tab.
+  await addToolTab(driver, 'Port Scan');
   await replaceInput(driver, '[data-testid="result-filter"]', '');
   await replaceInput(driver, '[data-testid="scan-host-input"]', '127.0.0.1');
   await replaceInput(driver, '[data-testid="scan-ports-input"]', String(port));


### PR DESCRIPTION
The app now starts on Discover (#243), so `exerciseScan` failed on a missing `scan-host-input` — the scan form does not exist until a scan tab is opened. Every other scenario in the suite already opens its own tab; scan was the exception only because it happened to match the old startup tab.

Found by running the e2e suite locally against a real build. With this fix the scan, DNS and inspect scenarios pass.

## Pre-existing failures this does not address

Three further failures were confirmed to reproduce identically at `8d3aca5` (before #243 and #244), by rebuilding and re-running the suite at that commit:

| Scenario | Failure | Cause |
| --- | --- | --- |
| Discover | `0 hosts` on `127.0.0.0/30` | ICMP to loopback never answers |
| Sweep | `0 hosts` | runs discover first, same cause |
| Interfaces | Ctrl+A selects 1 of 12 rows | unrelated, not diagnosed |

The first two share a root cause: `send_icmp_echo_v4` uses raw sockets via pnet, and on Windows raw sockets do not observe loopback traffic. `netscli ping 127.0.0.1` reports 100% loss while the system `ping` gets 0%, and LAN hosts ping fine. Left alone here rather than widening this PR.