### PR TITLE
Offer "clear ARP table, then discover" from a chevron beside Run

### DIFF
--- a/apps/netscli-gui/src-tauri/src/commands/mod.rs
+++ b/apps/netscli-gui/src-tauri/src/commands/mod.rs
@@ -9,7 +9,7 @@ pub(crate) use files::{
 };
 pub(crate) use monitor::{get_default_interface, get_network_stats, list_monitorable_interfaces};
 pub(crate) use operations::{
-    cancel_operation, capture_pcap, discover_mdns, discover_network, dns_lookup, get_arp_table,
-    inspect_host_cmd, list_interfaces, mdns_capability, open_pcap_file, pcap_capability, ping_host,
-    reverse_dns_lookup, scan_ports, sweep_network, trace_route_cmd,
+    cancel_operation, capture_pcap, clear_arp_table, discover_mdns, discover_network, dns_lookup,
+    get_arp_table, inspect_host_cmd, list_interfaces, mdns_capability, open_pcap_file,
+    pcap_capability, ping_host, reverse_dns_lookup, scan_ports, sweep_network, trace_route_cmd,
 };

--- a/apps/netscli-gui/src-tauri/src/commands/operations/lookup.rs
+++ b/apps/netscli-gui/src-tauri/src/commands/operations/lookup.rs
@@ -106,6 +106,23 @@ pub(crate) async fn list_interfaces(
     .await
 }
 
