### PR TITLE
Make ping reach this machine on Windows

### DIFF
--- a/crates/netscli-core/Cargo.toml
+++ b/crates/netscli-core/Cargo.toml
@@ -48,7 +48,7 @@ pnet_datalink = "0.35"
 
 [target.'cfg(windows)'.dependencies]
 ipconfig = "0.3"
-windows-sys = { version = "0.61", features = ["Win32_Networking_WinSock"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock"] }
 
 [features]
 # Lean by default: scan, discover, DNS, ARP, OUI lookup, stats.

--- a/crates/netscli-core/src/ping.rs
+++ b/crates/netscli-core/src/ping.rs
@@ -110,13 +110,7 @@ fn can_use_raw_icmpv4() -> bool {
 }
 
 #[cfg(not(windows))]
-fn can_use_raw_icmpv4() -> bool {
-    // Best-effort capability check: if we can open an ICMPv4 layer3 channel, raw ping is usable.
-    // This avoids making discovery completely useless when running unprivileged.
-    // Called once via `RAW_ICMP_OK` OnceLock.
-    let protocol = TransportChannelType::Layer3(IpNextHeaderProtocols::Icmp);
-    transport_channel(4096, protocol).is_ok()
-}
+use raw_icmp::can_use_raw_icmpv4;
 
 async fn ping_icmpv4(target: IpAddr, timeout_ms: u64, seq: u16) -> PingResult {
     // Use tokio::spawn_blocking for pnet operations since they are synchronous.

--- a/crates/netscli-core/src/ping.rs
+++ b/crates/netscli-core/src/ping.rs
@@ -1,7 +1,12 @@
+#[cfg(not(windows))]
 use pnet_packet::icmp::{echo_reply, echo_request, IcmpTypes};
+#[cfg(not(windows))]
 use pnet_packet::ip::IpNextHeaderProtocols;
+#[cfg(not(windows))]
 use pnet_packet::util::checksum;
+#[cfg(not(windows))]
 use pnet_packet::Packet;
+#[cfg(not(windows))]
 use pnet_transport::{transport_channel, TransportChannelType, TransportReceiver};
 use serde::Serialize;
 use std::net::IpAddr;
@@ -97,11 +102,18 @@ impl PingScanner {
     }
 }
 
+#[cfg(windows)]
+fn can_use_raw_icmpv4() -> bool {
+    // Windows pings through the IP Helper API rather than a raw socket, and
+    // `IcmpCreateFile` needs no privileges, so ICMP is always available.
+    true
+}
+
+#[cfg(not(windows))]
 fn can_use_raw_icmpv4() -> bool {
     // Best-effort capability check: if we can open an ICMPv4 layer3 channel, raw ping is usable.
     // This avoids making discovery completely useless when running unprivileged.
-    // Called once via `RAW_ICMP_OK` OnceLock — construction of the transport
-    // channel is non-trivial on Windows so we don't repeat it per scanner.
+    // Called once via `RAW_ICMP_OK` OnceLock.
     let protocol = TransportChannelType::Layer3(IpNextHeaderProtocols::Icmp);
     transport_channel(4096, protocol).is_ok()
 }
@@ -196,10 +208,130 @@ async fn ping_tcp_probe(target: IpAddr, timeout_ms: u64, seq: u16) -> PingResult
     }
 }
 
