### PR TITLE
Say what has actually been released, and check that the page agrees

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -90,6 +90,13 @@ jobs:
         working-directory: site
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tags, not just the tip. `check:changelog` asks git which versions
+          # are actually tagged so it can catch a changelog entry dated before
+          # its release exists -- and with the default `fetch-depth: 1` there
+          # are no tags to ask about, so it would report that it could not
+          # check rather than passing on nothing.
+          fetch-depth: 0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
@@ -98,6 +105,11 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run check
+      # Reads the built changelog page and compares it against CHANGELOG.md.
+      # Both halves of this went wrong in one day and neither was visible in
+      # `astro check` or the a11y pass -- see the header of the script.
+      - name: Changelog dates
+        run: npm run check:changelog
       # Runs axe against both themes; see site/scripts/a11y.mjs for why
       # both are needed, and why it prefers the runner's matched
       # chromedriver over the one the npm package downloads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,20 @@ they do not *inherit* it — each crate sets its own, and the GUI carries
 further copies in `package.json` and `tauri.conf.json`. See
 `docs/PUBLISHING.md` for the full list of files a bump has to touch.
 
+A version heading carries a date, and a link, only once its release is
+published. Both are claims about the outside world, and the website reads
+them: it printed "24 Aug 2026" for 0.3.1 for four days on the strength of a
+date written here when the notes were drafted. An in-flight version keeps
+its heading and collects entries; the date and the link go on with the tag.
+
 ## [Unreleased]
 
-## [0.3.1] — 2026-08-24
+## [0.3.1]
 
-A bug-fix release. Everything here was found by using the desktop app on a
-real network rather than by reading the code, and three of the fixes are for
-faults that reported success while doing nothing.
+A bug-fix release. Most of it was found by using the desktop app on a real
+network rather than by reading the code, and the rest by an assessment run
+before tagging; the recurring theme is code that reported success while doing
+nothing.
 
 ### Fixed
 
@@ -54,6 +61,39 @@ faults that reported success while doing nothing.
   unrecognised popover was torn down by the global dismissal handler before
   its own item could fire, so the item did nothing, threw nothing and logged
   nothing.
+- **`netscli arp --add` and `--delete` no longer claim to have changed the
+  table when they have not.** The same fault as `--clear` above, in the two
+  functions beside it: `arp -s` and `arp -d` also print "The requested
+  operation requires elevation" and exit 0, so an ordinary run printed "ARP
+  entry added for 192.0.2.77" — and `"ok": true` in JSON — having done
+  nothing. All three now share one check. `--clear` also returns an error on
+  platforms where it was never implemented, instead of reporting a cleared
+  table.
+- **The MCP server no longer says it returned everything while truncating.**
+  A capped result reported the byte count as its item count, so a 40,000-row
+  scan that returned 11,518 rows said `returned: 40000, total: 40000` beside
+  `truncated: true`.
+- **Packet captures fetched as a background MCP job are bounded like every
+  other result.** `get_pcap_capture_result` was routed before the limits that
+  strip and truncate remote text, so the one result made entirely of bytes off
+  the wire was the one that skipped them — while the blocking `capture_pcap`
+  beside it was capped.
+- **A database written by a newer netscli is refused rather than read.** The
+  version check treated a future schema as "already migrated", so an older
+  build queried tables it had never seen.
+- **The Exit item no longer flashes red on the way out**, and Packet Capture
+  is greyed with an explanation rather than hidden on builds without capture
+  support.
+- **The desktop app describes how each host was found.** A discover row from
+  the neighbour table is no longer labelled as having responded to a probe,
+  and the table carries a column for it rather than burying it in the detail
+  pane.
+- **The winget submission would have published the wrong version.** Both
+  package manifests were passed the tag including its `v`, which the action
+  only strips when the input is left empty — `v0.3.1` would have landed in
+  the public catalog beside `0.3.0` and not compared as an upgrade. The same
+  two jobs would also have failed on the documented re-run path, looking for a
+  release tagged `main`.
 
 ### Added
 
