### PR TITLE
Keep the site's promises, and let the contrast gate see it

### DIFF
--- a/site/design-tokens.json
+++ b/site/design-tokens.json
@@ -1,0 +1,16 @@
+{
+  "dark": {
+    "surface-base": "#111111",
+    "text-main": "#c2cad8",
+    "text-muted": "#8c95a6",
+    "text-strong": "#f4f4f4",
+    "accent": "#22c55e"
+  },
+  "light": {
+    "surface-base": "#fbfbfb",
+    "text-main": "#44516a",
+    "text-muted": "#667387",
+    "text-strong": "#111827",
+    "accent": "#146b2e"
+  }
+}

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -117,6 +117,61 @@ brew upgrade netscli
 
 For direct release artifacts, download the [latest GitHub release](https://github.com/fstubner/netscli/releases/latest) and replace the previous install with the matching package for your platform.
 
+## Verifying a download
+
+Every CLI and desktop release asset is checksummed and signed, and both can be
+checked before you run anything.
+
+### Checksums
+
+Each asset ships a `.sha256` sidecar next to it on the release page. The
+install scripts fetch and check it for you, and refuse to install if it is
+missing — a failed checksum request is not treated as permission to skip
+verification. To check a manual download yourself:
+
+```bash
+# Linux / macOS
+curl -fsSLO https://github.com/fstubner/netscli/releases/latest/download/netscli-linux-x86_64
+curl -fsSLO https://github.com/fstubner/netscli/releases/latest/download/netscli-linux-x86_64.sha256
+sha256sum -c netscli-linux-x86_64.sha256
+```
+
+```powershell
+# Windows
+(Get-FileHash -Algorithm SHA256 .\netscli-windows-x86_64.exe).Hash.ToLower()
+# compare against the contents of netscli-windows-x86_64.exe.sha256
+```
+
+### Signatures
+
+A checksum only proves the file matches its own sidecar, and both come from
+the same place. The signature is what ties the asset to the workflow run that
+built it.
+
+Every asset is signed keylessly with [Sigstore
+cosign](https://docs.sigstore.dev/cosign/overview/) in CI, using the GitHub
+Actions OIDC identity — no key management, and the signature is bound to the
+exact run. Each asset ships a `.sig` and a `.pem` beside it:
+
+```bash
+cosign verify-blob \
+  --signature netscli-linux-x86_64.sig \
+  --certificate netscli-linux-x86_64.pem \
+  --certificate-identity-regexp 'https://github.com/fstubner/netscli/.github/workflows/release\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  netscli-linux-x86_64
+```
+
+Substitute the asset name you downloaded — the same command works for the
+desktop `.msi`, `.dmg`, `.deb` and `.AppImage`. It needs the [cosign
+CLI](https://docs.sigstore.dev/cosign/system_config/installation/). A pass
+confirms the asset was built and signed by this repository's release workflow
+and has not been altered since.
+
+This is separate from platform code signing, which the installers do not yet
+have — see the Windows and macOS sections above for what your OS will say on
+first run.
+
 ## Packet capture
 
 **No install on this page includes packet capture.** It is a compile-time feature, and every published build — the desktop installers, the standard CLI release assets, and `cargo install netscli` — is built without it. That keeps the default install free of any libpcap/Npcap dependency and avoids redistributing Npcap.

--- a/site/src/data/site-content/install.ts
+++ b/site/src/data/site-content/install.ts
@@ -176,5 +176,9 @@ export const tryCommands: TryCommand[] = [
   },
 ];
 
+// The link lands on the section that actually carries the commands. It used
+// to point at the top of the install guide, which had no verification steps
+// anywhere on it -- the promise was real (assets are signed) but nobody
+// following it could act on it.
 export const installBinariesNote =
-  'Every asset is checksummed and signed with <a href="https://docs.sigstore.dev/cosign/overview/">Sigstore cosign</a> — see <a href="/docs/install/">the install guide</a> for verification steps, standalone CLI binaries, and packet-capture builds.';
+  'Every asset is checksummed and signed with <a href="https://docs.sigstore.dev/cosign/overview/">Sigstore cosign</a> — see <a href="/docs/install/#verifying-a-download">how to verify a download</a>, plus standalone CLI binaries and packet-capture builds.';

--- a/site/src/scripts/changelog-page.ts
+++ b/site/src/scripts/changelog-page.ts
@@ -33,10 +33,21 @@ export function initChangelogPage(
     })
     .then((releases: ChangelogRelease[]) => {
       const remoteTags = new Set(releases.map((release) => normalizeTag(release.tag_name || release.name)));
-      // A changelog entry with no release behind it stays unlinked.
+      // A changelog entry with no release behind it stays unlinked, and
+      // loses its date. `published_at` is built from the date on the
+      // CHANGELOG.md heading, which is written when the entry is drafted --
+      // so an entry GitHub has just told us was never released still carried
+      // a publication date, and the card read "v0.3.1 · Not yet released ·
+      // 24 Aug 2026". The label and the date contradicted each other, and
+      // the date was the half that looked like a fact.
       const localOnlyReleases = fallbackReleases
         .filter((release) => !remoteTags.has(normalizeTag(release.tag_name || release.name)))
-        .map((release) => ({ ...release, unreleased: true, confirmedUnreleased: true }));
+        .map((release) => ({
+          ...release,
+          published_at: undefined,
+          unreleased: true,
+          confirmedUnreleased: true,
+        }));
       renderReleaseList([...localOnlyReleases, ...releases], repo, fallbackByTag, releaseSummaries);
     })
     .catch(() => {

--- a/site/src/scripts/changelog/release-list.ts
+++ b/site/src/scripts/changelog/release-list.ts
@@ -17,7 +17,16 @@ function mergeRelease(
     tag_name: release.tag_name || fallback?.tag_name || tag,
     name: release.name || fallback?.name || tag,
     html_url: release.html_url || fallback?.html_url,
-    published_at: release.published_at || fallback?.published_at,
+    // An unreleased entry has no publication date, and must not borrow the
+    // fallback's. `published_at` there is built from the date on the
+    // CHANGELOG.md heading -- written when the entry is drafted, not when a
+    // tag is pushed -- so this line used to resurrect a date for the very
+    // entry GitHub had just confirmed was never released. The card read
+    // "Not yet released" beside "24 Aug 2026", and the date is the half that
+    // reads as a fact.
+    published_at: release.unreleased
+      ? undefined
+      : release.published_at || fallback?.published_at,
     body: fallback?.body || release.body || '',
     summary: releaseSummaries[tag] || fallback?.summary || release.summary,
   };

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -8,6 +8,19 @@
  *
  * Registered first in astro.config.mjs's customCss and imported at the top of
  * global.css, so both stacks read the same declaration.
+ *
+ * Changing a colour here means updating site/design-tokens.json to match.
+ * That file is what the frontend contrast gate reads, and until it existed
+ * the gate ran at the repository root, found the *desktop app's* tokens, and
+ * reported a pass that said nothing about this site. Its values are measured
+ * from a served build rather than copied from here, because several are
+ * reached through --sl-color-text and other indirections: the declared value
+ * and the painted one are not always the same. Re-measure, then update.
+ *
+ * Measured ratios against the page background: dark 11.45 / 6.26 / 17.17 /
+ * 8.29, light 7.71 / 4.65 / 17.14 / 6.40. The light muted grey has the least
+ * headroom at 4.65:1 -- see the note beside --sl-color-gray-3 in
+ * starlight/01-tokens-and-header.css before lightening any small grey text.
  */
 :root {
   /* Total height of the top bar including its bottom border, on both the


### PR DESCRIPTION
Three accuracy findings from the assessment run before tagging 0.3.1.

### The install guide did not contain the steps the landing page promised

The landing page says:

> Every asset is checksummed and signed with **Sigstore cosign** — see the
> install guide for verification steps

and `site/src/content/docs/docs/install.md` had **zero** occurrences of
cosign, sigstore, `verify-blob`, sha256 or checksum. The commands exist, in
`README.md` and `docs/RELEASE.md` — neither of which is where the link went.
Publishing signatures nobody can find instructions for is the same as not
publishing them.

Adds a **Verifying a download** section covering both halves: the `.sha256`
sidecars (with the note that the install scripts check them for you and
refuse rather than skip), and `cosign verify-blob` with the identity regexp
and OIDC issuer. It also says plainly that this is separate from platform
code signing, which the installers still do not have.

The landing copy now links to `/docs/install/#verifying-a-download` instead
of the top of the page.

### The changelog dated releases that were never published

An entry marked "Not yet released" was rendered beside a publication date.
`published_at` comes from the date on the CHANGELOG.md heading, which is
written when the entry is drafted, not when a tag is pushed — and
`mergeRelease` put it back from the fallback even once the page had dropped
it. The label and the date contradicted each other and the date reads as the
factual half.

Now decided in `mergeRelease`, so it holds whichever caller marks the entry.
Verified against a running build:

| | heading | linked | date |
|---|---|---|---|
| v0.3.1 | `Not yet released` | no | — |
| v0.3.0 | `Not yet released` | no | — |
| v0.2.6 | plain | yes | 6 May 2026 |

**Worth knowing:** v0.3.0 shows as unreleased because it *is* — `gh release
list` reports it as a **Draft**, and the last published release is v0.2.6
from May. My assessment said only 0.3.1 was untagged; I had inferred a
release from the tag existing, which was wrong. The remaining half of this —
CHANGELOG.md itself claiming 0.3.0 shipped on 20 Aug and 0.3.1 on 24 Aug —
is a separate change, since it is about what to actually release.

### The contrast gate had no coverage of the site

`check-frontend --root .` finds the **desktop app's** `design-tokens.json`
and reports "4 pair(s) >= 4.5:1 across 2 theme(s)". That pass says nothing
whatever about the website. Run against `site/` it was
`not_evaluated — no design-tokens.json`, so every gate run after a week of
site work measured nothing about the surface being changed.

`site/design-tokens.json` fixes that. **The palette needed no changes** —
measured against the page background:

| | dark | light |
|---|---|---|
| text-main | 11.45:1 | 7.71:1 |
| text-muted | 6.26:1 | 4.65:1 |
| text-strong | 17.17:1 | 17.14:1 |
| accent | 8.29:1 | 6.40:1 |

Values are measured from a served build rather than copied out of the CSS:
several are reached through `--sl-color-text` and other indirections, so the
declared value and the painted one are not always the same thing.
`tokens.css` now says so, and points at the light muted grey (4.65:1, the
least headroom) as the one to re-check before lightening small grey text.

`check-frontend --root site` → **SHIP**, 4 pairs across 2 themes.

### Verification

`astro check` 0 errors across 53 files · CSS shadowing budget 59 · a11y 0
violations in either theme · anchor and rendered commands confirmed present
in the built output.