+/// ICMP echo on Windows, via the IP Helper API.
+///
+/// `IcmpSendEcho` is the platform's own ping primitive. It works without
+/// administrator rights, which the raw path does not, and it reaches loopback
+/// and any address this host owns. Both properties are load-bearing: see the
+/// note on `send_icmp_echo_v4` for the failure each one fixes.
+#[cfg(windows)]
+mod windows_icmp {
+    use std::net::IpAddr;
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::NetworkManagement::IpHelper::{
+        IcmpCloseHandle, IcmpCreateFile, IcmpSendEcho, ICMP_ECHO_REPLY, IP_REQ_TIMED_OUT,
+        IP_SUCCESS,
+    };
+
+    /// Payload sent with each echo. Content is irrelevant to the result; a
+    /// recognisable string just makes the packets readable in a capture.
+    const PAYLOAD: &[u8] = b"netscli-ping";
+
+    /// Closes the ICMP handle however we leave the function.
+    ///
+    /// Every early return below is an error path, and each one used to be a
+    /// leaked kernel handle. A scan is thousands of pings, so that is a real
+    /// leak rather than a tidiness point.
+    struct IcmpHandle(windows_sys::Win32::Foundation::HANDLE);
+
+    impl Drop for IcmpHandle {
+        fn drop(&mut self) {
+            unsafe { IcmpCloseHandle(self.0) };
+        }
+    }
+
+    pub fn send_echo(target: IpAddr, timeout_ms: u64) -> anyhow::Result<u64> {
+        let IpAddr::V4(v4) = target else {
+            anyhow::bail!("IcmpSendEcho supports IPv4 only");
+        };
+
+        let handle = unsafe { IcmpCreateFile() };
+        if handle == INVALID_HANDLE_VALUE || handle.is_null() {
+            anyhow::bail!("IcmpCreateFile failed: {}", std::io::Error::last_os_error());
+        }
+        let handle = IcmpHandle(handle);
+
+        // The reply buffer holds one ICMP_ECHO_REPLY, the echoed payload, and
+        // room for the 8-byte ICMP error body Windows may append. Undersizing
+        // it makes IcmpSendEcho fail with IP_BUF_TOO_SMALL rather than write
+        // out of bounds, but there is no reason to find out.
+        let mut reply = vec![0u8; std::mem::size_of::<ICMP_ECHO_REPLY>() + PAYLOAD.len() + 8];
+
+        // `destinationaddress` is an in_addr: the four octets in network
+        // order, read as a u32 in the host's own byte order.
+        let destination = u32::from_ne_bytes(v4.octets());
+        let timeout = u32::try_from(timeout_ms).unwrap_or(u32::MAX);
+
+        let replies = unsafe {
+            IcmpSendEcho(
+                handle.0,
+                destination,
+                PAYLOAD.as_ptr().cast(),
+                PAYLOAD.len() as u16,
+                std::ptr::null(),
+                reply.as_mut_ptr().cast(),
+                reply.len() as u32,
+                timeout,
+            )
+        };
+
+        if replies == 0 {
+            // A timeout arrives here as a failed call, not as a reply with a
+            // timeout status, so it has to be recognised from the error code.
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() == Some(IP_REQ_TIMED_OUT as i32) {
+                anyhow::bail!("Timeout");
+            }
+            anyhow::bail!("IcmpSendEcho failed: {error}");
+        }
+
+        // Safe: IcmpSendEcho reported at least one reply, so it has written a
+        // full ICMP_ECHO_REPLY at the head of a buffer we sized above. `read_unaligned`
+        // because a Vec<u8> carries no alignment guarantee for the struct.
+        let echo = unsafe { reply.as_ptr().cast::<ICMP_ECHO_REPLY>().read_unaligned() };
+
+        match echo.Status {
+            IP_SUCCESS => Ok(u64::from(echo.RoundTripTime)),
+            IP_REQ_TIMED_OUT => anyhow::bail!("Timeout"),
+            // Unreachable, TTL expired and friends all land here. The host did
+            // not answer, which is all the caller needs; the code identifies
+            // which flavour for anyone reading the error.
+            status => anyhow::bail!("ICMP status {status}"),
+        }
+    }
+}
+
 /// Send a single ICMPv4 Echo Request and await a matching Echo Reply.
 ///
 /// Filters replies by (address, identifier, sequence) so overlapping pings
 /// from other tasks on the same host don't steal each other's replies.
+///
+/// Windows and Unix take different routes here, and the reason is a measured
+/// bug rather than portability pedantry. Pinging `127.0.0.1` on Windows --
+/// or the machine's own LAN address -- reported 100% loss while the system
+/// `ping` reported none.
+///
+/// Two things stacked up. Opening a raw ICMP socket needs administrator
+/// rights, so an ordinary run never reached the ICMP path at all: it fell
+/// back to the TCP probe below, which asks ports 80/443/22 and concludes a
+/// host is down when nothing answers -- true of most machines asked about
+/// themselves. Elevated runs have the separate, documented problem that a
+/// Windows raw socket does not observe traffic to an address the host owns.
+///
+/// The IP Helper API sidesteps both: it needs no privileges and it reaches
+/// local addresses. Unix keeps the raw socket, where loopback ICMP is
+/// observable and this dependency would buy nothing.
+#[cfg(windows)]
+fn send_icmp_echo_v4(target: IpAddr, timeout_ms: u64, seq: u16) -> anyhow::Result<u64> {
+    // `seq` is unused here: IcmpSendEcho owns its own request/reply matching
+    // per handle, which is the job the identifier and sequence do on the raw
+    // path. `PingResult` still reports the process-wide counter so the field
+    // means the same thing on both platforms.
+    let _ = seq;
+    windows_icmp::send_echo(target, timeout_ms)
+}
+
+#[cfg(not(windows))]
 fn send_icmp_echo_v4(target: IpAddr, timeout_ms: u64, seq: u16) -> anyhow::Result<u64> {
     let protocol = TransportChannelType::Layer3(IpNextHeaderProtocols::Icmp);
     let (mut tx, mut rx) = transport_channel(4096, protocol)?;
@@ -254,6 +386,7 @@ fn send_icmp_echo_v4(target: IpAddr, timeout_ms: u64, seq: u16) -> anyhow::Resul
     Err(anyhow::anyhow!("Timeout"))
 }
 
