### PR TITLE
Centre the settings dialog on the viewport, and repair before marking

### DIFF
--- a/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/settingsDialog.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/helpers/settingsDialog.mjs
@@ -104,58 +104,28 @@ async function closeSettingsDialog(driver) {
 }
 
 /**
- * The dialog should sit at the optical centre of the workspace, not of the
- * window.
+ * The dialog should be centred on the viewport.
  *
- * `.settings-overlay` pads itself by the chrome above and below the content
- * region so the centring box lands on that region. Those paddings are
- * measured constants, so this re-measures them: change the toolbar height
- * and the dialog silently drifts off centre, which is not something anyone
- * notices for months. Comparing against the live chrome rather than against
- * a stored number is what makes this a check rather than a second copy of
- * the same assumption.
+ * Not on the workspace region: an earlier version centred it there, on the
+ * reasoning that the app draws more chrome above the content than below, and
+ * it read as wrong to the person looking at it. This pins the simpler rule
+ * so nobody re-derives the clever one.
  */
 async function assertSettingsDialogCentring(driver) {
   const geometry = await driver.executeScript(`
-    const rect = (selector) => {
-      const el = document.querySelector(selector);
-      if (!el) return null;
-      const b = el.getBoundingClientRect();
-      return { top: b.top, bottom: b.bottom, height: b.height };
-    };
-    const dialog = rect('[data-testid="settings-dialog"]');
-    const workspace = rect('.workspace') || rect('.main-frame');
-    const statusbar = rect('[data-testid="statusbar"]');
-    const tabStrip = rect('[data-testid="tab-strip"]');
-    return { dialog, workspace, statusbar, tabStrip, viewportHeight: window.innerHeight };
+    const b = document.querySelector('[data-testid="settings-dialog"]')?.getBoundingClientRect();
+    return b ? { top: b.top, bottom: b.bottom, vh: window.innerHeight } : null;
   `);
+  assert.ok(geometry, 'settings dialog should be on screen to measure');
 
-  assert.ok(geometry.dialog, 'settings dialog should be on screen to measure');
-  assert.ok(geometry.tabStrip && geometry.statusbar, 'need the chrome to locate the content region');
+  const above = geometry.top;
+  const below = geometry.vh - geometry.bottom;
+  const drift = Math.abs(above - below);
 
-  // The content region is whatever sits between the last chrome above it and
-  // the status bar below, read from the running app rather than assumed.
-  const contentTop = geometry.tabStrip.bottom;
-  const contentBottom = geometry.statusbar.top;
-  const contentCentre = (contentTop + contentBottom) / 2;
-  const dialogCentre = (geometry.dialog.top + geometry.dialog.bottom) / 2;
-  const drift = Math.abs(dialogCentre - contentCentre);
-
-  // A few pixels of rounding is fine; the bug this pins was 45px.
   assert.ok(
     drift <= 6,
-    `settings dialog is ${drift.toFixed(0)}px off the centre of the content region `
-      + `(content ${contentTop.toFixed(0)}..${contentBottom.toFixed(0)}, `
-      + `dialog centre ${dialogCentre.toFixed(0)}). The chrome paddings in settings.css `
-      + 'are stale -- re-measure them against the current layout.',
-  );
-
-  // And it must still fit: a dialog taller than the region it centres on
-  // would be clipped at both ends by the chrome.
-  assert.ok(
-    geometry.dialog.height <= contentBottom - contentTop,
-    `settings dialog (${geometry.dialog.height.toFixed(0)}px) is taller than the content region `
-      + `(${(contentBottom - contentTop).toFixed(0)}px)`,
+    `settings dialog is ${drift.toFixed(0)}px off the vertical centre of the viewport `
+      + `(${above.toFixed(0)}px above, ${below.toFixed(0)}px below).`,
   );
 }
 

