### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,68 @@ further copies in `package.json` and `tauri.conf.json`. See
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-08-24
+
+A bug-fix release. Everything here was found by using the desktop app on a
+real network rather than by reading the code, and three of the fixes are for
+faults that reported success while doing nothing.
+
+### Fixed
+
+- **Pinging your own machine no longer reports 100% loss.** On Windows,
+  `ping 127.0.0.1` — and the machine's own LAN address — timed out while the
+  system `ping` answered immediately. Two causes stacked up: raw ICMP sockets
+  need administrator rights, so an ordinary run fell back to TCP probes on
+  ports 80/443/22 and concluded a host was down when nothing answered; and a
+  Windows raw socket does not observe traffic to an address the host owns.
+  Windows now sends echoes through the IP Helper API, which needs no
+  privileges and reaches local addresses. Discover and sweep both start from
+  a ping sweep, so both returned nothing for any range covering this host.
+- **IPv6 hosts can be pinged.** `ping ::1` reported total loss because IPv6
+  had no ICMP path at all and fell through to the same TCP probe. Windows now
+  uses `Icmp6SendEcho2`.
+- **A fresh install no longer runs one probe at a time.** `Number(null)` is
+  `0` and passes an `isFinite` check, so reading an unset preference produced
+  a stored zero rather than the default: max concurrent probes came out as 1
+  instead of 256, serialising every scan, discover and sweep. Traffic
+  precision had the same fault, showing no decimals. Profiles already left at
+  1 by the broken build are repaired once on upgrade.
+- **Discover reports devices the OS already knows about.** Results now merge
+  probe replies with the neighbour table, so a device that answers ARP but
+  not ICMP is no longer missing. Each host records whether it was found by
+  probe or by neighbour, since a stale neighbour entry can outlive the device.
+- **`netscli arp --clear` no longer claims to have cleared the table when it
+  has not.** `arp -d *` on Windows prints "The requested operation requires
+  elevation" and then exits 0, so checking the exit status alone reported
+  success while nothing was touched. It now fails, with the reason, and a
+  non-zero exit.
+- **The settings dialog is centred on the window**, and its Max Concurrent
+  Probes control is themed rather than rendering in the WebView's default
+  3D-bevelled controls with duplicate spin arrows.
+- **Menu items in the run options popover respond to clicks.** An
+  unrecognised popover was torn down by the global dismissal handler before
+  its own item could fire, so the item did nothing, threw nothing and logged
+  nothing.
+
+### Added
+
+- **Clear ARP table, then discover.** A chevron beside Run offers a
+  cache-flushing variant on discover, sweep and the ARP tab — the tools where
+  a stale neighbour entry changes the answer. Clearing needs administrator
+  rights; when it fails the run is suppressed rather than quietly returning
+  the stale entries it was meant to drop.
+
+### Changed
+
+- **The app opens on Discover** rather than Scan. The first useful question
+  on an unfamiliar network is what is on it, and a scan needs a host you do
+  not have yet.
+- **Completion notifications only appear for tabs you are not looking at.**
+  On the visible tab the result arriving in the table already says the run
+  finished. Failures still report unconditionally.
+- Dependency updates: `pcap` 2.4 → 2.5, `astro`, `lucide-react`, `vitest`,
+  `@axe-core/cli`, and the vite/rollup group.
+
 ## [0.3.0] — 2026-08-20
 
 ### Added
@@ -587,7 +649,8 @@ backed by the same core library.
 - Desktop app needs the WebView2 runtime on Windows. Most Windows
   10/11 systems have it preinstalled.
 
-[Unreleased]: https://github.com/fstubner/netscli/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/fstubner/netscli/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/fstubner/netscli/releases/tag/v0.3.1
 [0.3.0]: https://github.com/fstubner/netscli/releases/tag/v0.3.0
 [0.2.6]: https://github.com/fstubner/netscli/releases/tag/v0.2.6
 [0.2.5]: https://github.com/fstubner/netscli/releases/tag/v0.2.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "netscli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-gui"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dirs",
  "ipnet",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "netscli-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "ipnet",

--- a/apps/netscli-cli/Cargo.toml
+++ b/apps/netscli-cli/Cargo.toml
@@ -3,7 +3,7 @@
 # consistency, but the published crate is just `netscli` so users can
 # `cargo install netscli` (matching the produced binary name).
 name = "netscli"