+#[cfg(not(windows))]
 fn configure_read_timeout(rx: &TransportReceiver, timeout: Duration) -> anyhow::Result<()> {
     #[cfg(unix)]
     {

--- a/crates/netscli-core/src/ping.rs
+++ b/crates/netscli-core/src/ping.rs
@@ -1,19 +1,19 @@
-#[cfg(not(windows))]
-use pnet_packet::icmp::{echo_reply, echo_request, IcmpTypes};
-#[cfg(not(windows))]
-use pnet_packet::ip::IpNextHeaderProtocols;
-#[cfg(not(windows))]
-use pnet_packet::util::checksum;
-#[cfg(not(windows))]
-use pnet_packet::Packet;
-#[cfg(not(windows))]
-use pnet_transport::{transport_channel, TransportChannelType, TransportReceiver};
 use serde::Serialize;
 use std::net::IpAddr;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::Semaphore;
+
+/// One ICMP backend per platform. They are not interchangeable: see the note
+/// on `send_icmp_echo_v4` below for why Windows cannot use the raw socket.
+#[cfg(not(windows))]
+mod raw_icmp;
+#[cfg(windows)]
+mod windows_icmp;
+
+#[cfg(not(windows))]
+use raw_icmp::send_icmp_echo_v4;
 
 /// Process-wide monotonic counter for ICMP echo sequence numbers.
 ///
@@ -208,103 +208,7 @@ async fn ping_tcp_probe(target: IpAddr, timeout_ms: u64, seq: u16) -> PingResult
     }
 }
 
