### PR TITLE
Say what the coverage matrix actually means, in ticks and dashes

### DIFF
--- a/site/src/content/docs/docs/interface-coverage.md
+++ b/site/src/content/docs/docs/interface-coverage.md
@@ -3,53 +3,117 @@ title: Interface coverage
 description: What NetsCLI exposes in the desktop app, CLI, TUI, MCP server, and packet-capture builds.
 ---
 
-NetsCLI has one Rust core library and several interfaces. Shared network behavior belongs in the core; each interface exposes the parts that fit its job.
+One Rust core library sits under everything NetsCLI offers. Shared network
+behaviour belongs in the core; each surface exposes the parts that suit how
+it is used.
+
+## What the surfaces actually are
+
+**Three of the four are the same binary.** `netscli` with a command is the
+CLI, `netscli` with no command opens the terminal UI, and `netscli serve`
+starts the MCP server. Installing the CLI installs all three. The desktop app
+is a separate download built on the same core.
+
+That matters when reading the table below: a dash in the MCP column does not
+mean you need another install to get that capability, only that the MCP
+server does not expose it as a tool.
 
 ## Coverage matrix
 
 <div data-netscli-table="row-headers"></div>
 
-| Capability | Desktop app | TUI | CLI | MCP |
+| Capability | Desktop app | CLI | TUI | MCP |
 | --- | --- | --- | --- | --- |
