### PR TITLE
Centre the settings dialog on the workspace, and dress its number field

### DIFF
--- a/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/settingsDialog.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/settingsDialog.mjs
@@ -27,6 +27,8 @@ async function assertSettingsDialog(driver) {
   await waitForText(driver, '[data-testid="settings-dialog"]', /Network Interface/i);
   const text = await driver.findElement(By.css('[data-testid="settings-dialog"]')).getText();
   assert.doesNotMatch(text, /\bNIC\b/i, 'Settings should use Network Interface, not NIC');
+  // While it is still open -- this helper closes it at the end.
+  await assertSettingsDialogCentring(driver);
   const themeControl = await driver.executeScript(`
     const control = document.querySelector('[data-testid="settings-theme-toggle"]');
     const dialog = document.querySelector('[data-testid="settings-dialog"]');
@@ -101,4 +103,60 @@ async function closeSettingsDialog(driver) {
   await waitForNoElement(driver, '[data-testid="settings-dialog"]');
 }
 
-export { assertSettingsDialog, closeSettingsDialog, openSettingsDialog };
+/**
+ * The dialog should sit at the optical centre of the workspace, not of the
+ * window.
+ *
+ * `.settings-overlay` pads itself by the chrome above and below the content
+ * region so the centring box lands on that region. Those paddings are
+ * measured constants, so this re-measures them: change the toolbar height
+ * and the dialog silently drifts off centre, which is not something anyone
+ * notices for months. Comparing against the live chrome rather than against
+ * a stored number is what makes this a check rather than a second copy of
+ * the same assumption.
+ */
+async function assertSettingsDialogCentring(driver) {
+  const geometry = await driver.executeScript(`
+    const rect = (selector) => {
+      const el = document.querySelector(selector);
+      if (!el) return null;
+      const b = el.getBoundingClientRect();
+      return { top: b.top, bottom: b.bottom, height: b.height };
+    };
+    const dialog = rect('[data-testid="settings-dialog"]');
+    const workspace = rect('.workspace') || rect('.main-frame');
+    const statusbar = rect('[data-testid="statusbar"]');
+    const tabStrip = rect('[data-testid="tab-strip"]');
+    return { dialog, workspace, statusbar, tabStrip, viewportHeight: window.innerHeight };
+  `);
+
+  assert.ok(geometry.dialog, 'settings dialog should be on screen to measure');
+  assert.ok(geometry.tabStrip && geometry.statusbar, 'need the chrome to locate the content region');
+
+  // The content region is whatever sits between the last chrome above it and
+  // the status bar below, read from the running app rather than assumed.
+  const contentTop = geometry.tabStrip.bottom;
+  const contentBottom = geometry.statusbar.top;
+  const contentCentre = (contentTop + contentBottom) / 2;
+  const dialogCentre = (geometry.dialog.top + geometry.dialog.bottom) / 2;
+  const drift = Math.abs(dialogCentre - contentCentre);
+
+  // A few pixels of rounding is fine; the bug this pins was 45px.
+  assert.ok(
+    drift <= 6,
+    `settings dialog is ${drift.toFixed(0)}px off the centre of the content region `
+      + `(content ${contentTop.toFixed(0)}..${contentBottom.toFixed(0)}, `
+      + `dialog centre ${dialogCentre.toFixed(0)}). The chrome paddings in settings.css `
+      + 'are stale -- re-measure them against the current layout.',
+  );
+
+  // And it must still fit: a dialog taller than the region it centres on
+  // would be clipped at both ends by the chrome.
+  assert.ok(
+    geometry.dialog.height <= contentBottom - contentTop,
+    `settings dialog (${geometry.dialog.height.toFixed(0)}px) is taller than the content region `
+      + `(${(contentBottom - contentTop).toFixed(0)}px)`,
+  );
+}
+
+export { assertSettingsDialog, assertSettingsDialogCentring, closeSettingsDialog, openSettingsDialog };

--- a/apps/netscli-gui/src/hooks/usePreferences.test.ts
+++ b/apps/netscli-gui/src/hooks/usePreferences.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+//
+// Defaults on a fresh install.
+//
+// `Number(null)` is 0 and `Number.isFinite(0)` is true, so reading an unset
+// preference through `Number(localStorage.getItem(...))` produced a stored
+// zero rather than falling through to the default. Max concurrent probes
+// came out as 1 instead of 256 -- serialising every scan, discover and
+// sweep -- and traffic precision as 0 instead of 2. Both look like settings
+// someone chose, which is why neither was visible as a bug.
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { usePreferences } from './usePreferences';
+
+describe('preferences on a fresh install', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('runs probes concurrently rather than one at a time', () => {
+    const { result } = renderHook(() => usePreferences());
+
+    expect(result.current.maxConcurrentProbes).toBe(256);
+  });
+
+  it('shows traffic to two decimal places', () => {
+    const { result } = renderHook(() => usePreferences());
+
+    expect(result.current.trafficPrecision).toBe(2);
+  });
+
+  it('honours a stored value over the default', () => {
+    window.localStorage.setItem('netscli-max-concurrent-probes', '64');
+    window.localStorage.setItem('netscli-traffic-precision', '0');
+
+    const { result } = renderHook(() => usePreferences());
+
+    expect(result.current.maxConcurrentProbes).toBe(64);
+    // 0 is a legitimate stored precision, and must survive the "not set"
+    // check that this fix added.
+    expect(result.current.trafficPrecision).toBe(0);
+  });
+
+  it('falls back to the default when the stored value is unusable', () => {
+    window.localStorage.setItem('netscli-max-concurrent-probes', 'not-a-number');
+    window.localStorage.setItem('netscli-traffic-precision', '');
+
+    const { result } = renderHook(() => usePreferences());
+
+    expect(result.current.maxConcurrentProbes).toBe(256);
+    expect(result.current.trafficPrecision).toBe(2);
+  });
+});

--- a/apps/netscli-gui/src/hooks/usePreferences.ts
+++ b/apps/netscli-gui/src/hooks/usePreferences.ts
@@ -24,9 +24,25 @@ function initialTrafficDisplayUnit(): TrafficDisplayUnit {
   return value === 'Gbps' || value === 'Mbps' || value === 'Kbps' ? value : 'Mbps';
 }
 
+/**
+ * Read a persisted number, distinguishing "never set" from a stored value.
+ *
+ * `Number(null)` is `0`, and `Number.isFinite(0)` is `true`, so the obvious
+ * spelling treats a missing key as a stored zero and the default branch never
+ * runs. That gave a fresh install 1 concurrent probe instead of 256 -- every
+ * scan, discover and sweep serialised -- and traffic precision 0 instead of
+ * 2. Both read as deliberate settings, which is why neither was noticed.
+ */
+function storedNumber(key: string): number | null {
+  const raw = window.localStorage.getItem(key);
+  if (raw === null || raw.trim() === '') return null;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
 function initialTrafficPrecision(): TrafficPrecision {
   if (typeof window === 'undefined') return 2;
-  const value = Number(window.localStorage.getItem('netscli-traffic-precision'));
+  const value = storedNumber('netscli-traffic-precision');
   return value === 0 || value === 1 || value === 2 ? value : 2;
 }
 
@@ -38,8 +54,8 @@ function initialAddressPreference(): AddressPreference {
 
 function initialMaxConcurrentProbes(): MaxConcurrentProbes {
   if (typeof window === 'undefined') return 256;
-  const value = Number(window.localStorage.getItem('netscli-max-concurrent-probes'));
-  return Number.isFinite(value) ? clampMaxConcurrentProbes(value) : 256;
+  const value = storedNumber('netscli-max-concurrent-probes');
+  return value === null ? 256 : clampMaxConcurrentProbes(value);
 }
 
 export function clampMaxConcurrentProbes(value: number): MaxConcurrentProbes {

--- a/apps/netscli-gui/src/styles/shell.css
+++ b/apps/netscli-gui/src/styles/shell.css
@@ -5,6 +5,7 @@
 @import './shell/command-status.css';
 @import './shell/context-menu.css';
 @import './shell/settings-controls.css';
+@import './shell/settings-number-field.css';
 @import './shell/settings.css';
 @import './shell/window-controls.css';
 @import './shell/about-dialog.css';

--- a/apps/netscli-gui/src/styles/shell/settings-number-field.css
+++ b/apps/netscli-gui/src/styles/shell/settings-number-field.css
@@ -1,0 +1,76 @@
+/* Max Concurrent Probes.
+   These three classes were emitted by SettingsControls with no stylesheet
+   defining any of them, so the row rendered in the WebView's defaults: 3D
+   outset bevels on the two steppers, an inset light-grey field, and -- since
+   nothing set `appearance` -- the native spin arrows on top of the custom
+   +/- buttons. Two sets of controls for one value, in a dialog that is
+   otherwise fully themed. */
+.settings-number-field {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+}
+
+.settings-number-stepper {
+  width: 28px;
+  min-width: 28px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.settings-number-stepper:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--bg-elevated);
+}
+
+.settings-number-stepper:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.settings-number-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-input);
+  padding: 0 8px;
+}
+
+.settings-number-input-wrap:focus-within {
+  border-color: var(--border-strong);
+}
+
+.settings-number-input-wrap input[type="number"] {
+  width: 52px;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  padding: 6px 0;
+  text-align: right;
+  /* The +/- buttons are the stepper. Without this the WebView draws its own
+     spin arrows inside the field as well. */
+  appearance: textfield;
+}
+
+.settings-number-input-wrap input[type="number"]::-webkit-outer-spin-button,
+.settings-number-input-wrap input[type="number"]::-webkit-inner-spin-button {
+  margin: 0;
+  appearance: none;
+}
+
+.settings-number-input-wrap input[type="number"]:focus {
+  outline: none;
+}
+
+.settings-number-input-wrap span {
+  color: var(--text-secondary);
+  font-size: 12px;
+}

--- a/apps/netscli-gui/src/styles/shell/settings.css
+++ b/apps/netscli-gui/src/styles/shell/settings.css
@@ -1,16 +1,36 @@
 .settings-overlay {
+  /* The app draws its own chrome, and it is lopsided: 117px above the
+     workspace (title bar 34 + toolbar 45 + tab strip 38) against 27px of
+     status bar below. Centring on the viewport is therefore centred on the
+     window but sits 45px above the optical centre of the content, which is
+     what reads as "not quite centred".
+
+     Padding the overlay by each side's chrome makes the centring box the
+     content region exactly, while the backdrop still covers the whole
+     window. These numbers are measured, so `assertSettingsDialogCentring`
+     in the e2e suite re-measures them against the running app -- a silent
+     45px drift when someone changes the toolbar height is not something
+     anyone would notice for months. */
+  --chrome-above-workspace: 117px;
+  --chrome-below-workspace: 27px;
+
   position: fixed;
   inset: 0;
   z-index: var(--z-modal);
   display: grid;
   place-items: center;
-  padding: 18px;
+  padding: var(--chrome-above-workspace) 18px var(--chrome-below-workspace);
   background: rgba(0, 0, 0, 0.34);
 }
 
 .settings-dialog {
   width: min(680px, calc(100vw - 32px));
-  max-height: min(540px, calc(100vh - 36px));
+  /* Leaves 16px of breathing room inside the content region on a window too
+     short for the dialog's natural height. */
+  max-height: min(
+    540px,
+    calc(100vh - var(--chrome-above-workspace) - var(--chrome-below-workspace) - 16px)
+  );
   display: flex;
   flex-direction: column;
   border: 1px solid var(--border-strong);


### PR DESCRIPTION
Three things in the settings dialog, all found from one report that it did not look centred.

## It was centred — on the window

Measured in the running app: 160px each side, 80px top and bottom, and nothing in the ancestor chain creating a containing block. The CSS was doing exactly what it said.

But the app draws its own chrome, and it is lopsided — 117px above the workspace (title bar 34 + toolbar 45 + tab strip 38) against 27px of status bar below. So the content region runs 117..673, its centre is 395, and the window centre is 350: the dialog sat **45px above the optical centre of the content**.

The overlay now pads itself by each side's chrome, which makes the centring box the content region while the backdrop still covers the whole window.

Those paddings are measured constants, so `assertSettingsDialogCentring` re-measures them against the running app — comparing the dialog against the *live* chrome rather than a second copy of the same assumption. Change the toolbar height and it fails, instead of the dialog silently drifting for months. Confirmed to fail against the previous centring before being kept.

## The number field was unstyled

`.settings-number-field`, `.settings-number-stepper` and `.settings-number-input-wrap` were emitted by `SettingsControls` with **no stylesheet defining any of them**. Measured on the running app: `border: 1.6px outset rgba(195,195,195,0.3)` on the steppers — the native 3D bevel — and `1.6px inset` with a light grey background on the field. `appearance` was `auto`, so the WebView also drew its own spin arrows inside the field, giving two sets of controls for one value in an otherwise fully themed dialog.

Now styled with the same tokens as the other settings controls, native spinners suppressed since the +/- buttons are the stepper. New file because `settings-controls.css` was already at the 300-line guard.

## That field was showing 1, and it was right to

`Number(null)` is `0`, and `Number.isFinite(0)` is `true`. So reading an unset preference through `Number(localStorage.getItem(...))` sees a stored zero and never reaches the default:

| Preference | Intended default | Actual on a fresh install |
| --- | --- | --- |
| Max concurrent probes | 256 | **1** |
| Traffic precision | 2 | **0** |

The first is the significant one: a fresh install ran **one probe at a time**, serialising every scan, discover and sweep. The second is visible in the status bar as `0 Mbps` with no decimals. Both read as settings someone had deliberately chosen, which is why neither looked like a defect.

Fixed with a shared `storedNumber` helper that distinguishes "never set" from a stored value — two call sites, both real. Four unit tests; three fail against the previous behaviour (`expected 1 to be 256`, `expected +0 to be 2`). The fourth pins that a legitimately stored `0` precision still survives the new "not set" check.

## Verified

Full GUI e2e suite passes end to end — all eight scenarios. 134 unit tests, `tsc -b`, `eslint`, and the file-size guard clean.