-/// ICMP echo on Windows, via the IP Helper API.
-///
-/// `IcmpSendEcho` is the platform's own ping primitive. It works without
-/// administrator rights, which the raw path does not, and it reaches loopback
-/// and any address this host owns. Both properties are load-bearing: see the
-/// note on `send_icmp_echo_v4` for the failure each one fixes.
-#[cfg(windows)]
-mod windows_icmp {
-    use std::net::IpAddr;
-    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
-    use windows_sys::Win32::NetworkManagement::IpHelper::{
-        IcmpCloseHandle, IcmpCreateFile, IcmpSendEcho, ICMP_ECHO_REPLY, IP_REQ_TIMED_OUT,
-        IP_SUCCESS,
-    };
-
-    /// Payload sent with each echo. Content is irrelevant to the result; a
-    /// recognisable string just makes the packets readable in a capture.
-    const PAYLOAD: &[u8] = b"netscli-ping";
-
-    /// Closes the ICMP handle however we leave the function.
-    ///
-    /// Every early return below is an error path, and each one used to be a
-    /// leaked kernel handle. A scan is thousands of pings, so that is a real
-    /// leak rather than a tidiness point.
-    struct IcmpHandle(windows_sys::Win32::Foundation::HANDLE);
-
-    impl Drop for IcmpHandle {
-        fn drop(&mut self) {
-            unsafe { IcmpCloseHandle(self.0) };
-        }
-    }
-
-    pub fn send_echo(target: IpAddr, timeout_ms: u64) -> anyhow::Result<u64> {
-        let IpAddr::V4(v4) = target else {
-            anyhow::bail!("IcmpSendEcho supports IPv4 only");
-        };
-
-        let handle = unsafe { IcmpCreateFile() };
-        if handle == INVALID_HANDLE_VALUE || handle.is_null() {
-            anyhow::bail!("IcmpCreateFile failed: {}", std::io::Error::last_os_error());
-        }
-        let handle = IcmpHandle(handle);
-
-        // The reply buffer holds one ICMP_ECHO_REPLY, the echoed payload, and
-        // room for the 8-byte ICMP error body Windows may append. Undersizing
-        // it makes IcmpSendEcho fail with IP_BUF_TOO_SMALL rather than write
-        // out of bounds, but there is no reason to find out.
-        let mut reply = vec![0u8; std::mem::size_of::<ICMP_ECHO_REPLY>() + PAYLOAD.len() + 8];
-
-        // `destinationaddress` is an in_addr: the four octets in network
-        // order, read as a u32 in the host's own byte order.
-        let destination = u32::from_ne_bytes(v4.octets());
-        let timeout = u32::try_from(timeout_ms).unwrap_or(u32::MAX);
-
-        let replies = unsafe {
-            IcmpSendEcho(
-                handle.0,
-                destination,
-                PAYLOAD.as_ptr().cast(),
-                PAYLOAD.len() as u16,
-                std::ptr::null(),
-                reply.as_mut_ptr().cast(),
-                reply.len() as u32,
-                timeout,
-            )
-        };
-
-        if replies == 0 {
-            // A timeout arrives here as a failed call, not as a reply with a
-            // timeout status, so it has to be recognised from the error code.
-            let error = std::io::Error::last_os_error();
-            if error.raw_os_error() == Some(IP_REQ_TIMED_OUT as i32) {
-                anyhow::bail!("Timeout");
-            }
-            anyhow::bail!("IcmpSendEcho failed: {error}");
-        }
-
-        // Safe: IcmpSendEcho reported at least one reply, so it has written a
-        // full ICMP_ECHO_REPLY at the head of a buffer we sized above. `read_unaligned`
-        // because a Vec<u8> carries no alignment guarantee for the struct.
-        let echo = unsafe { reply.as_ptr().cast::<ICMP_ECHO_REPLY>().read_unaligned() };
-
-        match echo.Status {
-            IP_SUCCESS => Ok(u64::from(echo.RoundTripTime)),
-            IP_REQ_TIMED_OUT => anyhow::bail!("Timeout"),
-            // Unreachable, TTL expired and friends all land here. The host did
-            // not answer, which is all the caller needs; the code identifies
-            // which flavour for anyone reading the error.
-            status => anyhow::bail!("ICMP status {status}"),
-        }
-    }
-}
-
 /// Send a single ICMPv4 Echo Request and await a matching Echo Reply.
-///
-/// Filters replies by (address, identifier, sequence) so overlapping pings
-/// from other tasks on the same host don't steal each other's replies.
 ///
 /// Windows and Unix take different routes here, and the reason is a measured
 /// bug rather than portability pedantry. Pinging `127.0.0.1` on Windows --
@@ -329,94 +233,4 @@ fn send_icmp_echo_v4(target: IpAddr, timeout_ms: u64, seq: u16) -> anyhow::Resul
     // means the same thing on both platforms.
     let _ = seq;
     windows_icmp::send_echo(target, timeout_ms)