--- a/apps/netscli-gui/src/hooks/usePreferences.ts
+++ b/apps/netscli-gui/src/hooks/usePreferences.ts
@@ -64,11 +64,17 @@ function storedNumber(key: string): number | null {
 function repairZeroDefaults(): void {
   const REPAIRED = 'netscli-prefs-repaired-zero-defaults';
   if (window.localStorage.getItem(REPAIRED) === 'done') return;
-  window.localStorage.setItem(REPAIRED, 'done');
 
+  // Repair first, mark second. Marking first burns the one chance this gets:
+  // if anything writes the bad value back before the work happens -- another
+  // instance of the app sharing the profile, a crash between the two lines --
+  // the marker says "handled" forever and the install stays serialised with
+  // no way back. Observed exactly that: a profile went 1 -> 256 -> 1 with the
+  // marker set, and nothing could recover it.
   if (window.localStorage.getItem('netscli-max-concurrent-probes') === '1') {
     window.localStorage.setItem('netscli-max-concurrent-probes', '256');
   }
+  window.localStorage.setItem(REPAIRED, 'done');
 }
 
 function initialTrafficPrecision(): TrafficPrecision {

--- a/apps/netscli-gui/src/styles/shell/settings.css
+++ b/apps/netscli-gui/src/styles/shell/settings.css
@@ -1,36 +1,21 @@
 .settings-overlay {
-  /* The app draws its own chrome, and it is lopsided: 117px above the
-     workspace (title bar 34 + toolbar 45 + tab strip 38) against 27px of
-     status bar below. Centring on the viewport is therefore centred on the
-     window but sits 45px above the optical centre of the content, which is
-     what reads as "not quite centred".
-
-     Padding the overlay by each side's chrome makes the centring box the
-     content region exactly, while the backdrop still covers the whole
-     window. These numbers are measured, so `assertSettingsDialogCentring`
-     in the e2e suite re-measures them against the running app -- a silent
-     45px drift when someone changes the toolbar height is not something
-     anyone would notice for months. */
-  --chrome-above-workspace: 117px;
-  --chrome-below-workspace: 27px;
-
+  /* Centred on the viewport, which is what "centred" means to someone
+     looking at the window. An earlier version padded this by the chrome
+     above and below the workspace so the dialog sat at the centre of the
+     content region instead; that is defensible geometry and it read as
+     wrong, so the ruler loses to the eye here. */
   position: fixed;
   inset: 0;
   z-index: var(--z-modal);
   display: grid;
   place-items: center;
-  padding: var(--chrome-above-workspace) 18px var(--chrome-below-workspace);
+  padding: 18px;
   background: rgba(0, 0, 0, 0.34);
 }
 
 .settings-dialog {
   width: min(680px, calc(100vw - 32px));
-  /* Leaves 16px of breathing room inside the content region on a window too
-     short for the dialog's natural height. */
-  max-height: min(
-    540px,
-    calc(100vh - var(--chrome-above-workspace) - var(--chrome-below-workspace) - 16px)
-  );
+  max-height: min(540px, calc(100vh - 36px));
   display: flex;
   flex-direction: column;
   border: 1px solid var(--border-strong);


### PR DESCRIPTION
Two corrections from testing against a real install.

## Back to viewport centring

#248 centred the dialog on the workspace region, on the reasoning that the app draws 117px of chrome above the content and 27px below. That geometry is defensible and it read as wrong to the person looking at the window. The eye wins. The e2e assertion now pins the simple rule so nobody re-derives the clever one.

## The repair marked itself done before doing the work

Read out of a real profile's leveldb:

```
netscli-max-concurrent-probes = 1
netscli-max-concurrent-probes = 256     <- repair fired
netscli-max-concurrent-probes = 1       <- written back
netscli-prefs-repaired-zero-defaults = done
```

The repair ran and worked, something wrote the old value back, and because the marker was already set it can never run again — that profile is stuck at one probe at a time with no way back. Marking first burns the single chance the repair gets. Doing the work first means an interrupted repair is retried on the next launch.

This does not recover a profile already marked; that needs the value set once in Settings.

## Verified

137 unit tests, `tsc`, `eslint`, size guard clean. Full e2e run attached to the CI check.