### PR TITLE
Delete 17 CSS declarations that could never take effect

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview",
     "check": "astro check",
     "check:changelog": "node ./scripts/changelog-dates.mjs",
-    "check:css": "node ./scripts/css-shadowing.mjs --max 59",
+    "check:css": "node ./scripts/css-shadowing.mjs --max 42",
     "test:a11y": "npm run build && node ./scripts/a11y.mjs"
   },
   "dependencies": {

--- a/site/src/styles/starlight/12-docs-toc-responsive.css
+++ b/site/src/styles/starlight/12-docs-toc-responsive.css
@@ -6,7 +6,7 @@
   }.right-sidebar {
 
 
-    height: auto !important;
+
     padding: 0 !important;
     overflow: visible !important;
     border: 0 !important;
@@ -26,7 +26,7 @@
   mobile-starlight-toc summary {
 
 
-    padding-inline: clamp(1rem, 4vw, 1.5rem) !important;
+
     border-bottom: 0 !important;
     gap: 0.75rem !important;
   }
@@ -35,7 +35,7 @@
 
     gap: 0.65rem !important;
 
-    border-radius: 6px !important;
+
     background: rgba(255, 255, 255, 0.035) !important;
     color: var(--sl-color-gray-1) !important;
     font-weight: 720 !important;
@@ -53,7 +53,7 @@
 
     border-color: var(--sl-color-hairline-light) !important;
 
-    background: #171b22 !important;
+
     box-shadow: 0 18px 46px rgba(0, 0, 0, 0.34) !important;
   }mobile-starlight-toc .dropdown a:hover,
   mobile-starlight-toc .dropdown a[aria-current='true'] {

--- a/site/src/styles/starlight/14-docs-nav-table.css
+++ b/site/src/styles/starlight/14-docs-nav-table.css
@@ -16,7 +16,7 @@
   .right-sidebar-container {
 
 
-    flex: 0 0 100% !important;
+
     order: -1;
     background: var(--sl-color-bg);
     border-bottom: 1px solid var(--sl-color-hairline) !important;
@@ -32,7 +32,7 @@
   .right-sidebar {
 
 
-    height: auto !important;
+
     padding: 0 !important;
     overflow: visible !important;
     border: 0 !important;

--- a/site/src/styles/starlight/16-shell-interaction-closeout.css
+++ b/site/src/styles/starlight/16-shell-interaction-closeout.css
@@ -1,10 +1,4 @@
-/* Unified shell and interaction close-out. These final rules intentionally
-   sit last because Starlight and earlier feedback passes both style these
-   same surfaces. */
-.sidebar-content :where(details > ul) {
-
-  border-inline-start: 1px solid var(--sl-color-hairline) !important;
-}/* This selector outranks every `:where(details > ul a)` rule in the later
+/* This selector outranks every `:where(details > ul a)` rule in the later
    files -- `:where()` contributes no specificity, so those lose to a plain
    `.sidebar-content a[aria-current='page']` even when they load afterwards.
    The alignment therefore has to be set here, or it silently does nothing.

--- a/site/src/styles/starlight/17-mobile-shell-closeout-a.css
+++ b/site/src/styles/starlight/17-mobile-shell-closeout-a.css
@@ -15,7 +15,7 @@
     margin-inline: 0 !important;
     padding-inline-start: max(0.65rem, env(safe-area-inset-left)) !important;
     padding-inline-end: max(0.5rem, env(safe-area-inset-right)) !important;
-    gap: 0.55rem !important;
+
   }.docs-mark img {
     width: 132px !important;
   }
@@ -23,7 +23,7 @@
   .docs-header-search {
 
 
-    width: 2.5rem !important;
+
     max-width: 2.5rem !important;
     min-width: 2.5rem !important;
     margin-left: auto !important;
@@ -43,11 +43,7 @@
     gap: 0 !important;
   }.sidebar-pane {
     inset-block-start: var(--sl-nav-height) !important;
-  }}
-
-@media (min-width: 50rem) {}
-
-@media (max-width: 71.99rem) {
+  }}@media (max-width: 71.99rem) {
   :root {
     --netscli-mobile-docs-nav-height: 2.625rem;
     --netscli-mobile-toc-bar-height: 2.625rem;

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -49,7 +49,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
    same place, and the matching padding increase keeps the text still. */
 .sidebar-content :where(details > ul a) {
 
-  width: calc(100% + 0.5rem + 1px) !important;
+
   padding-inline-start: calc(.85rem + 0.5rem + 1px) !important;
   border-inline-start: 1px solid transparent !important;
   background-clip: border-box !important;
@@ -186,11 +186,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   }
 }
 
-@media (max-width: 49.99rem) {
-  .right-sidebar-container {
-  }
-
-  .docs-mark {
+@media (max-width: 49.99rem) {.docs-mark {
     transform: translateX(-24px) !important;
   }
 
@@ -240,9 +236,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 
   site-search dialog .dialog-frame > * {
     align-self: start !important;
-  }site-search button[data-close-modal] {
-  }
-}
+  }}
 
 #starlight__search .pagefind-ui__drawer {
   position: relative !important;

--- a/site/src/styles/starlight/21-mobile-docs-shell-verified.css
+++ b/site/src/styles/starlight/21-mobile-docs-shell-verified.css
@@ -8,12 +8,7 @@
 .sidebar-content :where(details > ul > li) {
 
   border-inline-start: 0 !important;
-}
-
-.sidebar-content :where(details > ul a) {
-}
-
-.sidebar-content :where(details > ul a:hover),
+}.sidebar-content :where(details > ul a:hover),
 .sidebar-content :where(details > ul a:focus-visible) {
   color: var(--sl-color-white) !important;
   background: rgba(255, 255, 255, 0.045) !important;

--- a/site/src/styles/starlight/23-regression-guardrails.css
+++ b/site/src/styles/starlight/23-regression-guardrails.css
@@ -47,12 +47,7 @@
     max-width: calc(100vw - 1rem) !important;
 
     margin: 0.5rem auto !important;
-  }
-
-  site-search dialog .dialog-frame {
-  }
-
-  site-search button[data-close-modal] {
+  }site-search button[data-close-modal] {
     grid-column: 2 !important;
     grid-row: 1 !important;
     justify-self: end !important;

--- a/site/src/styles/starlight/24-mobile-regression-guardrails.css
+++ b/site/src/styles/starlight/24-mobile-regression-guardrails.css
@@ -28,8 +28,6 @@
 
   .docs-header-search {
     margin-inline-end: .35rem !important;
-  }.content-panel table,
-  .sl-markdown-content table {
   }.content-panel thead th,
   .sl-markdown-content thead th {
     font-weight: 700 !important;
@@ -40,15 +38,7 @@
   .sl-markdown-content tbody th,
   .sl-markdown-content tbody td:first-child {
     font-weight: 400 !important;
-  }
-
-  site-search dialog {
-  }
-
-  site-search dialog .dialog-frame {
-  }
-
-  site-search dialog .search-container,
+  }site-search dialog .search-container,
   site-search dialog #starlight__search,
   site-search dialog .pagefind-ui,
   site-search dialog .pagefind-ui__form {
@@ -65,7 +55,4 @@
     justify-self: end !important;
     margin: 0 !important;
     min-height: 2.75rem !important;
-  }
-
-  site-search dialog .pagefind-ui__drawer {
   }}

--- a/site/src/styles/starlight/25-mobile-overrides-final.css
+++ b/site/src/styles/starlight/25-mobile-overrides-final.css
@@ -32,7 +32,7 @@
   .sl-markdown-content {
 
 
-    min-width: 0 !important;
+
     box-sizing: border-box !important;
     overflow-wrap: anywhere;
   }
@@ -56,12 +56,12 @@
   .content-panel > .sl-container {
 
 
-    margin-inline: 0 !important;
+
     padding-inline: clamp(1rem, 5vw, 1.5rem) !important;
   }starlight-menu-button {
 
 
-    inset-block-start: .625rem !important;
+
     inset-inline-end: .75rem !important;
     z-index: calc(var(--sl-z-index-navbar) + 2) !important;
   }
@@ -69,14 +69,14 @@
   starlight-menu-button button {
 
 
-    width: 2.5rem !important;
+
     height: 2.5rem !important;
   }
 
   .docs-header-search {
 
 
-    inset-inline-end: 3.75rem !important;
+
     z-index: calc(var(--sl-z-index-navbar) + 2) !important;
     width: 2.5rem !important;
     max-width: 2.5rem !important;
@@ -87,7 +87,7 @@
   .content-panel .netscli-table-scroll {
 
 
-    max-width: 100% !important;
+
     overflow-x: auto !important;
     overflow-y: hidden !important;
     -webkit-overflow-scrolling: touch !important;
@@ -98,7 +98,7 @@
     display: table !important;
 
 
-    max-width: none !important;
+
     table-layout: fixed !important;
   }
 


### PR DESCRIPTION
The other half of finding #13.

The shadowed-declaration budget sat at exactly **59 of 59**, so the next change that shadowed anything would fail the build with no room to absorb it. That is a ratchet working as designed; the way to give it room is to spend the dead rules it is holding.

`css-prune.mjs` already existed for exactly this. It removes what `css-shadowing.mjs` proves can never apply — same media context, same selector, and a later declaration of equal or greater importance already winning on every element the earlier could match. It located **17 of the 59** and left the rest in place rather than guess; ten rules were emptied entirely and removed.

Budget **59 → 42**.

### Behaviour-preserving, and checked

Every `(context, selector, property)` triple resolves to one winning declaration. Comparing that entire set before and after:

```
before: 1562 declarations, 59 shadowed, 1503 winners
after : 1545 declarations, 42 shadowed, 1503 winners
winners changed: 0
```

An identical winner set means no element can resolve any property differently. That is a stronger statement than a screenshot diff, which only covers the elements that happen to be on screen at the width it was taken — and the browser pane here reports `innerWidth: 0`, so layout values from it would have compared equal trivially and proved nothing.

### What I backed out

I first also collapsed the blank lines `css-prune` leaves behind where a declaration was. That rewrote whitespace *inside* multi-line values, showed 42 spurious winner differences, and touched 19 files instead of 10 — cosmetics widening a verified change into an unverifiable one. Reverted; the diff is the prune's output and nothing else.

### The 42 that remain

Concentrated in `25-mobile-overrides-final.css`, where the prune tool cannot locate the containing rule (duplicate rule bodies) and correctly refuses to guess. Worth a pass, but by hand and separately.

`astro check` 0 errors across 54 files · site build · `check:css` 42/42 · `check:changelog` · a11y 0 violations in both themes.