### PR TITLE
Submit the right version to winget, and pin the rest of the actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -37,7 +37,7 @@ jobs:
     name: cargo audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
         # See ci.yml's lint job for why this pin keeps a `# stable` comment
@@ -53,7 +53,7 @@ jobs:
       # Cache cargo-audit itself so we don't reinstall every run.
       - name: Cache cargo-audit
         id: cache-cargo-audit
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/cargo-audit
           key: cargo-audit-v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - id: filter
@@ -107,8 +107,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # 22, matching pages.yml / release.yml / site.yml / site-preview.yml.
           # Node 20 left standard support in April 2026, and the split meant
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # install.sh is user-facing; the release/ scripts hold GH_TOKEN and
       # push to three package registries. Both are worth linting, and
       # neither is exercised by any other job.
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # libpcap-dev: netscli-core pcap feature. GTK/WebKit: netscli-gui
       # (Tauri 2) — clippy --all-targets compiles the Tauri shell, which
       # won't link without these even when we only intend to lint Rust.
@@ -211,7 +211,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Linux needs libpcap for netscli-core's pcap feature and GTK/WebKit
       # for netscli-gui (Tauri 2). `cargo test --all` compiles the whole
@@ -253,8 +253,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # 22 — see the note on the maintainability job. This one is also
           # load-bearing for jsdom: jsdom 30 pulls an undici that calls
@@ -309,7 +309,7 @@ jobs:
       matrix:
         os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest", "windows-latest", "macos-latest"]') }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -326,7 +326,7 @@ jobs:
       - name: cargo build --release -p netscli
         run: cargo build --release -p netscli
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: netscli-${{ matrix.os }}
           path: |
@@ -359,7 +359,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/gui-render.yml
+++ b/.github/workflows/gui-render.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
         # See ci.yml's lint job for why this pin keeps a `# stable` comment
@@ -78,7 +78,7 @@ jobs:
         with:
           shared-key: gui-render-windows
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # 22, matching ci.yml and the release build. See ci.yml's note.
           node-version: 22

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,8 +33,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Astro 6 requires Node >=22.12. Pinning to 22 (active LTS).
           node-version: 22
@@ -46,9 +46,9 @@ jobs:
       - name: astro build
         run: npm run build
         working-directory: site
-      - uses: actions/configure-pages@v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Upload site/dist/
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site/dist
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -180,11 +180,35 @@ jobs:
           echo "asset never appeared after 15 minutes" >&2
           exit 1
 
+      # `version` is the PackageVersion that lands in the catalog, and it must
+      # not carry the tag's `v`. The action strips it only when the input is
+      # empty -- its own source reads
+      #
+      #   If ('' -eq '${{ inputs.version }}') { tag_name -replace '^v' }
+      #   Else                                { inputs.version }
+      #
+      # -- so passing `${{ env.TAG }}` opted out of the stripping and would
+      # have submitted `v0.3.1` beside the existing `0.3.0`. Winget sorts
+      # versions naturally, so the two do not compare as an upgrade.
+      - name: Resolve PackageVersion (tag without the leading v)
+        id: pkg
+        shell: bash
+        env:
+          TAG: ${{ env.TAG }}
+        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
       - name: Submit netscli to microsoft/winget-pkgs
         uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: fstubner.netscli
-          version: ${{ env.TAG }}
+          version: ${{ steps.pkg.outputs.version }}
+          # `release-tag` defaults to
+          # `github.event.release.tag_name || github.ref_name`, and on a
+          # `workflow_dispatch` the first is null and the second is the branch
+          # the run was dispatched from. The action would then ask the API for
+          # a release tagged `main` and fail -- on precisely the re-run path
+          # this workflow's header offers for recovering a failed publish.
+          release-tag: ${{ env.TAG }}
           installers-regex: 'netscli-windows-x86_64\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}
 
@@ -368,11 +392,22 @@ jobs:
           echo "asset never appeared after 15 minutes" >&2
           exit 1
 
