### PR TITLE
Let the run-options menu survive its own click

### DIFF
--- a/apps/netscli-gui/src/components/shell/RunSplitButton.tsx
+++ b/apps/netscli-gui/src/components/shell/RunSplitButton.tsx
@@ -75,7 +75,7 @@ export function RunSplitButton({
         <span>{runLabel}</span>
       </button>
       {supportsArpClear && (
-        <div className="toolbar-run-options">
+        <div className="toolbar-run-options" data-popover="run-options">
           <button
             className="icon-button strong toolbar-run-chevron"
             data-testid="run-options-button"
@@ -93,6 +93,7 @@ export function RunSplitButton({
           {menuOpen && (
             <div
               className="run-options-popover"
+              data-popover="run-options"
               data-testid="run-options-menu"
               ref={panelRef}
               role="menu"

--- a/apps/netscli-gui/src/hooks/usePopoverDismissal.test.tsx
+++ b/apps/netscli-gui/src/hooks/usePopoverDismissal.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+//
+// A popover that this hook does not recognise is not merely left unprotected.
+// The listeners run in the CAPTURE phase on pointerdown, mousedown and click,
+// so an unrecognised popover is torn down before its own item's onClick can
+// fire: the item does nothing, throws nothing, and logs nothing. The
+// run-options menu shipped in exactly that state and read as a dead button.
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { usePopoverDismissal } from './usePopoverDismissal';
+
+function mount(openMenu: string | null, setOpenMenu: (menu: string | null) => void) {
+  return renderHook(() =>
+    usePopoverDismissal({
+      contentContextMenu: null,
+      setContentContextMenu: () => undefined,
+      openMenu,
+      setOpenMenu,
+    }),
+  );
+}
+
+function pointerDownOn(element: Element) {
+  element.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+}
+
+describe('popover dismissal', () => {
+  let setOpenMenu: Mock<(menu: string | null) => void>;
+
+  beforeEach(() => {
+    setOpenMenu = vi.fn();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('leaves a popover alone when the press lands inside it', () => {
+    document.body.innerHTML =
+      '<div data-popover="run-options"><button id="item">Clear ARP table</button></div>';
+    mount('run-options', setOpenMenu);
+
+    pointerDownOn(document.getElementById('item')!);
+
+    // Not closing here is what lets the item's own click handler run at all.
+    expect(setOpenMenu).not.toHaveBeenCalled();
+  });
+
+  it('closes it when the press lands outside', () => {
+    document.body.innerHTML =
+      '<div data-popover="run-options"></div><div id="elsewhere"></div>';
+    mount('run-options', setOpenMenu);
+
+    pointerDownOn(document.getElementById('elsewhere')!);
+
+    expect(setOpenMenu).toHaveBeenCalledWith(null);
+  });
+
+  it('only protects the popover that is actually open', () => {
+    // A stale marker from another menu must not keep this one alive.
+    document.body.innerHTML = '<div data-popover="advanced-filter" id="other"></div>';
+    mount('run-options', setOpenMenu);
+
+    pointerDownOn(document.getElementById('other')!);
+
+    expect(setOpenMenu).toHaveBeenCalledWith(null);
+  });
+
+  it('still protects the menus that predate the data attribute', () => {
+    document.body.innerHTML = '<div class="menu-popover"><button id="entry">Open</button></div>';
+    mount('File', setOpenMenu);
+
+    pointerDownOn(document.getElementById('entry')!);
+
+    expect(setOpenMenu).not.toHaveBeenCalled();
+  });
+});

--- a/apps/netscli-gui/src/hooks/usePopoverDismissal.ts
+++ b/apps/netscli-gui/src/hooks/usePopoverDismissal.ts
@@ -45,7 +45,20 @@ export function usePopoverDismissal({
 
     function isProtectedPopoverTarget(target: EventTarget | null): boolean {
       if (!(target instanceof Element)) return false;
-      const protectedSelectors = ['.menu-root', '.menu-popover'];
+      // Anything marked as belonging to the open popover protects itself.
+      // The per-menu lists below predate this and still work, but a new
+      // popover that forgets to register here is not merely unprotected --
+      // these listeners run in the capture phase on pointerdown, mousedown
+      // AND click, so the menu is torn down before its own item's onClick
+      // can fire, and the item silently does nothing. That failure looks
+      // like a dead button with no error anywhere, which cost hours to
+      // track down for the run-options menu. `data-popover` lets a popover
+      // opt in where it is declared, instead of in a list it cannot see.
+      const protectedSelectors = [
+        `[data-popover="${openMenu}"]`,
+        '.menu-root',
+        '.menu-popover',
+      ];
       if (openMenu === 'new-tab') {
         protectedSelectors.push('.add-tab-group', '.tab-tool-popover');
       }


### PR DESCRIPTION
Clicking **"Clear ARP table, then discover"** did nothing at all — reported from the running app.

## Cause

`usePopoverDismissal` keeps an allowlist of protected selectors per open menu, and listens in the **capture phase** on `pointerdown`, `mousedown` *and* `click`:

| open menu | protected |
| --- | --- |
| always | `.menu-root`, `.menu-popover` |
| `new-tab` | `.add-tab-group`, `.tab-tool-popover` |
| `advanced-filter` | `.filter-control`, `.filter-advanced-popover` |

`run-options` was not in that list. So the first event of a real click tore the popover down before the item's own `onClick` could run: no action, no error, nothing in the console.

An unrecognised popover is therefore not merely unprotected — it is unusable, and it fails silently.

## Why I missed it

My verification used a DOM `.click()`, which dispatches only a click event on an element that still exists. It worked, so I concluded the native-click failure was a harness limitation and shipped. It was the bug, and the report was right.

## Fix

Register the menu, and add a `data-popover="<menu key>"` attribute to the allowlist so a popover can opt in **where it is declared** rather than in a list it cannot see. The existing per-menu entries are untouched.

## Verified with a native click, not a DOM click

```
menu still open after click: false
error strip: "Failed to clear ARP table: ... requires elevation."
operation running: false      (run suppressed, as intended)
scan tab: chevron present = false
```

4 new tests (144 total). The first fails against the previous behaviour; the last pins that the pre-existing `.menu-popover` protection still works. `tsc`, `eslint`, size guard clean.