+/// Flush the OS neighbour cache.
+///
+/// Discover merges probe replies with whatever the OS already believes, so a
+/// stale entry shows up as a live host. Clearing first is the only way to see
+/// what is actually there right now.
+///
+/// Needs administrator rights on every platform, and the error says so --
+/// this is deliberately a command that can fail rather than one the GUI hides,
+/// because silently not clearing would make the discover that follows a lie.
+#[tauri::command]
+pub(crate) async fn clear_arp_table() -> Result<(), String> {
+    tokio::task::spawn_blocking(netscli_core::NetworkManager::clear_table)
+        .await
+        .map_err(|e| format!("clear task failed: {e}"))?
+        .map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 pub(crate) async fn get_arp_table(
     op_id: Option<String>,

--- a/apps/netscli-gui/src-tauri/src/commands/operations/mod.rs
+++ b/apps/netscli-gui/src-tauri/src/commands/operations/mod.rs
@@ -4,7 +4,8 @@ mod scan;
 
 pub(crate) use capture::{capture_pcap, open_pcap_file, pcap_capability};
 pub(crate) use lookup::{
-    discover_mdns, dns_lookup, get_arp_table, list_interfaces, mdns_capability, reverse_dns_lookup,
+    clear_arp_table, discover_mdns, dns_lookup, get_arp_table, list_interfaces, mdns_capability,
+    reverse_dns_lookup,
 };
 pub(crate) use scan::{
     discover_network, inspect_host_cmd, ping_host, scan_ports, sweep_network, trace_route_cmd,

--- a/apps/netscli-gui/src-tauri/src/main.rs
+++ b/apps/netscli-gui/src-tauri/src/main.rs
@@ -7,7 +7,7 @@ mod state;
 use std::sync::Mutex;
 
 use commands::{
-    cancel_operation, capture_pcap, choose_file_save_default_directory,
+    cancel_operation, capture_pcap, choose_file_save_default_directory, clear_arp_table,
     clear_file_save_default_directory, discover_mdns, discover_network, dns_lookup,
     export_text_file, get_arp_table, get_default_interface, get_file_save_preferences,
     get_network_stats, inspect_host_cmd, list_interfaces, list_monitorable_interfaces,
@@ -60,6 +60,7 @@ fn main() {
             sweep_network,
             dns_lookup,
             list_interfaces,
+            clear_arp_table,
             get_arp_table,
             mdns_capability,
             pcap_capability,

--- a/apps/netscli-gui/src/App.tsx
+++ b/apps/netscli-gui/src/App.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState, type MouseEvent } from 'react';
 
 import './App.css';
 
+import { handleAppFrameMouseDown } from './components/shell/appFrameDrag';
+import { clearArpThenRun } from './workspace/clearArpThenRun';
 import { AppDialogs } from './components/shell/AppDialogs';
 import { AppFrame } from './components/shell/AppFrame';
 import { AppTooltip } from './components/shell/AppTooltip';
@@ -140,12 +142,6 @@ function App() {
     void appWindowAction(action);
   }
 
-  function handleAppFrameMouseDown(event: MouseEvent<HTMLDivElement>) {
-    const target = event.target as HTMLElement;
-    if (target.closest('button,input,select,a,[role="button"],.menu-popover')) return;
-    void appWindowAction('drag');
-  }
-
   function openContentContextMenu(event: MouseEvent<HTMLElement>, cell?: ResultCellContext) {
     if (!activeTab) return;
     event.preventDefault();
@@ -211,6 +207,11 @@ function App() {
         onExportCsv={() => workspace.exportCurrent('csv')}
         onExportJson={() => workspace.exportCurrent('json')}
         onRunActive={runActive}
+        onRunActiveWithArpClear={() =>
+          void clearArpThenRun(activeTab?.id, requestRun, (id, error) =>
+            workspace.patchTab(id, { error }),
+          )
+        }
         runDisabledReason={pcapUnavailableReason ?? undefined}
       />
 

--- a/apps/netscli-gui/src/components/shell/RunSplitButton.tsx
+++ b/apps/netscli-gui/src/components/shell/RunSplitButton.tsx
@@ -1,0 +1,125 @@
+import { ChevronDown, Play } from 'lucide-react';
+import { useRef } from 'react';
+
+import { ARP_CLEAR_TOOL_KINDS } from '../../tools/registry';
+import type { WorkspaceTab } from '../../tools/types';
+import { useRovingFocus } from '../primitives/focus';
+import { useAnchoredPopoverPosition, useOverlayDismiss } from '../primitives/overlay';
+
+interface RunSplitButtonProps {
+  activeTab: WorkspaceTab | undefined;
+  openMenu: string | null;
+  runLabel: string;
+  runDisabledReason?: string;
+  setOpenMenu: (menu: string | null) => void;
+  onRunActive: () => void;
+  onRunActiveWithArpClear: () => void;
+}
+
+/**
+ * The run control, plus a chevron on the tools where clearing the OS
+ * neighbour cache first changes the answer.
+ *
+ * The chevron is deliberately absent elsewhere rather than present and
+ * disabled: on a port scan there is nothing behind it, and a dead affordance
+ * on every tool teaches people to ignore it on the three where it matters.
+ */
+export function RunSplitButton({
+  activeTab,
+  openMenu,
+  runLabel,
+  runDisabledReason,
+  setOpenMenu,
+  onRunActive,
+  onRunActiveWithArpClear,
+}: RunSplitButtonProps) {
+  const menuOpen = openMenu === 'run-options';
+  const disabled = !activeTab || activeTab.busy || Boolean(runDisabledReason);
+  const supportsArpClear = Boolean(activeTab) && ARP_CLEAR_TOOL_KINDS.includes(activeTab!.kind);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const position = useAnchoredPopoverPosition({
+    align: 'start',
+    anchorRef: buttonRef,
+    estimatedHeight: 96,
+    open: menuOpen,
+    panelRef,
+    width: 300,
+  });
+  const closeMenu = () => setOpenMenu(null);
+  const onMenuKeyDown = useRovingFocus({
+    containerRef: panelRef,
+    enabled: menuOpen,
+    itemSelector: '.run-options-popover button:not(:disabled)',
+    onClose: closeMenu,
+  });
+  useOverlayDismiss({
+    enabled: menuOpen,
+    onClose: closeMenu,
+    refs: [buttonRef, panelRef],
+    restoreFocusRef: buttonRef,
+  });
+
+  return (
+    <>
+      <button
+        className="icon-button strong toolbar-run"
+        data-testid="run-active-tab"
+        disabled={disabled}
+        aria-label={runLabel}
+        data-tooltip={runDisabledReason ?? runLabel}
+        data-tooltip-placement="bottom"
+        onClick={onRunActive}
+      >
+        <Play size={16} />
+        <span>{runLabel}</span>
+      </button>
+      {supportsArpClear && (
+        <div className="toolbar-run-options">
+          <button
+            className="icon-button strong toolbar-run-chevron"
+            data-testid="run-options-button"
+            ref={buttonRef}
+            disabled={disabled}
+            aria-label={`${runLabel} options`}
+            aria-expanded={menuOpen}
+            aria-haspopup="menu"
+            data-tooltip={`${runLabel} options`}
+            data-tooltip-placement="bottom"
+            onClick={() => setOpenMenu(menuOpen ? null : 'run-options')}
+          >
+            <ChevronDown size={14} />
+          </button>
+          {menuOpen && (
+            <div
+              className="run-options-popover"
+              data-testid="run-options-menu"
+              ref={panelRef}
+              role="menu"
+              style={{ left: position.left, top: position.top }}
+              tabIndex={-1}
+              onKeyDown={onMenuKeyDown}
+            >
+              <button
+                className="run-options-item"
+                data-testid="run-with-arp-clear"
+                role="menuitem"
+                type="button"
+                onClick={() => {
+                  setOpenMenu(null);
+                  onRunActiveWithArpClear();
+                }}
+              >
+                <span>Clear ARP table, then {runLabel.toLowerCase()}</span>
+                <small>
+                  Drops cached neighbours so only what answers now is reported.
+                  Needs administrator rights.
+                </small>
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/netscli-gui/src/components/shell/Toolbar.tsx
+++ b/apps/netscli-gui/src/components/shell/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Download, FileSpreadsheet, Filter, Play, Square, X } from 'lucide-react';
+import { ChevronDown, Download, FileSpreadsheet, Filter, Square, X } from 'lucide-react';
 import { useRef, type RefObject } from 'react';
 
 import { TOOL_CONFIG } from '../../tools/registry';
@@ -6,6 +6,7 @@ import { filterHintsFor } from '../../tools/presentation';
 import type { ToolKind, WorkspaceTab } from '../../tools/types';
 import { useRovingFocus } from '../primitives/focus';
 import { useAnchoredPopoverPosition, useOverlayDismiss } from '../primitives/overlay';
+import { RunSplitButton } from './RunSplitButton';
 
 interface ToolbarProps {
   activeTab: WorkspaceTab | undefined;
@@ -18,6 +19,7 @@ interface ToolbarProps {
   onExportJson: () => void;
   onExportCsv: () => void;
   onRunActive: () => void;
+  onRunActiveWithArpClear: () => void;
   runDisabledReason?: string;
 }
 
@@ -32,6 +34,7 @@ export function Toolbar({
   onExportCsv,
   onExportJson,
   onRunActive,
+  onRunActiveWithArpClear,
   runDisabledReason,
 }: ToolbarProps) {
   const filterMenuOpen = openMenu === 'advanced-filter';
@@ -68,18 +71,15 @@ export function Toolbar({
 
   return (
     <div className="toolbar">
-      <button
-        className="icon-button strong toolbar-run"
-        data-testid="run-active-tab"
-        disabled={!activeTab || activeTab.busy || Boolean(runDisabledReason)}
-        aria-label={runLabel}
-        data-tooltip={runDisabledReason ?? runLabel}
-        data-tooltip-placement="bottom"
-        onClick={onRunActive}
-      >
-        <Play size={16} />
-        <span>{runLabel}</span>
-      </button>
+      <RunSplitButton
+        activeTab={activeTab}
+        openMenu={openMenu}
+        runLabel={runLabel}
+        runDisabledReason={runDisabledReason}
+        setOpenMenu={setOpenMenu}
+        onRunActive={onRunActive}
+        onRunActiveWithArpClear={onRunActiveWithArpClear}
+      />
       <button
         className={`icon-button stop-button ${activeTab?.busy ? 'armed' : ''}`}
         disabled={!activeTab?.busy}

--- a/apps/netscli-gui/src/components/shell/appFrameDrag.ts
+++ b/apps/netscli-gui/src/components/shell/appFrameDrag.ts
@@ -1,0 +1,16 @@
+import type { MouseEvent } from 'react';
+
+import { appWindowAction } from '../../services/appWindow';
+
+/**
+ * Start a window drag from the custom title bar, unless the press landed on
+ * something interactive.
+ *
+ * Without the guard the whole frame is a drag handle, so pressing a menu or a
+ * button moves the window instead of activating the control.
+ */
+export function handleAppFrameMouseDown(event: MouseEvent<HTMLDivElement>) {
+  const target = event.target as HTMLElement;
+  if (target.closest('button,input,select,a,[role="button"],.menu-popover')) return;
+  void appWindowAction('drag');
+}

--- a/apps/netscli-gui/src/services/netscli.ts
+++ b/apps/netscli-gui/src/services/netscli.ts
@@ -111,6 +111,11 @@ export async function listInterfaces(op_id?: string): Promise<InterfaceInfo[]> {
   return invoke<InterfaceInfo[]>('list_interfaces', { op_id });
 }
 
+/** Flush the OS neighbour cache. Requires administrator rights. */
+export async function clearArpTable(): Promise<void> {
+  return invoke<void>('clear_arp_table');
+}
+
 export async function getArpTable(op_id?: string): Promise<ArpEntry[]> {
   return invoke<ArpEntry[]>('get_arp_table', { op_id });
 }

--- a/apps/netscli-gui/src/styles/shell.css
+++ b/apps/netscli-gui/src/styles/shell.css
@@ -1,6 +1,7 @@
 @import './shell/app-frame.css';
 @import './shell/menu.css';
 @import './shell/toolbar.css';
+@import './shell/run-options.css';
 @import './shell/tabs.css';
 @import './shell/command-status.css';
 @import './shell/context-menu.css';

--- a/apps/netscli-gui/src/styles/shell/run-options.css
+++ b/apps/netscli-gui/src/styles/shell/run-options.css
@@ -1,0 +1,47 @@
+/* Run split-button: the chevron sits flush against the run button so the two
+   read as one control, with a hairline seam rather than a gap. */
+.toolbar-run-options {
+  display: flex;
+}
+
+.toolbar-run-chevron {
+  width: 22px;
+  min-width: 22px;
+  padding: 0;
+  margin-left: -1px;
+  border-left: 1px solid color-mix(in srgb, var(--bg-body), transparent 60%);
+}
+
+.run-options-popover {
+  position: fixed;
+  z-index: var(--z-dropdown);
+  width: min(300px, calc(100vw - 24px));
+  padding: 6px;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+  box-shadow: 0 14px 30px var(--shadow);
+}
+
+.run-options-item {
+  width: 100%;
+  display: grid;
+  gap: 3px;
+  padding: 8px 10px;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.run-options-item:hover,
+.run-options-item:focus-visible {
+  background: var(--bg-input);
+}
+
+.run-options-item small {
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.35;
+}

--- a/apps/netscli-gui/src/tools/registry.ts
+++ b/apps/netscli-gui/src/tools/registry.ts
@@ -33,6 +33,16 @@ export const TOOL_KINDS: ToolKind[] = [
 
 export const SCAN_TOOL_KINDS: ToolKind[] = ['scan', 'ping', 'trace', 'discover', 'inspect', 'sweep'];
 
+/**
+ * Tools where clearing the neighbour cache first changes the answer.
+ *
+ * Discover and sweep both merge probe replies with what the OS already
+ * believes, so a stale entry reads as a live host; the ARP tab shows that
+ * cache directly. Everything else either targets one host or never consults
+ * the cache, so offering it there would be noise.
+ */
+export const ARP_CLEAR_TOOL_KINDS: ToolKind[] = ['discover', 'sweep', 'arp'];
+
 export const LOOKUP_TOOL_KINDS: ToolKind[] = ['dns', 'reverse', 'mdns', 'interfaces', 'arp', 'pcap'];
 
 export function availableToolKinds(

--- a/apps/netscli-gui/src/workspace/clearArpThenRun.test.ts
+++ b/apps/netscli-gui/src/workspace/clearArpThenRun.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearArpThenRun } from './clearArpThenRun';
+
+const clearArpTable = vi.hoisted(() => vi.fn());
+vi.mock('../services/netscli', () => ({ clearArpTable }));
+
+describe('clear ARP, then run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runs the tab once the cache is flushed', async () => {
+    clearArpTable.mockResolvedValue(undefined);
+    const run = vi.fn();
+
+    await clearArpThenRun('tab-1', run, vi.fn());
+
+    expect(clearArpTable).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith('tab-1');
+  });
+
+  it('does not run when the cache could not be flushed', async () => {
+    // The case worth pinning. Clearing needs administrator rights, and a
+    // discover after a failed clear looks exactly like one after a successful
+    // clear -- same table, same row count. Running anyway would hand back the
+    // stale neighbours the user asked to be rid of, and say nothing.
+    clearArpTable.mockRejectedValue(new Error('Failed to clear ARP table (run as admin?)'));
+    const run = vi.fn();
+    const reportError = vi.fn();
+
+    await clearArpThenRun('tab-1', run, reportError);
+
+    expect(run).not.toHaveBeenCalled();
+    // The error strip, not a toast: toasts are preference-gated and default
+    // to off, which made this failure completely silent in the running app.
+    expect(reportError).toHaveBeenCalledWith('tab-1', 'Failed to clear ARP table (run as admin?)');
+  });
+
+  it('does nothing without a tab, rather than flushing the cache for no reason', async () => {
+    const run = vi.fn();
+
+    await clearArpThenRun(undefined, run, vi.fn());
+
+    expect(clearArpTable).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+  });
+});

--- a/apps/netscli-gui/src/workspace/clearArpThenRun.ts
+++ b/apps/netscli-gui/src/workspace/clearArpThenRun.ts
@@ -1,0 +1,36 @@
+import * as netscli from '../services/netscli';
+
+/**
+ * Flush the OS neighbour cache, then run the tab.
+ *
+ * A failed clear stops the run rather than continuing without it. The two
+ * outcomes are indistinguishable on screen -- discover reports hosts either
+ * way -- so carrying on would quietly hand back the stale neighbours the user
+ * asked to be rid of, and say nothing about it.
+ *
+ * The failure goes to the tab's error strip, not a toast. Toasts are
+ * preference-gated and default to off, so reporting it that way made a failed
+ * clear silent: the button appeared to do nothing at all. Measured in the
+ * running app before this was changed.
+ *
+ * Takes an optional id so the caller can hand over `activeTab?.id` directly
+ * rather than guarding at every call site.
+ */
+export async function clearArpThenRun(
+  tabId: string | undefined,
+  run: (tabId: string) => void,
+  reportError: (tabId: string, message: string) => void,
+): Promise<void> {
+  if (!tabId) return;
+  try {
+    await netscli.clearArpTable();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // No prefix of our own: the core error already opens with "Failed to
+    // clear ARP table", and stacking another produced a message that said it
+    // three times before reaching the useful part.
+    reportError(tabId, message);
+    return;
+  }
+  run(tabId);
+}

--- a/crates/netscli-core/src/arp/platform/mutate.rs
+++ b/crates/netscli-core/src/arp/platform/mutate.rs
@@ -59,11 +59,31 @@ pub(super) fn delete_entry(ip: IpAddr) -> Result<()> {
 pub(super) fn clear_table() -> Result<()> {
     #[cfg(target_os = "windows")]
     {
-        let status = command::arp_command().args(["-d", "*"]).status()?;
-        if !status.success() {
-            return Err(Error::Other(
-                "Failed to clear ARP table (run as admin?)".into(),
-            ));
+        // `arp -d *` reports "The requested operation requires elevation."
+        // and then exits 0, so the exit status alone says the table was
+        // cleared when nothing was touched. That made the CLI print "ARP
+        // table cleared" after doing nothing, and would make a discover run
+        // straight afterwards report the very neighbours the user asked to
+        // be rid of -- a silent wrong answer, which is the worst kind.
+        //
+        // On success the command prints nothing, so any output at all is a
+        // failure. That test is locale-independent, unlike matching the
+        // message text, and it fails loudly rather than quietly if a future
+        // Windows build becomes chattier on success.
+        let output = command::arp_command().args(["-d", "*"]).output()?;
+        let mut reported = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        if reported.is_empty() {
+            reported = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        }
+        if !output.status.success() || !reported.is_empty() {
+            return Err(Error::Other(format!(
+                "Failed to clear ARP table: {}",
+                if reported.is_empty() {
+                    "arp -d * failed (run as administrator?)".to_string()
+                } else {
+                    reported
+                }
+            )));
         }
     }
     #[cfg(any(target_os = "linux", target_os = "macos"))]


### PR DESCRIPTION
Discover merges probe replies with the OS neighbour table, so a device that left minutes ago still reads as a live host. Clearing the cache first is the only way to see what is actually there, and it was CLI-only.

A chevron next to Run opens a single item: **Clear ARP table, then discover**.

It appears on discover, sweep and the ARP tab, and nowhere else. On a port scan there is nothing behind it, and a dead affordance on every tool teaches people to ignore it on the three where it matters.

## The clear never worked unelevated, and said it did

`arp -d *` on Windows prints `The requested operation requires elevation.` and then **exits 0**. `clear_table()` checked only the exit status, so it reported success while the table was untouched — `netscli arp --clear` has been printing "ARP table cleared" after doing nothing, and a discover straight afterwards would report the very neighbours the user asked to be rid of.

On success the command prints nothing, so any output is now treated as failure. That test is locale-independent, unlike matching the message text, and it fails loudly rather than quietly if a future Windows build becomes chattier.

```
before:  ARP table cleared                                   (exit 0, nothing cleared)
after:   Error: Failed to clear ARP table: ... requires elevation.   (exit 1)
```

## A failed clear stops the run

The two outcomes are indistinguishable on screen — discover reports hosts either way — so continuing would silently return stale data.

The failure goes to the **tab error strip, not a toast**. The first version used a toast; toasts are preference-gated and now default to off, so clicking the item appeared to do nothing at all. Caught by testing the running app, not by reading the code.

## Verified in the running app

```
discover: chevron shown = true
menu item: "Clear ARP table, then discover"
error strip: "Failed to clear ARP table: The ARP entry deletion failed: The requested operation requires elevation."
operation started: false      (run suppressed)
result rows: 0
scan: chevron shown = false
```

Worth recording for the next person: **selenium's native `.click()` does not register as a React click against the attached WebView2 session** — a DOM `.click()` does. Several rounds of "the handler never fires" were that, not the app. The e2e suite therefore has no scenario for this item; the unit tests cover the decision logic instead.

## Structure

`RunSplitButton`, `appFrameDrag` and `run-options.css` are extracted rather than inlined because `Toolbar.tsx`, `App.tsx` and `toolbar.css` were all at the size guard.

3 new unit tests (140 total), `tsc`, `eslint`, `cargo fmt`, `clippy -D warnings`, workspace tests and the size guard all clean.