+      # Same two corrections as the CLI winget job above: strip the `v` from
+      # the PackageVersion, and name the release tag explicitly so a
+      # `workflow_dispatch` re-run does not look for a release tagged `main`.
+      - name: Resolve PackageVersion (tag without the leading v)
+        id: pkg
+        shell: bash
+        env:
+          TAG: ${{ env.TAG }}
+        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
       - name: Submit netscli-gui to microsoft/winget-pkgs
         uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: fstubner.netscli.gui
-          version: ${{ env.TAG }}
+          version: ${{ steps.pkg.outputs.version }}
+          release-tag: ${{ env.TAG }}
           installers-regex: 'netscli-gui-windows-x86_64\.msi$'
           token: ${{ secrets.WINGET_TOKEN }}
 

--- a/.github/workflows/site-preview.yml
+++ b/.github/workflows/site-preview.yml
@@ -62,9 +62,9 @@ jobs:
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -146,7 +146,7 @@ jobs:
       - name: Comment the preview URL
         # Only a pull_request run has somewhere to put this.
         if: github.event_name == 'pull_request' && steps.deploy.outputs.url != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PREVIEW_URL: ${{ steps.deploy.outputs.url }}
         with:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       site: ${{ steps.filter.outputs.site }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - id: filter
@@ -64,8 +64,8 @@ jobs:
     if: needs.changes.outputs.site == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
       - run: node scripts/check-file-size.mjs
@@ -89,8 +89,8 @@ jobs:
       run:
         working-directory: site
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
Closes the one item my assessment left in **Unconfirmed**, which turned out
to be two bugs rather than none, plus the pinning inconsistency.

### Both winget jobs would submit the wrong PackageVersion

`publish.yml` passed `version: ${{ env.TAG }}` — that is `v0.3.1`. The action
strips the `v` only when the input is **empty**. From its own `action.yml`:

```powershell
If ('' -eq '${{ inputs.version }}') {
  Write-Output "version=$($ReleaseInfo.tag_name -replace '^v')" >> $env:GITHUB_OUTPUT
} Else {
  Write-Output "version=${{ inputs.version }}" >> $env:GITHUB_OUTPUT
}
```

Passing it explicitly opted out of the stripping. The catalog entry would
have been `v0.3.1` next to the existing `0.3.0`; winget sorts versions
naturally, so those do not compare as an upgrade, and it would have been
permanent in a moderated public catalog. A `Resolve PackageVersion` step now
derives `${TAG#v}` and both jobs use it.

### …and would fail on the documented re-run path

`release-tag` was left at its default, `github.event.release.tag_name ||
github.ref_name`. On `release: published` that is right. On
`workflow_dispatch` the first is null and the second is the *branch* the run
was dispatched from, so the action asks the API for a release tagged `main`
and fails — on precisely the recovery path this workflow's own header
advertises:

> `workflow_dispatch` with a tag input (re-run a specific job after fixing a
> transient failure)

Both jobs now pass `release-tag: ${{ env.TAG }}`.

Neither bug had a chance to show up yet: the winget GUI job has never run to
completion (it needs microsoft/winget-pkgs to accept an initial submission
first, PR #368471), and the committed `0.3.0` manifests under
`packaging/winget/` were hand-written, not produced by this job.

### Action pinning

`publish.yml`, `release.yml` and `release-drafter.yml` were fully SHA-pinned.
`ci.yml`, `site.yml`, `site-preview.yml`, `pages.yml`, `audit.yml` and
`gui-render.yml` pinned their third-party actions and left the first-party
`actions/*` on mutable tags — so the policy read as deliberate in three files
and absent in six. Now uniform: 28 uses pinned across six workflows, each
with the resolved version in a trailing comment so Dependabot can still see
what it is.

### Verification

All nine workflow files parse as YAML. `actionlint` is not installed here, so
this is a parse check plus review, not a lint. The winget jobs themselves
cannot be exercised outside a real publish — the version derivation is the
part I could check, and `${TAG#v}` gives `0.3.1` for both `v0.3.1` and a
bare `0.3.1`.