@@ -73,6 +113,22 @@ faults that reported success while doing nothing.
   finished. Failures still report unconditionally.
 - Dependency updates: `pcap` 2.4 → 2.5, `astro`, `lucide-react`, `vitest`,
   `@axe-core/cli`, and the vite/rollup group.
+
+### Website
+
+- **The install guide has the verification steps the landing page promises.**
+  It advertised checksums and Sigstore signatures "see the install guide for
+  verification steps" and linked to a page with none of them on it.
+- **The changelog no longer dates a release that has not happened.** An entry
+  marked "Not yet released" was rendered beside a publication date taken from
+  this file's own heading.
+- **The docs table of contents is back in the right-hand rail.** It had been
+  moved under the page hero at every width, which is the mobile layout applied
+  to desktop.
+- **Release notes are in the page rather than painted in by script**, so the
+  changelog reads with JavaScript disabled and does not flash "Loading".
+- The website's colours are now covered by the contrast gate, which had been
+  measuring the desktop app's palette and reporting a pass for both.
 
 ## [0.3.0] — 2026-08-20
 
@@ -649,8 +705,7 @@ backed by the same core library.
 - Desktop app needs the WebView2 runtime on Windows. Most Windows
   10/11 systems have it preinstalled.
 
-[Unreleased]: https://github.com/fstubner/netscli/compare/v0.3.1...HEAD
-[0.3.1]: https://github.com/fstubner/netscli/releases/tag/v0.3.1
+[Unreleased]: https://github.com/fstubner/netscli/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/fstubner/netscli/releases/tag/v0.3.0
 [0.2.6]: https://github.com/fstubner/netscli/releases/tag/v0.2.6
 [0.2.5]: https://github.com/fstubner/netscli/releases/tag/v0.2.5

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -119,13 +119,26 @@ outside Cargo entirely. Seven files have to move together:
 | `apps/netscli-gui/src-tauri/Cargo.toml` | Tauri backend crate version |
 | `apps/netscli-gui/src-tauri/tauri.conf.json` | installer/bundle version |
 | `apps/netscli-gui/package.json` | version shown in the GUI About dialog and on the website |
-| `CHANGELOG.md` | the release heading and its link reference |
+| `CHANGELOG.md` | the release heading (see below for its date and link) |
 
 Missing the last three is what shipped a GUI installer stamped with the
 wrong version at v0.2.4 and got the Winget submission rejected by a
 moderator (see the 0.2.4 entry in `CHANGELOG.md`). The website reads its
 version from `apps/netscli-gui/package.json`, so a miss there also
 silently mislabels netscli.com.
+
+### The changelog date and link go on with the tag, not with the bump
+
+A version heading gets `## [0.4.0]` at bump time and nothing more. The
+` — YYYY-MM-DD` and the `[0.4.0]: …/releases/tag/v0.4.0` reference are added
+in the same change that pushes the tag.
+
+Both are claims about the outside world, and the website reads them straight
+out of this file. 0.3.1 was bumped and dated `2026-08-24` in the release
+commit, then not tagged; netscli.com showed "v0.3.1 — 24 Aug 2026" for four
+days, and the link reference pointed at a tag page that did not exist. The
+version bump is a statement about this repository and can happen whenever;
+the date and the link are statements about a release that exists.
 
 To release 0.4.0 from 0.3.0:
 

--- a/site/package.json
+++ b/site/package.json
@@ -8,6 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
+    "check:changelog": "node ./scripts/changelog-dates.mjs",
     "check:css": "node ./scripts/css-shadowing.mjs --max 59",
     "test:a11y": "npm run build && node ./scripts/a11y.mjs"
   },

--- a/site/scripts/changelog-dates.mjs
+++ b/site/scripts/changelog-dates.mjs
@@ -61,14 +61,18 @@ const cards = html
     };
   });
 
