### PR TITLE
Recover installs the zero-default bug left running one probe at a time

### DIFF
--- a/apps/netscli-gui/src/hooks/usePreferences.test.ts
+++ b/apps/netscli-gui/src/hooks/usePreferences.test.ts
@@ -53,3 +53,46 @@ describe('preferences on a fresh install', () => {
     expect(result.current.trafficPrecision).toBe(2);
   });
 });
+
+// Fixing the default alone was not enough: the hook writes every preference
+// back on mount, so the broken build had already saved its wrong values as
+// though they were chosen. An install that ran it stayed serialised.
+describe('recovering an install that ran the broken build', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('restores concurrency on a profile the bug left at 1', () => {
+    window.localStorage.setItem('netscli-max-concurrent-probes', '1');
+    window.localStorage.setItem('netscli-traffic-precision', '0');
+
+    const { result } = renderHook(() => usePreferences());
+
+    expect(result.current.maxConcurrentProbes).toBe(256);
+    // Precision is deliberately NOT repaired: 0 decimals is a reasonable
+    // thing to want, so overriding it to undo a cosmetic bug would cost
+    // more than it fixes.
+    expect(result.current.trafficPrecision).toBe(0);
+  });
+
+  it('runs once, so a later deliberate choice of 1 survives', () => {
+    window.localStorage.setItem('netscli-max-concurrent-probes', '1');
+    renderHook(() => usePreferences());
+
+    // The repair has run. Someone now genuinely picks one probe at a time.
+    window.localStorage.setItem('netscli-max-concurrent-probes', '1');
+    const { result } = renderHook(() => usePreferences());
+
+    expect(result.current.maxConcurrentProbes).toBe(1);
+  });
+
+  it('leaves any other stored value alone', () => {
+    window.localStorage.setItem('netscli-max-concurrent-probes', '32');
+    window.localStorage.setItem('netscli-traffic-precision', '1');
+
+    const { result } = renderHook(() => usePreferences());
+
+    expect(result.current.maxConcurrentProbes).toBe(32);
+    expect(result.current.trafficPrecision).toBe(1);
+  });
+});

--- a/apps/netscli-gui/src/hooks/usePreferences.ts
+++ b/apps/netscli-gui/src/hooks/usePreferences.ts
@@ -40,6 +40,37 @@ function storedNumber(key: string): number | null {
   return Number.isFinite(value) ? value : null;
 }
 
+/**
+ * Undo the values the zero-default bug wrote, once.
+ *
+ * Fixing `storedNumber` only helps an install that never ran the broken
+ * build. Everyone else already has the bad value persisted -- the hook
+ * writes every preference back on mount, so the very first launch saved
+ * `1` probes and `0` precision as though they had been chosen. Reading
+ * them correctly now just reads a wrong number correctly, and the install
+ * stays serialised forever.
+ *
+ * Only concurrency is repaired. 1 probe is never a sensible choice -- it
+ * serialises every scan, discover and sweep -- so a stored 1 at this moment
+ * is the bug's fingerprint rather than a preference. Traffic precision is
+ * deliberately left alone: 0 decimals is a reasonable thing to want, the
+ * cost of being wrong is cosmetic, and overriding a real choice to fix a
+ * rounding display is the worse trade. Anyone bitten by that half can change
+ * it in Settings.
+ *
+ * The marker makes this run exactly once, so a genuine later choice of 1 is
+ * never second-guessed.
+ */
+function repairZeroDefaults(): void {
+  const REPAIRED = 'netscli-prefs-repaired-zero-defaults';
+  if (window.localStorage.getItem(REPAIRED) === 'done') return;
+  window.localStorage.setItem(REPAIRED, 'done');
+
+  if (window.localStorage.getItem('netscli-max-concurrent-probes') === '1') {
+    window.localStorage.setItem('netscli-max-concurrent-probes', '256');
+  }
+}
+
 function initialTrafficPrecision(): TrafficPrecision {
   if (typeof window === 'undefined') return 2;
   const value = storedNumber('netscli-traffic-precision');
@@ -54,6 +85,7 @@ function initialAddressPreference(): AddressPreference {
 
 function initialMaxConcurrentProbes(): MaxConcurrentProbes {
   if (typeof window === 'undefined') return 256;
+  repairZeroDefaults();
   const value = storedNumber('netscli-max-concurrent-probes');
   return value === null ? 256 : clampMaxConcurrentProbes(value);
 }


### PR DESCRIPTION
#248 fixed the default but not the damage. The hook writes every preference back on mount, so the broken build's first launch saved `1` concurrent probe as though it had been chosen. Reading it correctly afterwards just reads a wrong number correctly, and the install stays serialised forever.

Reproduced against the running app, not reasoned about:

```
before: after reload with the bug value persisted: {"probes":"1"}  -> STUCK AT 1
after:  after reload with the bug value persisted: {"probes":"256"} -> recovered
```

A stored `1` at this moment is the bug's fingerprint rather than a preference — one probe at a time is never a sensible choice. A marker key makes the repair run exactly once, so a genuine later choice of 1 is never second-guessed.

## Traffic precision is deliberately not repaired

It was written by the same defect, but `0` decimals is a reasonable thing to want, the cost of being wrong is cosmetic, and overriding a real preference to fix a rounding display is the worse trade.

I had it in the first version. The existing test asserting that a stored `0` must survive failed, which was the right call — anyone bitten by that half can change it in Settings.

## Tests

Three added (7 in the file): recovery from a bug-left profile, the repair running only once so a later deliberate 1 survives, and other stored values left alone. Full GUI e2e suite passes; 137 unit tests, `tsc`, `eslint` and the size guard clean.