-}
-
-#[cfg(not(windows))]
-fn send_icmp_echo_v4(target: IpAddr, timeout_ms: u64, seq: u16) -> anyhow::Result<u64> {
-    let protocol = TransportChannelType::Layer3(IpNextHeaderProtocols::Icmp);
-    let (mut tx, mut rx) = transport_channel(4096, protocol)?;
-    configure_read_timeout(&rx, Duration::from_millis(10))?;
-
-    let identifier = std::process::id() as u16;
-
-    let mut buffer = [0u8; 64];
-    let mut echo_packet = echo_request::MutableEchoRequestPacket::new(&mut buffer)
-        .ok_or_else(|| anyhow::anyhow!("failed to build ICMP echo request packet"))?;
-
-    echo_packet.set_icmp_type(IcmpTypes::EchoRequest);
-    echo_packet.set_identifier(identifier);
-    echo_packet.set_sequence_number(seq);
-
-    let checksum = checksum(echo_packet.packet(), 1);
-    echo_packet.set_checksum(checksum);
-
-    let start = std::time::Instant::now();
-    tx.send_to(echo_packet, target)?;
-
-    let mut iter = pnet_transport::icmp_packet_iter(&mut rx);
-    let end_time = start + Duration::from_millis(timeout_ms);
-
-    while std::time::Instant::now() < end_time {
-        match iter.next() {
-            Ok((packet, addr)) => {
-                if addr != target || packet.get_icmp_type() != IcmpTypes::EchoReply {
-                    continue;
-                }
-                // Parse the echo-reply body so we can confirm identifier
-                // and sequence match OUR request rather than another
-                // concurrent ping's. `EchoReplyPacket::new` accepts the
-                // full ICMP packet bytes (the type/code/checksum header
-                // plus identifier/seq fields) — use `packet.packet()`
-                // here, not `.payload()`.
-                if let Some(reply) = echo_reply::EchoReplyPacket::new(packet.packet()) {
-                    if reply.get_identifier() == identifier && reply.get_sequence_number() == seq {
-                        return Ok(start.elapsed().as_millis() as u64);
-                    }
-                    // Not ours — keep reading until the timeout.
-                }
-            }
-            Err(_) => {
-                // Read error — usually just the read-timeout firing. Yield
-                // briefly so we don't spin the CPU when there's no traffic.
-                std::thread::sleep(Duration::from_millis(1));
-            }
-        }
-    }
-
-    Err(anyhow::anyhow!("Timeout"))
-}
-
-#[cfg(not(windows))]
-fn configure_read_timeout(rx: &TransportReceiver, timeout: Duration) -> anyhow::Result<()> {
-    #[cfg(unix)]
-    {
-        pnet_sys::set_socket_receive_timeout(rx.socket.fd, timeout)
-            .map_err(|e| anyhow::anyhow!("failed to set read timeout: {e}"))?;
-    }
-
-    #[cfg(windows)]
-    {
-        use windows_sys::Win32::Networking::WinSock::{
-            setsockopt, SOCKET_ERROR, SOL_SOCKET, SO_RCVTIMEO,
-        };
-
-        let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
-        let result = unsafe {
-            setsockopt(
-                rx.socket.fd,
-                SOL_SOCKET,
-                SO_RCVTIMEO,
-                (&timeout_ms as *const i32).cast(),
-                std::mem::size_of::<i32>() as i32,
-            )
-        };
-        if result == SOCKET_ERROR {
-            return Err(anyhow::anyhow!(
-                "failed to set read timeout: {}",
-                std::io::Error::last_os_error()
-            ));
-        }
-    }
-
-    Ok(())
 }