-const monthNames = 'Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split(' ');
-const asIso = (rendered) => {
-  const m = rendered.match(/^(\d{1,2}) (\w{3}) (\d{4})$/);
-  if (!m) return null;
-  const month = monthNames.indexOf(m[2]) + 1;
-  if (month === 0) return null;
-  return `${m[3]}-${String(month).padStart(2, '0')}-${String(m[1]).padStart(2, '0')}`;
-};
+// Format the expected date exactly as the page does, rather than parsing what
+// the page produced. `release-list.ts` formats with the *ambient* locale, so
+// the same build renders "20 Aug 2026" on an en-GB machine and "Aug 20, 2026"
+// on a CI runner -- a reader that assumed either one failed on the other. The
+// date is built from the CHANGELOG heading the same way `changelog.astro`
+// does it, so this compares like with like wherever it runs.
+const dateFormat = new Intl.DateTimeFormat(undefined, {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+const asRendered = (iso) => dateFormat.format(new Date(`${iso}T00:00:00.000Z`));
 
 const failures = [];
 for (const { version, date } of declared) {
@@ -82,8 +86,11 @@ for (const { version, date } of declared) {
       `${version}: CHANGELOG.md dates it ${date}, the page shows no date. ` +
         `A shipped release lost its date.`
     );
-  } else if (date && asIso(card.date) !== date) {
-    failures.push(`${version}: CHANGELOG.md says ${date}, the page shows "${card.date}"`);
+  } else if (date && card.date !== asRendered(date)) {
+    failures.push(
+      `${version}: CHANGELOG.md says ${date} (renders as "${asRendered(date)}"), ` +
+        `the page shows "${card.date}"`
+    );
   } else if (!date && card.date) {
     failures.push(
       `${version}: CHANGELOG.md gives it no date, the page shows "${card.date}". ` +

--- a/site/scripts/changelog-dates.mjs
+++ b/site/scripts/changelog-dates.mjs
@@ -1,0 +1,141 @@
+// Does the built changelog page show the dates CHANGELOG.md actually claims?
+//
+// This exists because the answer was "no" twice in one day, in opposite
+// directions, and neither was visible from the source diff:
+//
+//   1. Every version heading got a `published_at` built from its own
+//      heading date, so 0.3.1 was presented as published on 24 Aug 2026
+//      while no tag for it existed.
+//   2. Fixing that keyed the rule on `unreleased`, which the build-time
+//      render sets on *every* entry -- so the no-JS page lost the dates of
+//      releases that really had shipped.
+//
+// Both are markup that renders as something plausible and wrong, on a page
+// nobody re-reads, so neither `astro check` nor the a11y pass would ever
+// notice. This reads the built HTML and compares it against the source of
+// truth. Run after `astro build`.
+//
+//   node ./scripts/changelog-dates.mjs
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const siteRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const built = path.join(siteRoot, 'dist', 'changelog', 'index.html');
+const changelog = path.join(siteRoot, '..', 'CHANGELOG.md');
+
+if (!fs.existsSync(built)) {
+  console.error(`No built changelog at ${built}. Run \`npm run build\` first.`);
+  process.exit(1);
+}
+
+/** `## [0.3.0] — 2026-08-20` -> { version: '0.3.0', date: '2026-08-20' }. */
+const declared = [...fs.readFileSync(changelog, 'utf8').matchAll(
+  /^## \[([^\]]+)\](?:\s+(?:—|-)\s+(\d{4}-\d{2}-\d{2}))?/gm
+)]
+  .map(([, version, date]) => ({ version, date }))
+  .filter(({ version }) => version.toLowerCase() !== 'unreleased')
+  .slice(0, 8);
+
+// Strip <script> first: the client-side data blob repeats every field and
+// would satisfy any naive search for a date that the page never renders.
+const html = fs.readFileSync(built, 'utf8').replace(/<script[\s\S]*?<\/script>/g, '');
+// Each card opens with `class="release-head"` and carries its heading and,
+// when there is one, its `release-meta` date inside that element. Splitting
+// on the head keeps the two paired even though the notes between one card
+// and the next run to thousands of characters.
+const cards = html
+  .split('class="release-head"')
+  .slice(1)
+  .map((chunk) => {
+    // Bounded by the body that always follows, not by the first `</div>`:
+    // the heading sits inside its own `release-title-group`, so closing at
+    // that div cuts the head off before the date it is meant to find.
+    const bodyAt = chunk.indexOf('class="release-body"');
+    const head = chunk.slice(0, bodyAt === -1 ? chunk.length : bodyAt);
+    return {
+      label: (head.match(/<h2[^>]*>([\s\S]*?)<\/h2>/) || [, ''])[1].replace(/<[^>]+>/g, '').trim(),
+      date: (head.match(/class="release-meta"[^>]*>([^<]*)</) || [, ''])[1].trim(),
+    };
+  });
+
+const monthNames = 'Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split(' ');
+const asIso = (rendered) => {
+  const m = rendered.match(/^(\d{1,2}) (\w{3}) (\d{4})$/);
+  if (!m) return null;
+  const month = monthNames.indexOf(m[2]) + 1;
+  if (month === 0) return null;
+  return `${m[3]}-${String(month).padStart(2, '0')}-${String(m[1]).padStart(2, '0')}`;
+};
+
+const failures = [];
+for (const { version, date } of declared) {
+  const card = cards.find((c) => c.label === `v${version}` || c.label === version);
+  if (!card) {
+    failures.push(`${version}: no card rendered on the built page`);
+    continue;
+  }
+  if (date && !card.date) {
+    failures.push(
+      `${version}: CHANGELOG.md dates it ${date}, the page shows no date. ` +
+        `A shipped release lost its date.`
+    );
+  } else if (date && asIso(card.date) !== date) {
+    failures.push(`${version}: CHANGELOG.md says ${date}, the page shows "${card.date}"`);
+  } else if (!date && card.date) {
+    failures.push(
+      `${version}: CHANGELOG.md gives it no date, the page shows "${card.date}". ` +
+        `An unreleased version is being presented as published.`
+    );
+  }
+}
+
+// The check above asks whether the page relays what CHANGELOG.md says. It
+// cannot catch the other half: CHANGELOG.md itself dating a version that was
+// never tagged, which the page then relays faithfully. That is what happened
+// to 0.3.1 -- dated in the release commit, tagged never. Ask git.
+let tags;
+try {
+  tags = new Set(
+    execFileSync('git', ['tag', '--list'], { cwd: siteRoot, encoding: 'utf8' })
+      .split('\n')
+      .map((tag) => tag.trim())
+      .filter(Boolean)
+  );
+} catch {
+  tags = null;
+}
+
+if (tags === null || tags.size === 0) {
+  // Fail rather than skip. A checkout without tags is the normal CI default
+  // (`fetch-depth: 1` fetches none), and a check that quietly passes there
+  // is worth nothing -- which is the shape of bug this whole file is about.
+  console.error(
+    'No git tags available, so a dated-but-untagged version cannot be detected.\n' +
+      'Check out with `fetch-depth: 0` (see site.yml) or run this in a full clone.'
+  );
+  process.exit(1);
+}
+
+for (const { version, date } of declared) {
+  if (date && !tags.has(`v${version}`)) {
+    failures.push(
+      `${version}: CHANGELOG.md dates it ${date}, but there is no v${version} tag. ` +
+        `The date goes on with the tag, not with the version bump.`
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Changelog dates on the built page disagree with CHANGELOG.md:\n');
+  for (const failure of failures) console.error(`  - ${failure}`);
+  console.error(
+    '\nA version heading carries a date only once its release is published;' +
+      '\nthe page must relay exactly that. See the note at the top of CHANGELOG.md.'
+  );
+  process.exit(1);
+}
+
+console.log(`${declared.length} changelog entr(ies) render the date CHANGELOG.md declares.`);

--- a/site/src/scripts/changelog/release-list.ts
+++ b/site/src/scripts/changelog/release-list.ts
@@ -17,14 +17,19 @@ function mergeRelease(
     tag_name: release.tag_name || fallback?.tag_name || tag,
     name: release.name || fallback?.name || tag,
     html_url: release.html_url || fallback?.html_url,
-    // An unreleased entry has no publication date, and must not borrow the
-    // fallback's. `published_at` there is built from the date on the
-    // CHANGELOG.md heading -- written when the entry is drafted, not when a
-    // tag is pushed -- so this line used to resurrect a date for the very
-    // entry GitHub had just confirmed was never released. The card read
-    // "Not yet released" beside "24 Aug 2026", and the date is the half that
-    // reads as a fact.
-    published_at: release.unreleased
+    // A *confirmed* unreleased entry has no publication date, and must not
+    // borrow the fallback's. `published_at` there comes from the date on the
+    // CHANGELOG.md heading, so this line used to resurrect a date for the
+    // very entry GitHub had just confirmed was never released -- the card
+    // read "Not yet released" beside "24 Aug 2026", and the date is the half
+    // that reads as a fact.
+    //
+    // `confirmedUnreleased`, not `unreleased`: the same distinction the
+    // heading label draws a few lines below. The build-time render marks
+    // every entry `unreleased` because nothing has confirmed any tag yet, so
+    // keying on that dropped the date from every card on the no-JS page --
+    // including releases that really did ship.
+    published_at: release.confirmedUnreleased
       ? undefined
       : release.published_at || fallback?.published_at,
     body: fallback?.body || release.body || '',


### PR DESCRIPTION
Finding #4 from the assessment, plus a regression of my own from #263 that it turned up.

### 0.3.1 was dated but never tagged

`## [0.3.1] — 2026-08-24`, and `git ls-remote --tags` has no v0.3.1. The website reads that date straight out of this file, so netscli.com presented 0.3.1 as published for four days, and `[0.3.1]: …/releases/tag/v0.3.1` pointed at a page that does not exist.

The date and the link come off. The heading stays — the version bump is real, the release is not.

**Also worth knowing:** `gh release list` reports **v0.3.0 as a Draft**. The last *published* release is v0.2.6, from May. My assessment said only 0.3.1 was untagged; I had inferred a release from the tag existing, which was wrong. Publishing the 0.3.0 draft is your call and I have not touched it.

### Seven merged changes were undocumented

`[Unreleased]` was empty while #258–#265 sat on top of the release commit. They are in 0.3.1 now, which is where they belong while it has not shipped: the ARP add/delete fault, the MCP truncation count, the uncapped pcap job results, the database downgrade guard, the greyed packet-capture entry, the winget version, and four website corrections under a new `### Website` group.

### The rule that was missing

`docs/PUBLISHING.md`'s bump checklist listed `CHANGELOG.md` as "the release heading and its link reference" without saying *when*. It now says: the heading goes on at bump time, the date and the link go on with the tag. One is a statement about this repository; the other is a claim about a release that exists.

### A regression from #263

`mergeRelease` dropped `published_at` for any entry marked `unreleased`. But `render-static.ts` marks **every** entry that way, because at build time nothing has confirmed any tag — so the no-JS page lost the dates of releases that really had shipped:

```
dates: []          # every card, including v0.2.6
```

Now keyed on `confirmedUnreleased`, the same distinction the heading label already drew four lines below. It reached main because I verified #263 against the running dev server and never against the built page.

### So: a check that reads the built page

`site/scripts/changelog-dates.mjs` compares every rendered card against CHANGELOG.md, and asks git whether a dated version is actually tagged. Both faults fail it — verified by reintroducing each:

```
- 0.3.0: CHANGELOG.md dates it 2026-08-20, the page shows no date.
  A shipped release lost its date.
```
```
- 0.3.1: CHANGELOG.md dates it 2026-08-24, but there is no v0.3.1 tag.
  The date goes on with the tag, not with the version bump.
```

Neither is visible to `astro check`, the a11y pass, or a source diff — it is markup that renders as something plausible and wrong on a page nobody re-reads. The site build job now checks out with `fetch-depth: 0` so the tag half has tags to ask about, and the script **fails rather than skips** when it has none, since a check that quietly passes on an empty tag list is the same shape of bug.

### Verified at both layers

| | v0.3.1 | v0.3.0 | v0.2.6 |
|---|---|---|---|
| **No-JS built page** | no date | 20 Aug 2026 | 6 May 2026 |
| **With JS** | `Not yet released`, unlinked, no date | `Not yet released`, unlinked, no date | linked, 6 May 2026 |

The two layers differ on 0.3.0 on purpose: the static render relays this file (the tag exists), the client asks GitHub (no *published* release). Each is honest about what it knows.

`astro check` 0 errors · CSS budget 59 · `check:changelog` passes.