-| Discover hosts | Yes | Yes | Yes | Yes |
-| Scan TCP ports | Yes | Yes | Yes | Yes |
-| Inspect host | Yes | Yes | Yes | Yes |
-| Sweep subnet | Yes | Yes | Yes | Yes |
-| Ping | Yes | Yes | Yes | Yes |
-| Trace route | Yes | Yes | Yes | No |
-| DNS lookup | Yes | Yes | Yes | Yes |
-| Reverse DNS | Yes | Yes | Yes | No |
-| mDNS discovery | Yes | Yes | Yes | Yes |
-| Interfaces | Yes | Yes | Yes | Yes |
-| ARP neighbor cache | Yes | Yes | Yes | Yes |
-| Packet capture | Packet-capture build | Packet-capture build | Packet-capture build | Packet-capture build |
-| JSON/YAML output | Export-oriented | Session export | Yes | JSON-RPC |
-| Result bundles | Yes | No | No | No |
-| Setup and doctor | No | No | Yes | No |
-| MCP service management | No | No | Yes | No |
+| Discover hosts | ✓ | ✓ | ✓ | ✓ |
+| Scan TCP ports | ✓ | ✓ | ✓ | ✓ |
+| Inspect host | ✓ | ✓ | ✓ | ✓ |
+| Sweep subnet | ✓ | ✓ | ✓ | ✓ |
+| Ping | ✓ | ✓ | ✓ | ✓ |
+| Trace route | ✓ | ✓ | ✓ | – |
+| DNS lookup | ✓ | ✓ | ✓ | ✓ |
+| Reverse DNS | ✓ | ✓ | ✓ | – |
+| mDNS discovery | ✓ | ✓ | ✓ | ✓ |
+| List interfaces | ✓ | ✓ | ✓ | ✓ |
+| Read the ARP table | ✓ | ✓ | ✓ | ✓ |
+| Change the ARP table | ✓ | ✓ | ✓ | – |
+| Packet capture | ✓ | ✓ | ✓ | ✓ |
+| Structured output | ✓ | ✓ | ✓ | ✓ |
+| Result bundles | ✓ | – | – | – |
+| First-run setup | – | ✓ | – | – |
+| Diagnostics | – | ✓ | – | – |
+| MCP service management | – | ✓ | – | – |
+| Completions and man page | – | ✓ | – | – |
+
+✓ available here · – not offered here
+
+### Notes on the dashes
+
+- **Trace route** has no MCP tool. Everything else it needs is in the core,
+  so this is a gap rather than a decision.
+- **Reverse DNS** on the MCP server means asking `dns_lookup` for a `PTR`
+  record, which works but wants the `in-addr.arpa` name rather than an
+  address. The other three take an address directly.
+- **Changing the ARP table** needs administrator rights and edits machine
+  state, which is not something to hand an agent. The desktop app offers
+  clearing only; the CLI and TUI also add and delete single entries.
+- **Result bundles** are the desktop app's own save format, for reopening a
+  run later. The equivalent elsewhere is structured output: `--json` and
+  `--yaml` on the CLI, `/export` in the TUI, JSON-RPC results over MCP.
+- **First-run setup** (`netscli setup`) and **diagnostics**
+  (`netscli doctor`) are two different commands and used to share a row here.
+  Setup is an interactive wizard; doctor is a headless report that works on
+  every build and is the way to find out what your build can do.
+
+### Notes on the ticks
+
+- **Packet capture** needs a build compiled with the feature *and* the system
+  capture library — Npcap on Windows, libpcap elsewhere. No published build
+  has it. See [Installation](/docs/install/#packet-capture).
+- **Structured output** means something different on each surface, which is
+  why it is one row rather than four: the desktop app exports files and
+  result bundles, the CLI takes `--json` and `--yaml`, the TUI exports a
+  session with `/export`, and the MCP server returns JSON-RPC results.
 
 ## Desktop app
 
-The desktop app focuses on interactive network work: tabs, filtering, row selection, details, history, exports, and local status indicators.
+Interactive network work: tabs, filtering, row selection, a details pane,
+history, exports, and local status indicators. It exposes the shared
+operations where a table or a details pane earns its place.
 
-It exposes shared operations where a table or details pane improves the workflow. Shell maintenance workflows such as setup, doctor, completions, manpages, and MCP service management stay in the CLI.
+Shell maintenance — setup, doctor, completions, man pages, MCP service
+management — stays in the CLI, because none of it benefits from a window.
 
-## CLI
+## CLI — `netscli <command>`
 
-The CLI exposes shared network operations plus command-line maintenance workflows:
+Every shared network operation, plus the workflows that only make sense at a
+prompt:
 
-- Structured output through `--json` and `--yaml`.
-- Setup and dependency checks.
-- MCP server launch and service management where supported.
-- Shell completions and manpage generation.
+- `--json` and `--yaml` on every operation.
+- `netscli setup` for the first-run wizard, `netscli doctor` for a headless
+  capability report.
+- `netscli serve` to start the MCP server, and `netscli mcp-service` to
+  manage it as a system service where that is supported.
+- `netscli completions` and `netscli man`.
 
-## TUI
+## TUI — `netscli` with no command
 
-The terminal UI is for keyboard-driven interactive work inside a terminal. It stays close to the CLI operation model while favoring readable summaries and terminal-native navigation. It can export the current session as Markdown or JSON with `/export`.
+The same operations, driven from a terminal with slash commands (`/discover`,
+`/scan`, `/inspect`, and the rest) rather than arguments. It favours readable
+summaries and keyboard navigation, and exports the session as Markdown or
+JSON with `/export`.
 
-## MCP server
+It is the same binary as the CLI, so anything installed for one is installed
+for the other.
 
-The MCP server exposes shared network operations to AI-agent clients. It does not define desktop UI behavior, and desktop app actions do not depend on MCP service-management code.
+## MCP server — `netscli serve`
+
+Exposes the shared operations to AI-agent clients as MCP tools. Also the same
+binary.
+
+Results are bounded before they reach a model: the full probe response is
+dropped, banners and packet summaries are truncated, and an oversized result
+is cut with a count of what was left out. A scanned host's banner is bytes
+that host chose, and a model reads tool output as instructions.
 
 ## Build and runtime availability
 
@@ -57,5 +121,5 @@ Most NetsCLI operations work in the standard published builds. A few capabilitie
 
 - Packet capture runs only on builds that include packet-capture support, and also needs Npcap on Windows or libpcap on Linux/macOS. On the CLI the `pcap` subcommand is absent from standard builds.
 - mDNS discovery is included in the published CLI, desktop app, and MCP server. Library consumers can still build `netscli-core` without the `mdns` feature if they need a leaner dependency set.
-- The desktop app keeps Packet Capture visible even in builds without capture support, and shows setup guidance in place of results. Tools whose feature is genuinely absent from the build, such as mDNS discovery, are hidden.
+- The desktop app keeps Packet Capture visible in builds without capture support — greyed, with an explanation of what it needs — rather than hiding it. A tool that vanishes leaves nowhere to explain why.
 - If a runtime dependency is missing, NetsCLI keeps the rest of the app usable and explains what to install for that feature.


### PR DESCRIPTION
Two of the open items: the matrix should use ticks and dashes, and several of its cells were wrong about *why* something was absent.

### It presented four programs. Three are one binary.

`netscli` with a command is the CLI, with no command it opens the terminal UI, and `netscli serve` starts the MCP server. Installing one installs all three; the desktop app is the only separate download.

That is now stated above the table, because without it a dash in the MCP column reads as "you need another install for that" — which is never true.

### Rows that conflated two things

- **"Setup and doctor"** was one row for two commands: `netscli setup` is an interactive wizard, `netscli doctor` is a headless capability report that works on every build. Split.
- **"ARP neighbor cache"** was one row for reading the table and changing it. The MCP server reads it and deliberately cannot change it — that needs administrator rights and edits machine state. Split, with the reason given.

### Dashes that meant "not applicable", not "missing"

- **Result bundles** are the desktop app's own save format. `--json` on the CLI, `/export` in the TUI and JSON-RPC over MCP are the equivalent, so **Structured output** is a tick on all four with a note on what it means on each.
- **Reverse DNS** over MCP works — `dns_lookup` takes a `PTR` record. What is missing is passing an address directly rather than an `in-addr.arpa` name.

### Dashes that are real gaps, now labelled as such

- **Trace route** has no MCP tool, and everything it needs is already in the core.

### Also corrected

The build-availability section claimed the desktop app hides tools whose feature is absent from the build. Since #259 it greys Packet Capture with an explanation instead — a tool that vanishes leaves nowhere to say why.

The per-surface prose below the table was rewritten to name the actual commands (`netscli setup`, `netscli doctor`, `netscli serve`, `netscli mcp-service`, the TUI's slash commands) rather than describe them abstractly, and the MCP section now mentions that results are bounded before a model sees them.

### Verified from the built page

19 rows · ticks and dashes rendering · legend present · table still inside its horizontal scroll wrapper with no page overflow at 500px or 1440px · `astro check` 0 errors · a11y 0 violations in both themes.

Every cell was checked against the real surfaces rather than the old table: `netscli --help` for the CLI, the TUI's slash-command list, the GUI tool registry, and the MCP `tools/list` names.