--- a/crates/netscli-core/src/ping/raw_icmp.rs
+++ b/crates/netscli-core/src/ping/raw_icmp.rs
@@ -1,0 +1,106 @@
+//! ICMPv4 echo over a raw socket, via pnet.
+//!
+//! Unix only. See the note on `send_icmp_echo_v4` in the parent module for
+//! why Windows cannot use this path.
+
+use pnet_packet::icmp::{echo_reply, echo_request, IcmpTypes};
+use pnet_packet::ip::IpNextHeaderProtocols;
+use pnet_packet::util::checksum;
+use pnet_packet::Packet;
+use pnet_transport::{transport_channel, TransportChannelType, TransportReceiver};
+use std::net::IpAddr;
+use std::time::Duration;
+
+/// Send a single ICMPv4 Echo Request and await a matching Echo Reply.
+///
+/// Filters replies by (address, identifier, sequence) so overlapping pings
+/// from other tasks on the same host don't steal each other's replies. The
+/// Windows backend needs no equivalent: `IcmpSendEcho` matches replies to
+/// requests itself, per handle.
+pub(super) fn send_icmp_echo_v4(target: IpAddr, timeout_ms: u64, seq: u16) -> anyhow::Result<u64> {
+    let protocol = TransportChannelType::Layer3(IpNextHeaderProtocols::Icmp);
+    let (mut tx, mut rx) = transport_channel(4096, protocol)?;
+    configure_read_timeout(&rx, Duration::from_millis(10))?;
+
+    let identifier = std::process::id() as u16;
+
+    let mut buffer = [0u8; 64];
+    let mut echo_packet = echo_request::MutableEchoRequestPacket::new(&mut buffer)
+        .ok_or_else(|| anyhow::anyhow!("failed to build ICMP echo request packet"))?;
+
+    echo_packet.set_icmp_type(IcmpTypes::EchoRequest);
+    echo_packet.set_identifier(identifier);
+    echo_packet.set_sequence_number(seq);
+
+    let checksum = checksum(echo_packet.packet(), 1);
+    echo_packet.set_checksum(checksum);
+
+    let start = std::time::Instant::now();
+    tx.send_to(echo_packet, target)?;
+
+    let mut iter = pnet_transport::icmp_packet_iter(&mut rx);
+    let end_time = start + Duration::from_millis(timeout_ms);
+
+    while std::time::Instant::now() < end_time {
+        match iter.next() {
+            Ok((packet, addr)) => {
+                if addr != target || packet.get_icmp_type() != IcmpTypes::EchoReply {
+                    continue;
+                }
+                // Parse the echo-reply body so we can confirm identifier
+                // and sequence match OUR request rather than another
+                // concurrent ping's. `EchoReplyPacket::new` accepts the
+                // full ICMP packet bytes (the type/code/checksum header
+                // plus identifier/seq fields) — use `packet.packet()`
+                // here, not `.payload()`.
+                if let Some(reply) = echo_reply::EchoReplyPacket::new(packet.packet()) {
+                    if reply.get_identifier() == identifier && reply.get_sequence_number() == seq {
+                        return Ok(start.elapsed().as_millis() as u64);
+                    }
+                    // Not ours — keep reading until the timeout.
+                }
+            }
+            Err(_) => {
+                // Read error — usually just the read-timeout firing. Yield
+                // briefly so we don't spin the CPU when there's no traffic.
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }
+    }
+
+    Err(anyhow::anyhow!("Timeout"))
+}
+
+fn configure_read_timeout(rx: &TransportReceiver, timeout: Duration) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        pnet_sys::set_socket_receive_timeout(rx.socket.fd, timeout)
+            .map_err(|e| anyhow::anyhow!("failed to set read timeout: {e}"))?;
+    }
+
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Networking::WinSock::{
+            setsockopt, SOCKET_ERROR, SOL_SOCKET, SO_RCVTIMEO,
+        };
+
+        let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+        let result = unsafe {
+            setsockopt(
+                rx.socket.fd,
+                SOL_SOCKET,
+                SO_RCVTIMEO,
+                (&timeout_ms as *const i32).cast(),
+                std::mem::size_of::<i32>() as i32,
+            )
+        };
+        if result == SOCKET_ERROR {
+            return Err(anyhow::anyhow!(
+                "failed to set read timeout: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/netscli-core/src/ping/raw_icmp.rs
+++ b/crates/netscli-core/src/ping/raw_icmp.rs
@@ -11,6 +11,14 @@ use pnet_transport::{transport_channel, TransportChannelType, TransportReceiver}
 use std::net::IpAddr;
 use std::time::Duration;
 
+/// Best-effort capability check: if we can open an ICMPv4 layer3 channel, raw
+/// ping is usable. This avoids making discovery useless when unprivileged.
+/// Called once via the parent's `RAW_ICMP_OK` OnceLock.
+pub(super) fn can_use_raw_icmpv4() -> bool {
+    let protocol = TransportChannelType::Layer3(IpNextHeaderProtocols::Icmp);
+    transport_channel(4096, protocol).is_ok()
+}
+
 /// Send a single ICMPv4 Echo Request and await a matching Echo Reply.
 ///
 /// Filters replies by (address, identifier, sequence) so overlapping pings

--- a/crates/netscli-core/src/ping/windows_icmp.rs
+++ b/crates/netscli-core/src/ping/windows_icmp.rs
@@ -1,0 +1,89 @@
+//! ICMP echo on Windows, via the IP Helper API.
+//!
+//! `IcmpSendEcho` is the platform's own ping primitive. It works without
+//! administrator rights, which the raw path does not, and it reaches loopback
+//! and any address this host owns. Both properties are load-bearing: see the
+//! note on `send_icmp_echo_v4` for the failure each one fixes.
+
+use std::net::IpAddr;
+use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+use windows_sys::Win32::NetworkManagement::IpHelper::{
+    IcmpCloseHandle, IcmpCreateFile, IcmpSendEcho, ICMP_ECHO_REPLY, IP_REQ_TIMED_OUT, IP_SUCCESS,
+};
+
+/// Payload sent with each echo. Content is irrelevant to the result; a
+/// recognisable string just makes the packets readable in a capture.
+const PAYLOAD: &[u8] = b"netscli-ping";
+
+/// Closes the ICMP handle however we leave the function.
+///
+/// Every early return below is an error path, and each one used to be a
+/// leaked kernel handle. A scan is thousands of pings, so that is a real
+/// leak rather than a tidiness point.
+struct IcmpHandle(windows_sys::Win32::Foundation::HANDLE);
+
+impl Drop for IcmpHandle {
+    fn drop(&mut self) {
+        unsafe { IcmpCloseHandle(self.0) };
+    }
+}
+
+pub fn send_echo(target: IpAddr, timeout_ms: u64) -> anyhow::Result<u64> {
+    let IpAddr::V4(v4) = target else {
+        anyhow::bail!("IcmpSendEcho supports IPv4 only");
+    };
+
+    let handle = unsafe { IcmpCreateFile() };
+    if handle == INVALID_HANDLE_VALUE || handle.is_null() {
+        anyhow::bail!("IcmpCreateFile failed: {}", std::io::Error::last_os_error());
+    }
+    let handle = IcmpHandle(handle);
+
+    // The reply buffer holds one ICMP_ECHO_REPLY, the echoed payload, and
+    // room for the 8-byte ICMP error body Windows may append. Undersizing
+    // it makes IcmpSendEcho fail with IP_BUF_TOO_SMALL rather than write
+    // out of bounds, but there is no reason to find out.
+    let mut reply = vec![0u8; std::mem::size_of::<ICMP_ECHO_REPLY>() + PAYLOAD.len() + 8];
+
+    // `destinationaddress` is an in_addr: the four octets in network
+    // order, read as a u32 in the host's own byte order.
+    let destination = u32::from_ne_bytes(v4.octets());
+    let timeout = u32::try_from(timeout_ms).unwrap_or(u32::MAX);
+
+    let replies = unsafe {
+        IcmpSendEcho(
+            handle.0,
+            destination,
+            PAYLOAD.as_ptr().cast(),
+            PAYLOAD.len() as u16,
+            std::ptr::null(),
+            reply.as_mut_ptr().cast(),
+            reply.len() as u32,
+            timeout,
+        )
+    };
+
+    if replies == 0 {
+        // A timeout arrives here as a failed call, not as a reply with a
+        // timeout status, so it has to be recognised from the error code.
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(IP_REQ_TIMED_OUT as i32) {
+            anyhow::bail!("Timeout");
+        }
+        anyhow::bail!("IcmpSendEcho failed: {error}");
+    }
+
+    // Safe: IcmpSendEcho reported at least one reply, so it has written a
+    // full ICMP_ECHO_REPLY at the head of a buffer we sized above. `read_unaligned`
+    // because a Vec<u8> carries no alignment guarantee for the struct.
+    let echo = unsafe { reply.as_ptr().cast::<ICMP_ECHO_REPLY>().read_unaligned() };
+
+    match echo.Status {
+        IP_SUCCESS => Ok(u64::from(echo.RoundTripTime)),
+        IP_REQ_TIMED_OUT => anyhow::bail!("Timeout"),
+        // Unreachable, TTL expired and friends all land here. The host did
+        // not answer, which is all the caller needs; the code identifies
+        // which flavour for anyone reading the error.
+        status => anyhow::bail!("ICMP status {status}"),
+    }
+}

--- a/crates/netscli-core/tests/test_ping.rs
+++ b/crates/netscli-core/tests/test_ping.rs
@@ -93,3 +93,69 @@ async fn results_serialize_with_the_fields_downstream_reads() {
         assert!(value.get(key).is_some(), "missing {key}: {value}");
     }
 }
+
+/// Regression: pinging this host used to always report 100% loss on Windows.
+///
+/// Raw ICMP needs administrator rights on Windows, so an ordinary run fell
+/// back to TCP connect probes on ports 80/443/22 -- which nothing answers on
+/// a machine asked about itself, so `netscli ping 127.0.0.1` reported total
+/// loss while the system `ping` answered immediately. (Elevated runs have a
+/// second problem: a Windows raw socket does not see traffic to an address
+/// the host owns.) It took discover and sweep down too, since both start
+/// from a ping sweep: `discover 127.0.0.0/30` came back empty.
+///
+/// Windows-only on purpose. Everywhere else this is a claim about the
+/// environment rather than about netscli: whether an unprivileged process may
+/// send ICMP depends on the runner, and the surrounding tests avoid asserting
+/// success for exactly that reason. On Windows the IP Helper API needs no
+/// privileges, so a failure here is a real defect and not a permission.
+#[cfg(windows)]
+#[tokio::test]
+async fn pinging_this_host_succeeds_on_windows() {
+    let scanner = PingScanner::new(1);
+    let target = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+    let result = scanner.ping(target, 2_000).await;
+
+    assert!(
+        result.alive,
+        "loopback must answer its own ping: {result:?}"
+    );
+    assert!(result.rtt_ms.is_some(), "a live host must carry an RTT");
+    // Pin the mechanism too. Without this the test would also pass if ICMP
+    // silently degraded to the TCP fallback and something happened to be
+    // listening on port 80 -- which is the original bug wearing a disguise.
+    assert_eq!(
+        result.method.as_deref(),
+        Some("icmpv4"),
+        "loopback should be reached over ICMP, not the TCP fallback: {result:?}"
+    );
+}
+
+/// The same defect reached past loopback: an address the *host itself* owns
+/// is short-circuited the same way, so `ping <my own LAN IP>` also reported
+/// total loss. That is why the fix is not an `is_loopback()` special case.
+#[cfg(windows)]
+#[tokio::test]
+async fn pinging_an_address_this_host_owns_succeeds_on_windows() {
+    let Some(local) = netscli_core::NetworkManager::get_interfaces()
+        .into_iter()
+        .filter(|iface| !iface.is_loopback && iface.is_up)
+        .find_map(|iface| {
+            iface.ips.into_iter().find_map(|net| match net.addr() {
+                IpAddr::V4(v4) if !v4.is_link_local() && !v4.is_loopback() => Some(IpAddr::V4(v4)),
+                _ => None,
+            })
+        })
+    else {
+        // No non-loopback IPv4 address: nothing to assert about.
+        return;
+    };
+
+    let result = PingScanner::new(1).ping(local, 2_000).await;
+
+    assert!(
+        result.alive,
+        "this host must answer a ping to its own address {local}: {result:?}"
+    );
+}


### PR DESCRIPTION
`netscli ping 127.0.0.1` reported `loss=100.0%` on Windows while the system `ping` reported none. The machine's own LAN address failed identically, and since discover and sweep both start from a ping sweep, both returned nothing for any range covering this host — including the GUI e2e suite's `discover 127.0.0.0/30`.

## Cause

Two things stacked up, and only the first shows up in an ordinary run:

1. **Raw ICMP needs administrator rights on Windows.** Unprivileged runs never reached the ICMP path at all — `can_use_raw_icmpv4()` returned false and the scanner fell back to TCP connect probes on ports 80/443/22. Nothing answers those on a machine asked about itself, so it concluded "down". This is the one I measured: the pre-fix failure output reports `method: Some("tcp-connect")`.
2. **A Windows raw socket does not observe traffic to an address the host owns.** Documented platform behaviour that would bite an elevated run. I did not verify this one directly — it needs an elevated run — so it is stated as the reason the raw path is not worth repairing, not as a measured result.

## Fix

Windows sends echoes through the IP Helper API (`IcmpSendEcho`), which needs no privileges and reaches local addresses. Unix keeps the raw socket, where loopback ICMP is observable and this dependency would buy nothing.

Because cause 2 reaches past loopback, the `is_loopback()` special case I first considered would have left "ping my own machine" broken.

## Verified

| Target | Before | After |
| --- | --- | --- |
| `127.0.0.1` | 100% loss | 0% loss |
| own LAN address | 100% loss | 0% loss |
| `127.0.0.2` | 100% loss | 0% loss |
| LAN gateway | 0% loss | 0% loss |
| absent host on the LAN | 100% loss | 100% loss |

That last row is the one worth keeping: the fix does not make everything look alive. `discover 127.0.0.0/30` now returns both hosts, and a full LAN discover is unchanged at 26 hosts (20 probe, 6 neighbour).

## Tests

Two added to `test_ping.rs`, both confirmed failing against the previous behaviour before being kept. Windows-gated on purpose — elsewhere "loopback answers" is a claim about the runner's ICMP permissions rather than about netscli, which is why the surrounding tests avoid asserting success. CI runs `cargo test --all` on `windows-latest`, so they do execute there.

One asserts `method == "icmpv4"`: without it the test would also pass if ICMP silently degraded to the TCP fallback and something happened to be listening on port 80, which is the original bug wearing a disguise.

`cargo fmt`, `clippy --all-targets -D warnings` and the full workspace suite are clean.

## Not addressed

`ping ::1` still fails. IPv6 has no ICMP path at all and falls back to TCP, which is a separate pre-existing gap.