### PR TITLE
Ping IPv6 over ICMP, and aim the keyboard test at the grid

### DIFF
--- a/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/table.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/table.mjs
@@ -2,20 +2,28 @@ import assert from 'node:assert/strict';
 import { By, Key } from '../../driver.mjs';
 import { waitForText } from '../../ui.mjs';
 
+// Keyboard events go to the grid, not to the scroll container that carries
+// the test id. `tabIndex` and the key handler live on the inner
+// `<table role="grid">` -- deliberately, so `aria-activedescendant` sits on
+// the focused element -- and keydown bubbles up, so an event dispatched on
+// the container never reaches the handler. A real user focuses the table by
+// tabbing to it or clicking a row; targeting the container tested nothing.
+const GRID = '[data-testid="result-table"] table[role="grid"]';
+
 async function assertKeyboardSelection(driver) {
   const rowCount = await driver.executeScript(`
     const rows = document.querySelectorAll('[data-testid="result-table"] tbody tr');
     return rows.length;
   `);
   assert.ok(rowCount > 1, 'Keyboard selection test needs multiple rows');
-  const table = await driver.findElement(By.css('[data-testid="result-table"]'));
-  await driver.executeScript("document.querySelector('[data-testid=\"result-table\"]')?.focus();");
+  const table = await driver.findElement(By.css(GRID));
+  await driver.executeScript(`document.querySelector('${GRID}')?.focus();`);
   const tableUserSelect = await driver.executeScript(`
     return getComputedStyle(document.querySelector('[data-testid="result-table"]')).userSelect;
   `);
   assert.equal(tableUserSelect, 'none', 'Result table should not select text during keyboard row selection');
   await driver.executeScript(`
-    const table = document.querySelector('[data-testid="result-table"]');
+    const table = document.querySelector('${GRID}');
     window.getSelection()?.removeAllRanges();
     table?.dispatchEvent(new KeyboardEvent('keydown', {
       key: 'a',
@@ -48,7 +56,7 @@ async function assertKeyboardSelection(driver) {
   `);
   assert.equal(afterEnd, rowCount - 1, 'End should select the last row');
   await driver.executeScript(`
-    const table = document.querySelector('[data-testid="result-table"]');
+    const table = document.querySelector('${GRID}');
     table?.dispatchEvent(new KeyboardEvent('keydown', {
       key: 'ArrowUp',
       shiftKey: true,

--- a/crates/netscli-core/src/ping.rs
+++ b/crates/netscli-core/src/ping.rs
@@ -94,9 +94,14 @@ impl PingScanner {
             }
         };
 
-        // Prefer raw ICMPv4 when available and target is IPv4. Otherwise fall back to TCP probe.
+        // Prefer ICMP when the platform offers it for this address family.
+        // Otherwise fall back to the TCP probe, which is a weaker signal: it
+        // can only prove a host is up by getting something back from a port.
         match (self.backend, target) {
             (PingBackend::RawIcmpV4, IpAddr::V4(_)) => ping_icmpv4(target, timeout_ms, seq).await,
+            // Unix has no ICMPv6 path here, so v6 keeps falling back there.
+            #[cfg(windows)]
+            (_, IpAddr::V6(v6)) => ping_icmpv6(v6, timeout_ms, seq).await,
             _ => ping_tcp_probe(target, timeout_ms, seq).await,
         }
     }
@@ -140,6 +145,25 @@ async fn ping_icmpv4(target: IpAddr, timeout_ms: u64, seq: u16) -> PingResult {
             error: Some(format!("ping task failed: {e}")),
             method: Some("icmpv4".to_string()),
         },
+    }
+}
+
+#[cfg(windows)]
+async fn ping_icmpv6(target: std::net::Ipv6Addr, timeout_ms: u64, seq: u16) -> PingResult {
+    let outcome =
+        tokio::task::spawn_blocking(move || windows_icmp::send_echo6(target, timeout_ms)).await;
+    let (rtt_ms, error) = match outcome {
+        Ok(Ok(rtt)) => (Some(rtt), None),
+        Ok(Err(e)) => (None, Some(e.to_string())),
+        Err(e) => (None, Some(format!("ping task failed: {e}"))),
+    };
+    PingResult {
+        ip: IpAddr::V6(target),
+        alive: rtt_ms.is_some(),
+        rtt_ms,
+        seq,
+        error,
+        method: Some("icmpv6".to_string()),
     }
 }
 

--- a/crates/netscli-core/src/ping/windows_icmp.rs
+++ b/crates/netscli-core/src/ping/windows_icmp.rs
@@ -5,11 +5,13 @@
 //! and any address this host owns. Both properties are load-bearing: see the
 //! note on `send_icmp_echo_v4` for the failure each one fixes.
 
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
 use windows_sys::Win32::NetworkManagement::IpHelper::{
-    IcmpCloseHandle, IcmpCreateFile, IcmpSendEcho, ICMP_ECHO_REPLY, IP_REQ_TIMED_OUT, IP_SUCCESS,
+    Icmp6CreateFile, Icmp6SendEcho2, IcmpCloseHandle, IcmpCreateFile, IcmpSendEcho,
+    ICMPV6_ECHO_REPLY_LH, ICMP_ECHO_REPLY, IP_REQ_TIMED_OUT, IP_SUCCESS,
 };
+use windows_sys::Win32::Networking::WinSock::{AF_INET6, SOCKADDR_IN6};
 
 /// Payload sent with each echo. Content is irrelevant to the result; a
 /// recognisable string just makes the packets readable in a capture.
@@ -85,5 +87,77 @@ pub fn send_echo(target: IpAddr, timeout_ms: u64) -> anyhow::Result<u64> {
         // not answer, which is all the caller needs; the code identifies
         // which flavour for anyone reading the error.
         status => anyhow::bail!("ICMP status {status}"),
+    }
+}
+
+/// Send an ICMPv6 echo and wait for the reply.
+///
+/// IPv6 had no ICMP path at all before this: it fell through to the TCP
+/// probe, so `ping ::1` reported total loss for the same reason IPv4 loopback
+/// did. `Icmp6SendEcho2` differs from its v4 counterpart in wanting both
+/// endpoints as socket addresses, and the source is not optional -- passing a
+/// zeroed `SOCKADDR_IN6` is how you say "any", which lets the stack pick.
+pub fn send_echo6(target: Ipv6Addr, timeout_ms: u64) -> anyhow::Result<u64> {
+    let handle = unsafe { Icmp6CreateFile() };
+    if handle == INVALID_HANDLE_VALUE || handle.is_null() {
+        anyhow::bail!(
+            "Icmp6CreateFile failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    let handle = IcmpHandle(handle);
+
+    let source = SOCKADDR_IN6 {
+        sin6_family: AF_INET6,
+        ..Default::default()
+    };
+    let mut destination = SOCKADDR_IN6 {
+        sin6_family: AF_INET6,
+        ..Default::default()
+    };
+    destination.sin6_addr.u.Byte = target.octets();
+
+    // Same shape as the v4 buffer, around the v6 reply struct.
+    let mut reply = vec![0u8; std::mem::size_of::<ICMPV6_ECHO_REPLY_LH>() + PAYLOAD.len() + 8];
+    let timeout = u32::try_from(timeout_ms).unwrap_or(u32::MAX);
+
+    // A null event and APC routine is what makes this synchronous; the return
+    // value is then the reply count rather than a completion signal.
+    let replies = unsafe {
+        Icmp6SendEcho2(
+            handle.0,
+            std::ptr::null_mut(),
+            None,
+            std::ptr::null(),
+            &source,
+            &destination,
+            PAYLOAD.as_ptr().cast(),
+            PAYLOAD.len() as u16,
+            std::ptr::null(),
+            reply.as_mut_ptr().cast(),
+            reply.len() as u32,
+            timeout,
+        )
+    };
+
+    if replies == 0 {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(IP_REQ_TIMED_OUT as i32) {
+            anyhow::bail!("Timeout");
+        }
+        anyhow::bail!("Icmp6SendEcho2 failed: {error}");
+    }
+
+    let echo = unsafe {
+        reply
+            .as_ptr()
+            .cast::<ICMPV6_ECHO_REPLY_LH>()
+            .read_unaligned()
+    };
+
+    match echo.Status {
+        IP_SUCCESS => Ok(u64::from(echo.RoundTripTime)),
+        IP_REQ_TIMED_OUT => anyhow::bail!("Timeout"),
+        status => anyhow::bail!("ICMPv6 status {status}"),
     }
 }

--- a/crates/netscli-core/tests/test_ping.rs
+++ b/crates/netscli-core/tests/test_ping.rs
@@ -159,3 +159,42 @@ async fn pinging_an_address_this_host_owns_succeeds_on_windows() {
         "this host must answer a ping to its own address {local}: {result:?}"
     );
 }
+
+/// Regression: `ping ::1` reported total loss because IPv6 had no ICMP path.
+///
+/// It fell through to the TCP probe, which asks ports 80/443/22 and concludes
+/// a host is down when nothing answers -- the same shape of failure IPv4
+/// loopback had, from a different cause. Windows-gated because Unix still
+/// falls back for v6; the assertion here is about netscli having an ICMPv6
+/// path at all, not about the runner's permissions.
+#[cfg(windows)]
+#[tokio::test]
+async fn pinging_ipv6_loopback_succeeds_on_windows() {
+    let scanner = PingScanner::new(1);
+    let target = IpAddr::V6(Ipv6Addr::LOCALHOST);
+
+    let result = scanner.ping(target, 2_000).await;
+
+    assert!(result.alive, "::1 must answer its own ping: {result:?}");
+    assert_eq!(
+        result.method.as_deref(),
+        Some("icmpv6"),
+        "v6 should go over ICMPv6, not the TCP fallback: {result:?}"
+    );
+}
+
+/// The v6 path must still be able to say "no". A probe that reported every
+/// address alive would pass the test above and be worse than no probe.
+#[cfg(windows)]
+#[tokio::test]
+async fn an_unreachable_ipv6_target_is_reported_dead() {
+    // 2001:db8::/32 is RFC 3849 documentation space: never routed.
+    let target = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+
+    let result = PingScanner::new(1).ping(target, 1_000).await;
+
+    assert!(
+        !result.alive,
+        "documentation space must not answer: {result:?}"
+    );
+}


### PR DESCRIPTION
Two unrelated leftovers from the e2e triage. With both in, the GUI e2e suite passes end to end for the first time — all eight scenarios, including the discover and sweep ones unblocked by #246.

## `ping ::1` reported 100% loss

IPv6 had no ICMP path at all. It fell through to the TCP probe, which asks ports 80/443/22 and concludes a host is down when nothing answers — the same shape of failure IPv4 loopback had in #246, from a different cause.

Windows now sends ICMPv6 via `Icmp6SendEcho2`. Its signature differs from the v4 call in wanting both endpoints as `SOCKADDR_IN6`, and the source is not optional: a zeroed one is how you ask the stack to choose. Unix has no ICMPv6 path and still falls back to TCP, which is why the new tests are Windows-gated.

| Target | Before | After |
| --- | --- | --- |
| `::1` | 100% loss | 0% loss |
| `2001:db8::1` (RFC 3849, never routed) | 100% loss | 100% loss |

Two tests. `pinging_ipv6_loopback_succeeds_on_windows` was confirmed failing against the previous behaviour. `an_unreachable_ipv6_target_is_reported_dead` passes either way by design — it is a guard against a probe that calls everything alive, not a regression test.

## Ctrl+A selected 1 row of 12

This one was the test, not the app.

`data-testid="result-table"` is on the scroll container. `tabIndex` and the key handler are on the inner `<table role="grid">` — deliberately, per the B-20 comment, so `aria-activedescendant` sits on the focused element. Keyboard events bubble *up*, so an event dispatched on the container never reached the handler, and `.focus()` on a div with no tabIndex does nothing. The helper had been asserting against an element no key press can reach.

A real user focuses the grid by tabbing to it or clicking a row (rows carry `tabIndex={-1}`), so Ctrl+A always worked. The helper now targets the grid for focus, dispatch and `sendKeys`; row queries are unchanged. It passes against the running app.

`cargo fmt`, `clippy --all-targets -D warnings`, the full workspace suite and the file-size guard are clean.