-version = "0.3.0"
+version = "0.3.1"
 description = "Interactive TUI and CLI for network discovery, scanning, and diagnostics"
 authors.workspace = true
 license.workspace = true
@@ -25,8 +25,8 @@ clap_mangen = "0.3"
 ratatui = "0.30"
 crossterm = "0.29"
 ratatui-textarea = "0.9"
-netscli-core = { path = "../../crates/netscli-core", version = "0.3.0", default-features = false, features = ["db", "mdns"] }
-netscli-mcp = { path = "../../crates/netscli-mcp", version = "0.3.0", features = ["mdns"] }
+netscli-core = { path = "../../crates/netscli-core", version = "0.3.1", default-features = false, features = ["db", "mdns"] }
+netscli-mcp = { path = "../../crates/netscli-mcp", version = "0.3.1", features = ["mdns"] }
 serde_yaml_ng = "0.10"
 dirs = "6.0"
 mac_address = "1.1.8"

--- a/apps/netscli-gui/package.json
+++ b/apps/netscli-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netscli-gui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "NetsCLI GUI - Modern network scanner with beautiful desktop interface",
   "private": true,
   "type": "module",

--- a/apps/netscli-gui/src-tauri/Cargo.toml
+++ b/apps/netscli-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-gui"
-version = "0.3.0"
+version = "0.3.1"
 description = "Tauri 2.0 desktop GUI for network discovery, scanning, and diagnostics"
 authors.workspace = true
 license.workspace = true

--- a/apps/netscli-gui/src-tauri/tauri.conf.json
+++ b/apps/netscli-gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "NetsCLI",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.netscli.gui",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/crates/netscli-core/Cargo.toml
+++ b/crates/netscli-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-core"
-version = "0.3.0"
+version = "0.3.1"
 description = "Core networking library: discovery, scanning, DNS, ARP, PCAP, and OUI resolution"
 authors.workspace = true
 license.workspace = true

--- a/crates/netscli-mcp/Cargo.toml
+++ b/crates/netscli-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netscli-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Model Context Protocol (MCP) server exposing netscli-core tools to LLM agents"
 authors.workspace = true
 license.workspace = true
@@ -17,7 +17,7 @@ thiserror.workspace = true
 ipnet.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-netscli-core = { path = "../netscli-core", version = "0.3.0", default-features = false }
+netscli-core = { path = "../netscli-core", version = "0.3.1", default-features = false }
 
 [features]
 default = ["mdns"]


### PR DESCRIPTION
`v0.3.0` is tagged at `21d58d4`, **21 commits behind `main`**. Everything since is a bug fix found by using the desktop app on a real network. Releasing the tag as it stands would ship a build where pinging your own machine reports total loss, a fresh install runs one probe at a time, and `arp --clear` claims to have cleared a table it never touched.

## Why 0.3.1 rather than moving the tag

`v0.3.0` has been public for four days. Moving a published tag is the kind of thing that bites whoever already fetched it, and the draft release can simply be retargeted.

## What's in it

Three of the seven fixes are for faults that **reported success while doing nothing** — the category that survives longest because nothing looks wrong:

| | |
| --- | --- |
| `ping 127.0.0.1` / own LAN address | 100% loss → works |
| `ping ::1` | 100% loss → works |
| Max concurrent probes, fresh install | 1 → 256 (every scan was serialised) |
| `netscli arp --clear` unelevated | "ARP table cleared", exit 0 → fails with the reason, exit 1 |
| Discover | now includes hosts only the neighbour table knows |
| Settings dialog | centred, number field themed |
| Run-options menu items | were dismissed before their own click could fire |

Plus: the app opens on Discover, completion toasts only fire for tabs you are not looking at, a "Clear ARP table, then discover" action, and six dependency updates.

## Version surfaces

Bumped per `docs/PUBLISHING.md` — the four crate manifests including their inter-workspace dep specs, `package.json`, `tauri.conf.json`, and `Cargo.lock` via `cargo update -w`. That document's verification command prints `0.3.1` and nothing else.

## Verified

Full workspace tests, 144 GUI unit tests, `tsc -b` clean. The GUI e2e suite passes end to end.

## Not done here

Tagging and publishing are deliberately left out — crates.io is irreversible. After this merges: `git tag v0.3.1 && git push origin v0.3.1`, retarget the draft release, then publish.