### PR TITLE
Split the test and script families their own files already named

### DIFF
--- a/apps/netscli-gui/src/components/results/ResultTable.tsx
+++ b/apps/netscli-gui/src/components/results/ResultTable.tsx
@@ -188,28 +188,22 @@ export function ResultTable({
                 onClick={(event) => onSelectRow(index, selectionModeForPointer(event))}
               >
                 {effectiveColumns.map((column) => {
+                  // One `<td>`, not two near-identical ones. The branches
+                  // differed only in the class and what went inside, but each
+                  // carried its own copy of the seven-argument context-menu
+                  // handler -- so a change to how a cell opens its menu had
+                  // two places to remember.
+                  const isStatus = column.key === 'status' || column.key === 'state';
                   const value = row.data[column.key];
-                  if (column.key === 'status' || column.key === 'state') {
-                    return (
-                      <td
-                        key={column.key}
-                        onContextMenu={(event) =>
-                          openCellContextMenu(event, row, index, column, selected, onSelectRow, onContentContextMenu)
-                        }
-                      >
-                        <StatusPill value={value} />
-                      </td>
-                    );
-                  }
                   return (
                     <td
-                      className={column.mono ? 'mono' : ''}
+                      className={!isStatus && column.mono ? 'mono' : ''}
                       key={column.key}
                       onContextMenu={(event) =>
                         openCellContextMenu(event, row, index, column, selected, onSelectRow, onContentContextMenu)
                       }
                     >
-                      {renderValue(value)}
+                      {isStatus ? <StatusPill value={value} /> : renderValue(value)}
                     </td>
                   );
                 })}

--- a/apps/netscli-gui/src/components/tools/FieldSelectOptions.tsx
+++ b/apps/netscli-gui/src/components/tools/FieldSelectOptions.tsx
@@ -1,0 +1,38 @@
+import type { SelectOption } from './toolFormFields';
+
+interface FieldSelectOptionsProps {
+  options: SelectOption[];
+  selected: string | undefined;
+  onSelect: (value: string) => void;
+}
+
+/**
+ * The listbox rows inside a form field's select popover.
+ *
+ * Split out of ToolForm purely for depth: an options `.map` holding a button
+ * holding a click handler sat eight braces deep inside the field `.map`
+ * inside the component, which is the point where the shape of the markup
+ * stops being readable. Nothing about the behaviour changed, and the state
+ * stays in ToolForm -- this takes the three things a row actually needs.
+ */
+export function FieldSelectOptions({ options, selected, onSelect }: FieldSelectOptionsProps) {
+  return (
+    <>
+      {options.map((option) => (
+        <button
+          className={option.value === selected ? 'selected' : ''}
+          key={option.value}
+          role="option"
+          aria-selected={option.value === selected}
+          type="button"
+          onClick={() => onSelect(option.value)}
+        >
+          <span className="field-select-option-label">{option.label}</span>
+          {option.description ? (
+            <span className="field-select-option-meta">{option.description}</span>
+          ) : null}
+        </button>
+      ))}
+    </>
+  );
+}

--- a/apps/netscli-gui/src/components/tools/ToolForm.tsx
+++ b/apps/netscli-gui/src/components/tools/ToolForm.tsx
@@ -6,6 +6,7 @@ import { useAnchoredPopoverPosition, useOverlayDismiss } from '../primitives/ove
 import { TOOL_CONFIG } from '../../tools/registry';
 import type { WorkspaceTab } from '../../tools/types';
 import type { InterfaceInfo } from '../../types/netscli';
+import { FieldSelectOptions } from './FieldSelectOptions';
 import { NumberField } from './NumberField';
 import { fieldsForTab, selectOptionsForField } from './toolFormFields';
 
@@ -109,24 +110,14 @@ export function ToolForm({ tab, interfaces = [], onPatchForm, onRun }: ToolFormP
                   tabIndex={-1}
                   onKeyDown={onSelectKeyDown}
                 >
-                  {options.map((option) => (
-                    <button
-                      className={option.value === tab.form[field.key] ? 'selected' : ''}
-                      key={option.value}
-                      role="option"
-                      aria-selected={option.value === tab.form[field.key]}
-                      type="button"
-                      onClick={() => {
-                        onPatchForm(tab.id, field.key, option.value);
-                        setOpenField(null);
-                      }}
-                    >
-                      <span className="field-select-option-label">{option.label}</span>
-                      {option.description ? (
-                        <span className="field-select-option-meta">{option.description}</span>
-                      ) : null}
-                    </button>
-                  ))}
+                  <FieldSelectOptions
+                    options={options}
+                    selected={tab.form[field.key]}
+                    onSelect={(value) => {
+                      onPatchForm(tab.id, field.key, value);
+                      setOpenField(null);
+                    }}
+                  />
                 </div>
               )}
               </div>

--- a/apps/netscli-gui/src/tools/presentation.columns.test.ts
+++ b/apps/netscli-gui/src/tools/presentation.columns.test.ts
@@ -1,0 +1,55 @@
+// Which columns a result gets, and how much width each is allowed to take.
+//
+// Split out of presentation.test.ts alongside presentation.rows.test.ts; this
+// is the column half of that file's stated next split.
+
+import { describe, expect, it } from 'vitest';
+
+import { columnsFor } from './presentation';
+import type { ToolResult } from '../types/app';
+
+describe('column selection', () => {
+  it('keeps DNS record type compact and leaves value column to fill the table', () => {
+    const columns = columnsFor('dns', null);
+    expect(columns[0]).toMatchObject({ key: 'record_type', width: 72 });
+    expect(columns[1]).toMatchObject({ key: 'value', grow: true });
+    expect(columns.map((column) => column.key)).toContain('ttl');
+    expect(columns.map((column) => column.key)).toContain('resolver');
+  });
+
+  it('does not let empty optional columns consume the main table width', () => {
+    const discoverWithoutHostnames: ToolResult = {
+      kind: 'discover',
+      data: [
+        {
+          ip: '192.168.1.125',
+          hostname: '',
+          mac: '00:17:88:6E:6C:5C',
+          vendor: 'Philips Lighting BV',
+        },
+      ],
+    };
+    const emptyHostnameColumns = columnsFor('discover', discoverWithoutHostnames);
+    expect(emptyHostnameColumns.find((column) => column.key === 'hostname')).toMatchObject({
+      width: 130,
+    });
+    expect(emptyHostnameColumns.find((column) => column.key === 'vendor')).toMatchObject({
+      grow: true,
+    });
+
+    const discoverWithHostname: ToolResult = {
+      kind: 'discover',
+      data: [
+        {
+          ip: '192.168.1.125',
+          hostname: 'lamp.local',
+          mac: '00:17:88:6E:6C:5C',
+          vendor: 'Philips Lighting BV',
+        },
+      ],
+    };
+    expect(columnsFor('discover', discoverWithHostname).find((column) => column.key === 'hostname')).toMatchObject({
+      grow: true,
+    });
+  });
+});

--- a/apps/netscli-gui/src/tools/presentation.rows.test.ts
+++ b/apps/netscli-gui/src/tools/presentation.rows.test.ts
@@ -1,0 +1,218 @@
+// Turning a tool result into table rows: normalisation across statuses,
+// inspect and capture shapes, and the filtering and sorting applied on top.
+//
+// Split out of presentation.test.ts, which carried a transition exception at
+// 500 lines. Its stated next step was "row and column building are the next
+// families out"; this is the row half.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildRows,
+  columnsFor,
+  filterAndSortRows,
+  filterHintsFor,
+  latencyOf,
+  latencyOfPort,
+} from './presentation';
+import { createTab } from './registry';
+import type { ToolResult } from '../types/app';
+import type { PortResult, PortStatus } from '../types/netscli';
+
+function portResult(port: number, status: PortStatus, latency_ms?: number, banner?: string): PortResult {
+  return {
+    port,
+    open: status === 'open',
+    status,
+    service: port === 443 ? 'https' : 'http',
+    latency_ms,
+    banner,
+  };
+}
+
+describe('row building', () => {
+  it('normalizes port rows across statuses and latency states', () => {
+    const result: ToolResult = {
+      kind: 'scan',
+      data: [
+        portResult(80, 'open', 14, 'cloudflare'),
+        portResult(22, 'closed', 8),
+        portResult(443, 'filtered'),
+        portResult(8443, 'error', undefined, 'probe failed'),
+      ],
+    };
+
+    const rows = buildRows(result);
+    expect(rows.map((row) => row.data.status)).toEqual(['open', 'closed', 'filtered', 'error']);
+    // The `error` row reads '-' rather than ''. This assertion previously
+    // pinned the table's own formatter, which returned '' where the detail
+    // pane returned a reason for the same port -- the M-7 divergence. Both
+    // now come from one function, so a port with no measured latency always
+    // explains itself.
+    expect(rows.map((row) => row.data.latency)).toEqual(['14 ms', '8 ms', 'timeout', '-']);
+    expect(rows[0]?.searchText).toContain('cloudflare');
+  });
+
+  // M-7 regression: the table and detail pane must agree for every status.
+
+  it('reports the same latency text in the table and the detail pane', () => {
+    const statuses = ['open', 'closed', 'filtered', 'error'] as const;
+    for (const status of statuses) {
+      const port = portResult(80, status);
+      expect(latencyOf(port)).toBe(latencyOfPort(port));
+    }
+    // A closed port used to be blank in the table and 'refused' in details.
+    expect(latencyOf(portResult(22, 'closed'))).toBe('refused');
+  });
+
+  it('normalizes inspect rows from all scanned ports, not only open ports', () => {
+    const rows = buildRows({
+      kind: 'inspect',
+      data: {
+        host: '127.0.0.1',
+        ports: [portResult(22, 'filtered'), portResult(80, 'closed'), portResult(443, 'open')],
+        open_ports: [portResult(443, 'open')],
+        ping: { ip: '127.0.0.1', alive: false, seq: 0 },
+        hostname: 'localhost',
+      },
+    });
+
+    expect(rows.map((row) => row.data.port)).toEqual([22, 80, 443]);
+    expect(rows.map((row) => row.data.status)).toEqual(['filtered', 'closed', 'open']);
+    expect(columnsFor('inspect', null, rows).map((column) => column.key)).toContain('port');
+  });
+
+  it('normalizes PCAP captures into packet rows instead of a capture summary row', () => {
+    const rows = buildRows({
+      kind: 'pcap',
+      data: {
+        packets_captured: 1,
+        duration: { secs: 1, nanos: 250_000_000 },
+        file_path: 'capture.pcap',
+        packets_truncated: false,
+        packets: [
+          {
+            index: 1,
+            timestamp: '1716900000.000001',
+            source: '192.168.1.10',
+            destination: '1.1.1.1',
+            protocol: 'TCP',
+            length: 54,
+            captured_length: 54,
+            info: '54231 -> 443 [SYN] Len=0',
+            source_port: 54231,
+            destination_port: 443,
+            tcp_flags: 'SYN',
+            hex_preview: '00 11',
+          },
+        ],
+      },
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.data).toMatchObject({
+      no: 1,
+      source: '192.168.1.10',
+      destination: '1.1.1.1',
+      protocol: 'TCP',
+      ports: '54231 -> 443',
+      length: 54,
+    });
+    expect(columnsFor('pcap', null).map((column) => column.key)).toEqual([
+      'no',
+      'time',
+      'source',
+      'destination',
+      'protocol',
+      'ports',
+      'length',
+      'info',
+    ]);
+  });
+
+  it('filters and sorts normalized rows', () => {
+    const tab = createTab('scan');
+    tab.sortKey = 'port';
+    tab.sortDir = 'desc';
+
+    const rows = buildRows({
+      kind: 'scan',
+      data: [portResult(80, 'open', 14, 'nginx'), portResult(443, 'open', 12, 'cloudflare')],
+    });
+
+    expect(filterAndSortRows(rows, tab, '').map((row) => row.data.port)).toEqual([443, 80]);
+    expect(filterAndSortRows(rows, tab, 'nginx').map((row) => row.data.port)).toEqual([80]);
+    expect(filterAndSortRows(rows, tab, 'status:open port:443').map((row) => row.data.port)).toEqual([
+      443,
+    ]);
+    expect(filterAndSortRows(rows, tab, '-service:http').map((row) => row.data.port)).toEqual([]);
+  });
+
+  it('keeps quoted field filters together for multi-word values', () => {
+    const tab = createTab('sweep');
+    tab.sortKey = 'ip';
+    tab.result = {
+      kind: 'sweep',
+      data: [
+        {
+          host: {
+            ip: '192.168.1.74',
+            vendor: 'WNC Corporation',
+          },
+          open_ports: [portResult(22, 'open')],
+        },
+        {
+          host: {
+            ip: '192.168.1.125',
+            vendor: 'Philips Lighting BV',
+          },
+          open_ports: [portResult(80, 'open')],
+        },
+      ],
+    };
+
+    const rows = buildRows(tab.result);
+    expect(filterAndSortRows(rows, tab, 'vendor:"WNC Corporation"').map((row) => row.data.ip)).toEqual([
+      '192.168.1.74',
+    ]);
+    expect(filterAndSortRows(rows, tab, 'vendor:"Philips Lighting BV"').map((row) => row.data.ip)).toEqual([
+      '192.168.1.125',
+    ]);
+  });
+
+  it('builds tab-aware filter hints without site-specific canned values', () => {
+    const dns = createTab('dns');
+    dns.result = {
+      kind: 'dns',
+      data: [
+        { record_type: 'A', value: '185.199.110.153' },
+        { record_type: 'MX', value: '10 mail.example.test', ttl_seconds: 300, resolver_source: 'system' },
+      ],
+    };
+    const dnsHints = filterHintsFor(dns);
+    const dnsText = JSON.stringify(dnsHints);
+    expect(dnsHints.placeholder).toContain('type:A');
+    expect(dnsText).toContain('type:A');
+    expect(dnsText).toContain('value:185.199.110.153');
+    expect(dnsText).toContain('resolver:system');
+    expect(dnsText).not.toMatch(/GitHub Pages|vendor:apple|value:mail/i);
+
+    const discover = createTab('discover');
+    discover.result = {
+      kind: 'discover',
+      data: [
+        {
+          ip: '192.168.1.125',
+          hostname: 'lamp.local',
+          mac: '00:17:88:6E:6C:5C',
+          vendor: 'Philips Lighting BV',
+        },
+      ],
+    };
+    const discoverHints = filterHintsFor(discover);
+    const discoverValues = discoverHints.sections.flatMap((section) => section.options.map((option) => option[1]));
+    expect(discoverValues).toContain('ip:192.168.1.125');
+    expect(discoverValues).toContain('vendor:"Philips Lighting BV"');
+    expect(JSON.stringify(discoverHints)).not.toContain('vendor:apple');
+  });
+});

--- a/apps/netscli-gui/src/tools/presentation.test.ts
+++ b/apps/netscli-gui/src/tools/presentation.test.ts
@@ -5,15 +5,10 @@ import { createTab } from './registry';
 import {
   buildCommand,
   buildRows,
-  columnsFor,
   copyContextForCell,
   detailTabsFor,
-  filterHintsFor,
-  filterAndSortRows,
   inspectOverviewLines,
   inspectPortsLines,
-  latencyOf,
-  latencyOfPort,
   portBannerLines,
   portHeaderLines,
   portRawPreview,
@@ -23,7 +18,6 @@ import {
   selectionSummaryLines,
   tabIdentity,
 } from './presentation';
-import type { ToolResult } from '../types/app';
 import type { PortResult, PortStatus } from '../types/netscli';
 
 function portResult(port: number, status: PortStatus, latency_ms?: number, banner?: string): PortResult {
@@ -178,190 +172,6 @@ describe('result presentation', () => {
     ).toBe('host down - 0 open ports');
   });
 
-  it('normalizes port rows across statuses and latency states', () => {
-    const result: ToolResult = {
-      kind: 'scan',
-      data: [
-        portResult(80, 'open', 14, 'cloudflare'),
-        portResult(22, 'closed', 8),
-        portResult(443, 'filtered'),
-        portResult(8443, 'error', undefined, 'probe failed'),
-      ],
-    };
-
-    const rows = buildRows(result);
-    expect(rows.map((row) => row.data.status)).toEqual(['open', 'closed', 'filtered', 'error']);
-    // The `error` row reads '-' rather than ''. This assertion previously
-    // pinned the table's own formatter, which returned '' where the detail
-    // pane returned a reason for the same port -- the M-7 divergence. Both
-    // now come from one function, so a port with no measured latency always
-    // explains itself.
-    expect(rows.map((row) => row.data.latency)).toEqual(['14 ms', '8 ms', 'timeout', '-']);
-    expect(rows[0]?.searchText).toContain('cloudflare');
-  });
-
-  // M-7 regression: the table and detail pane must agree for every status.
-  it('reports the same latency text in the table and the detail pane', () => {
-    const statuses = ['open', 'closed', 'filtered', 'error'] as const;
-    for (const status of statuses) {
-      const port = portResult(80, status);
-      expect(latencyOf(port)).toBe(latencyOfPort(port));
-    }
-    // A closed port used to be blank in the table and 'refused' in details.
-    expect(latencyOf(portResult(22, 'closed'))).toBe('refused');
-  });
-
-  it('normalizes inspect rows from all scanned ports, not only open ports', () => {
-    const rows = buildRows({
-      kind: 'inspect',
-      data: {
-        host: '127.0.0.1',
-        ports: [portResult(22, 'filtered'), portResult(80, 'closed'), portResult(443, 'open')],
-        open_ports: [portResult(443, 'open')],
-        ping: { ip: '127.0.0.1', alive: false, seq: 0 },
-        hostname: 'localhost',
-      },
-    });
-
-    expect(rows.map((row) => row.data.port)).toEqual([22, 80, 443]);
-    expect(rows.map((row) => row.data.status)).toEqual(['filtered', 'closed', 'open']);
-    expect(columnsFor('inspect', null, rows).map((column) => column.key)).toContain('port');
-  });
-
-  it('normalizes PCAP captures into packet rows instead of a capture summary row', () => {
-    const rows = buildRows({
-      kind: 'pcap',
-      data: {
-        packets_captured: 1,
-        duration: { secs: 1, nanos: 250_000_000 },
-        file_path: 'capture.pcap',
-        packets_truncated: false,
-        packets: [
-          {
-            index: 1,
-            timestamp: '1716900000.000001',
-            source: '192.168.1.10',
-            destination: '1.1.1.1',
-            protocol: 'TCP',
-            length: 54,
-            captured_length: 54,
-            info: '54231 -> 443 [SYN] Len=0',
-            source_port: 54231,
-            destination_port: 443,
-            tcp_flags: 'SYN',
-            hex_preview: '00 11',
-          },
-        ],
-      },
-    });
-
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.data).toMatchObject({
-      no: 1,
-      source: '192.168.1.10',
-      destination: '1.1.1.1',
-      protocol: 'TCP',
-      ports: '54231 -> 443',
-      length: 54,
-    });
-    expect(columnsFor('pcap', null).map((column) => column.key)).toEqual([
-      'no',
-      'time',
-      'source',
-      'destination',
-      'protocol',
-      'ports',
-      'length',
-      'info',
-    ]);
-  });
-
-  it('filters and sorts normalized rows', () => {
-    const tab = createTab('scan');
-    tab.sortKey = 'port';
-    tab.sortDir = 'desc';
-
-    const rows = buildRows({
-      kind: 'scan',
-      data: [portResult(80, 'open', 14, 'nginx'), portResult(443, 'open', 12, 'cloudflare')],
-    });
-
-    expect(filterAndSortRows(rows, tab, '').map((row) => row.data.port)).toEqual([443, 80]);
-    expect(filterAndSortRows(rows, tab, 'nginx').map((row) => row.data.port)).toEqual([80]);
-    expect(filterAndSortRows(rows, tab, 'status:open port:443').map((row) => row.data.port)).toEqual([
-      443,
-    ]);
-    expect(filterAndSortRows(rows, tab, '-service:http').map((row) => row.data.port)).toEqual([]);
-  });
-
-  it('keeps quoted field filters together for multi-word values', () => {
-    const tab = createTab('sweep');
-    tab.sortKey = 'ip';
-    tab.result = {
-      kind: 'sweep',
-      data: [
-        {
-          host: {
-            ip: '192.168.1.74',
-            vendor: 'WNC Corporation',
-          },
-          open_ports: [portResult(22, 'open')],
-        },
-        {
-          host: {
-            ip: '192.168.1.125',
-            vendor: 'Philips Lighting BV',
-          },
-          open_ports: [portResult(80, 'open')],
-        },
-      ],
-    };
-
-    const rows = buildRows(tab.result);
-    expect(filterAndSortRows(rows, tab, 'vendor:"WNC Corporation"').map((row) => row.data.ip)).toEqual([
-      '192.168.1.74',
-    ]);
-    expect(filterAndSortRows(rows, tab, 'vendor:"Philips Lighting BV"').map((row) => row.data.ip)).toEqual([
-      '192.168.1.125',
-    ]);
-  });
-
-  it('builds tab-aware filter hints without site-specific canned values', () => {
-    const dns = createTab('dns');
-    dns.result = {
-      kind: 'dns',
-      data: [
-        { record_type: 'A', value: '185.199.110.153' },
-        { record_type: 'MX', value: '10 mail.example.test', ttl_seconds: 300, resolver_source: 'system' },
-      ],
-    };
-    const dnsHints = filterHintsFor(dns);
-    const dnsText = JSON.stringify(dnsHints);
-    expect(dnsHints.placeholder).toContain('type:A');
-    expect(dnsText).toContain('type:A');
-    expect(dnsText).toContain('value:185.199.110.153');
-    expect(dnsText).toContain('resolver:system');
-    expect(dnsText).not.toMatch(/GitHub Pages|vendor:apple|value:mail/i);
-
-    const discover = createTab('discover');
-    discover.result = {
-      kind: 'discover',
-      data: [
-        {
-          ip: '192.168.1.125',
-          hostname: 'lamp.local',
-          mac: '00:17:88:6E:6C:5C',
-          vendor: 'Philips Lighting BV',
-        },
-      ],
-    };
-    const discoverHints = filterHintsFor(discover);
-    const discoverValues = discoverHints.sections.flatMap((section) => section.options.map((option) => option[1]));
-    expect(discoverValues).toContain('ip:192.168.1.125');
-    expect(discoverValues).toContain('vendor:"Philips Lighting BV"');
-    expect(JSON.stringify(discoverHints)).not.toContain('vendor:apple');
-  });
-
   it('selects detail tabs by row type', () => {
     const rows = buildRows({ kind: 'scan', data: [portResult(443, 'open')] });
     expect(detailTabsFor(rows[0])).toEqual(['banner', 'headers', 'tls', 'raw']);
@@ -396,50 +206,6 @@ describe('result presentation', () => {
       ]),
     );
     expect(inspectPortsLines(result, undefined).find((line) => line.label === 'Open Ports')?.value).toBe('443');
-  });
-
-  it('keeps DNS record type compact and leaves value column to fill the table', () => {
-    const columns = columnsFor('dns', null);
-    expect(columns[0]).toMatchObject({ key: 'record_type', width: 72 });
-    expect(columns[1]).toMatchObject({ key: 'value', grow: true });
-    expect(columns.map((column) => column.key)).toContain('ttl');
-    expect(columns.map((column) => column.key)).toContain('resolver');
-  });
-
-  it('does not let empty optional columns consume the main table width', () => {
-    const discoverWithoutHostnames: ToolResult = {
-      kind: 'discover',
-      data: [
-        {
-          ip: '192.168.1.125',
-          hostname: '',
-          mac: '00:17:88:6E:6C:5C',
-          vendor: 'Philips Lighting BV',
-        },
-      ],
-    };
-    const emptyHostnameColumns = columnsFor('discover', discoverWithoutHostnames);
-    expect(emptyHostnameColumns.find((column) => column.key === 'hostname')).toMatchObject({
-      width: 130,
-    });
-    expect(emptyHostnameColumns.find((column) => column.key === 'vendor')).toMatchObject({
-      grow: true,
-    });
-
-    const discoverWithHostname: ToolResult = {
-      kind: 'discover',
-      data: [
-        {
-          ip: '192.168.1.125',
-          hostname: 'lamp.local',
-          mac: '00:17:88:6E:6C:5C',
-          vendor: 'Philips Lighting BV',
-        },
-      ],
-    };
-    expect(columnsFor('discover', discoverWithHostname).find((column) => column.key === 'hostname')).toMatchObject({
-      grow: true,
-    });
   });
 
   it('summarizes multi-row detail selections', () => {

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -6,15 +6,6 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const maxLines = 300;
 const transitionExceptions = new Map([
   [
-    'apps/netscli-gui/src/tools/presentation.test.ts',
-    {
-      maxLines: 500,
-      reason:
-        'broad presentation-helper fixture coverage. The value/CSV helpers split out to ' +
-        'presentation.values.test.ts; row and column building are the next families out.',
-    },
-  ],
-  [
     'apps/netscli-gui/src/styles/results.css',
     {
       maxLines: 435,
@@ -68,8 +59,10 @@ const transitionExceptions = new Map([
   [
     'site/src/scripts/docs-header.ts',
     {
-      maxLines: 360,
-      reason: 'docs header/search/toc behaviors; split search vs toc vs tables next',
+      maxLines: 280,
+      reason:
+        'docs header/search/toc behaviors. Tables split out to docs-tables.ts; ' +
+        'search vs toc are the remaining two families.',
     },
   ],
   [

--- a/site/src/scripts/docs-header.ts
+++ b/site/src/scripts/docs-header.ts
@@ -1,4 +1,5 @@
 import { disposeDocsHeader, onDispose, registerDisposal } from './docs-header-disposal';
+import { applyDocsTableBehaviour } from './docs-tables';
 
 export function initDocsHeader(): void {
   // Re-entrant under view transitions: drop the previous run's observers
@@ -264,82 +265,5 @@ export function initDocsHeader(): void {
   window.setTimeout(scheduleMobileTocCurrent, 250);
   window.setTimeout(scheduleMobileTocCurrent, 1000);
 
-  const tableOptionClasses = new Map([
-    ['netscli-table: row-headers', 'table-row-headers'],
-    ['netscli-table: plain-first-column', 'table-plain-first-column'],
-  ]);
-
-  const applyTableOptions = () => {
-    const content = document.querySelector('.sl-markdown-content');
-    if (!content) return;
-
-    content.querySelectorAll('[data-netscli-table]').forEach((marker) => {
-      const markerValue = marker.getAttribute('data-netscli-table')?.trim().toLowerCase();
-      const option = tableOptionClasses.get(`netscli-table: ${markerValue}`);
-      if (!option) return;
-
-      let sibling = marker.nextElementSibling;
-      while (sibling) {
-        if (sibling instanceof HTMLTableElement) {
-          sibling.classList.add(option);
-          break;
-        }
-        sibling = sibling.nextElementSibling;
-      }
-    });
-
-    const walker = document.createTreeWalker(content, NodeFilter.SHOW_COMMENT);
-    let comment = walker.nextNode();
-    while (comment) {
-      const option = tableOptionClasses.get(comment.nodeValue?.trim().toLowerCase() ?? '');
-      if (option) {
-        let sibling = comment.nextSibling;
-        while (sibling) {
-          if (sibling.nodeType === Node.ELEMENT_NODE) {
-            if (sibling instanceof HTMLTableElement) sibling.classList.add(option);
-            break;
-          }
-          sibling = sibling.nextSibling;
-        }
-      }
-      comment = walker.nextNode();
-    }
-
-    content.querySelectorAll('table').forEach((table) => {
-      const labels = [...table.querySelectorAll('thead th')].map(
-        (cell) => cell.textContent?.trim().replace(/\s+/g, ' ') ?? ''
-      );
-
-      table.querySelectorAll('tbody tr').forEach((row) => {
-        [...row.children].forEach((cell, index) => {
-          if (cell instanceof HTMLElement && labels[index]) {
-            cell.dataset.label = labels[index];
-          }
-        });
-      });
-
-      if (table.parentElement?.classList.contains('netscli-table-scroll')) return;
-
-      const wrapper = document.createElement('div');
-      wrapper.className = 'netscli-table-scroll';
-      // The wrapper is the horizontally-scrollable region; make it reachable
-      // by keyboard (axe scrollable-region-focusable) since the table inside
-      // it isn't otherwise a focusable element.
-      wrapper.tabIndex = 0;
-      wrapper.setAttribute('role', 'region');
-      wrapper.setAttribute('aria-label', 'Scrollable table');
-      table.before(wrapper);
-      wrapper.append(table);
-    });
-  };
-
-  const scheduleTableOptions = () => {
-    window.requestAnimationFrame(applyTableOptions);
-  };
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', scheduleTableOptions, { once: true });
-  } else {
-    scheduleTableOptions();
-  }
+  applyDocsTableBehaviour();
 }

--- a/site/src/scripts/docs-tables.ts
+++ b/site/src/scripts/docs-tables.ts
@@ -1,0 +1,109 @@
+// Markdown table behaviour for the docs: option markers, per-cell column
+// labels for the narrow-screen card layout, and the horizontal scroll
+// wrapper.
+//
+// Split out of docs-header.ts, whose transition exception named
+// "split search vs toc vs tables next". This is the tables third.
+
+export function applyDocsTableBehaviour(): void {
+  // Two markers, two different rules, and they were four levels of nested
+  // loop apart in the same function -- close enough to look identical and
+  // far enough apart that the difference was invisible. Named, the
+  // difference is the names.
+
+  /** Scan forward past other elements until a table turns up, and tag it. */
+  const tagNextTableElement = (marker: Element, option: string): void => {
+    let sibling = marker.nextElementSibling;
+    while (sibling) {
+      if (sibling instanceof HTMLTableElement) {
+        sibling.classList.add(option);
+        return;
+      }
+      sibling = sibling.nextElementSibling;
+    }
+  };
+
+  /** Tag only the very next element, and only if it is a table. */
+  const tagImmediatelyFollowingTable = (marker: Node, option: string): void => {
+    let sibling = marker.nextSibling;
+    while (sibling) {
+      if (sibling.nodeType === Node.ELEMENT_NODE) {
+        if (sibling instanceof HTMLTableElement) sibling.classList.add(option);
+        return;
+      }
+      sibling = sibling.nextSibling;
+    }
+  };
+
+  /**
+   * Copy each column's heading onto its cells as `data-label`.
+   *
+   * The narrow-screen styles stack a table into cards and print that label
+   * beside each value, so a cell without one loses its meaning entirely at
+   * mobile widths.
+   */
+  const labelCellsWithTheirColumn = (table: Element): void => {
+    const labels = [...table.querySelectorAll('thead th')].map(
+      (cell) => cell.textContent?.trim().replace(/\s+/g, ' ') ?? ''
+    );
+    table.querySelectorAll('tbody tr').forEach((row) => {
+      [...row.children].forEach((cell, index) => {
+        if (cell instanceof HTMLElement && labels[index]) cell.dataset.label = labels[index];
+      });
+    });
+  };
+
+  const tableOptionClasses = new Map([
+    ['netscli-table: row-headers', 'table-row-headers'],
+    ['netscli-table: plain-first-column', 'table-plain-first-column'],
+  ]);
+
+  const applyTableOptions = () => {
+    const content = document.querySelector('.sl-markdown-content');
+    if (!content) return;
+
+    content.querySelectorAll('[data-netscli-table]').forEach((marker) => {
+      const markerValue = marker.getAttribute('data-netscli-table')?.trim().toLowerCase();
+      const option = tableOptionClasses.get(`netscli-table: ${markerValue}`);
+      if (!option) return;
+
+      tagNextTableElement(marker, option);
+    });
+
+    const walker = document.createTreeWalker(content, NodeFilter.SHOW_COMMENT);
+    let comment = walker.nextNode();
+    while (comment) {
+      const option = tableOptionClasses.get(comment.nodeValue?.trim().toLowerCase() ?? '');
+      if (option) tagImmediatelyFollowingTable(comment, option);
+      comment = walker.nextNode();
+    }
+
+    content.querySelectorAll('table').forEach((table) => {
+      labelCellsWithTheirColumn(table);
+
+      if (table.parentElement?.classList.contains('netscli-table-scroll')) return;
+
+      const wrapper = document.createElement('div');
+      wrapper.className = 'netscli-table-scroll';
+      // The wrapper is the horizontally-scrollable region; make it reachable
+      // by keyboard (axe scrollable-region-focusable) since the table inside
+      // it isn't otherwise a focusable element.
+      wrapper.tabIndex = 0;
+      wrapper.setAttribute('role', 'region');
+      wrapper.setAttribute('aria-label', 'Scrollable table');
+      table.before(wrapper);
+      wrapper.append(table);
+    });
+  };
+
+  const scheduleTableOptions = () => {
+    window.requestAnimationFrame(applyTableOptions);
+  };
+
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', scheduleTableOptions, { once: true });
+  } else {
+    scheduleTableOptions();
+  }
+}


### PR DESCRIPTION
Findings #10 and #13's structural half from the pre-release assessment — each fixed the way the repository's own notes said to fix it, rather than by raising a limit.

### `presentation.test.ts` — 496 lines against a 500-line exception

The exception's stated reason was *"the value/CSV helpers split out to presentation.values.test.ts; **row and column building are the next families out**"*. Those two families are now their own files:

| file | lines |
|---|---|
| `presentation.test.ts` | 496 → 262 |
| `presentation.rows.test.ts` | new, 218 |
| `presentation.columns.test.ts` | new, 55 |

The transition exception is **deleted**, not raised — all three are under the 300-line limit now. 152 tests before, 152 after, 26 files → 28.

### `docs-header.ts` — a difference hidden by distance

Two nearly identical sibling walks sat four levels of nesting apart in one function. One scans forward past other elements until a table turns up; the other tags only the immediately following element and gives up. Close enough to read as the same code, far enough apart that nobody would notice they are not. Both are now named functions where the names *are* the difference, and the per-cell column labelling is a third.

That took the file over its own 360-line cap, whose reason read *"split search vs toc vs tables next"* — so the tables third moves to `docs-tables.ts` (109 lines), `docs-header.ts` drops to 269, and the cap drops to 280.

### `ToolForm.tsx` — depth 8

An options `.map` holding a button holding a click handler, eight braces deep inside the field `.map` inside the component. The listbox rows move to `FieldSelectOptions`; the popover state stays in `ToolForm`, so this is three props, not a component with eleven.

### `ResultTable.tsx` — two `<td>`s that were one

The branches differed only in class and content, but each carried its own copy of the seven-argument context-menu handler — so changing how a cell opens its menu had two places to remember.

### Two left, deliberately

The checker reports one site at a time, so fixing the worst reveals the next. Both remaining ones are shape, not smell:

- **`ResultTable`** rows-by-columns double `.map` — that is what a table *is*. Extracting a cell component moves the depth to another file behind seven props.
- **`os-tabs.ts`** — a `.then` inside a feature-detect branch inside a handler: the shape of an optional async upgrade, already commented as such.

### Not done here

The CSS shadowing budget (the other half of #13) is untouched. It sits at exactly 59/59, and the 59 provably-dead declarations are concentrated in `25-mobile-overrides-final.css` (25) and `12-docs-toc-responsive.css` (12) — and #261 changes what the TOC rail renders, which will change that second set. Doing it before #261 lands would measure the wrong page.

### Verification

tsc · eslint · 152 unit tests · `astro check` 0 errors across 54 files · site build · a11y 0 violations in both themes · file-size guard.