### PR TITLE
Lead with winget, and thin the install panel

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -103,8 +103,8 @@ const { hero, social } = site;
       </div>
     </div>
     <div class="hero-cta-sub">
-      <div class="hero-command has-copy hero-copy" id="hero-package-install" data-copy="winget install fstubner.netscli">
-        <code>winget install fstubner.netscli</code>
+      <div class="hero-command has-copy hero-copy" id="hero-package-install" data-copy={hero.quickInstallAlt}>
+        <code>{hero.quickInstallAlt}</code>
       </div>
       <a class="hero-install-link" href="#install">{hero.installLinkLabel}</a>
     </div>

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -191,6 +191,14 @@ const groups = [
    tint with no padding, on text set in the same face as the code above it.
    It read as a command and hovered like a bar. It is a button now: its own
    box, sized to its label, in the body face. */
+/* Neutral, like the command bars beside it.
+ *
+ * This was accent text on an accent tint inside an accent border -- the
+ * loudest thing in the section, on the row that is the *least* recommended
+ * route: a direct download is unsigned, unverified and unmanaged, while the
+ * package-manager rows above it check a hash. The green was pointing at the
+ * wrong option. It reads as one route among several now, and keeps the
+ * accent for hover and focus so it is still obviously a control. */
 a.install-download{
   display:inline-flex;
   align-items:center;
@@ -201,19 +209,19 @@ a.install-download{
   font-size:.8125rem;
   font-weight:500;
   line-height:1;
-  color:var(--netscli-accent);
+  color:#ccc;
   text-decoration:none;
   padding:8px 14px;
-  border:1px solid rgba(var(--netscli-accent-rgb),.32);
+  border:1px solid rgba(255,255,255,.08);
   border-radius:7px;
-  background:rgba(var(--netscli-accent-rgb),.06);
+  background:rgba(255,255,255,.04);
   transition:background 140ms ease,border-color 140ms ease,color 140ms ease;
 }
 a.install-download:hover,
 a.install-download:focus-visible{
   color:var(--netscli-accent-bright);
-  border-color:rgba(var(--netscli-accent-rgb),.62);
-  background:rgba(var(--netscli-accent-rgb),.14);
+  border-color:rgba(var(--netscli-accent-rgb),.48);
+  background:rgba(var(--netscli-accent-rgb),.10);
 }
 .footer-note{margin-top:14px;font-size:.8125rem;color:#808080}
 .footer-note a{color:var(--netscli-accent);text-decoration:underline;text-underline-offset:3px}

--- a/site/src/data/site-content/hero.ts
+++ b/site/src/data/site-content/hero.ts
@@ -22,7 +22,19 @@ export const hero: Hero = {
     // the feature stays on the page; it just no longer implies the download
     // above it includes it.
     'Discover LAN devices, scan TCP ports, query DNS, trace routes, and inspect hosts from the desktop app, terminal UI, CLI, or MCP server — with packet capture in capture-enabled CLI builds. Each interface calls the same Rust core, so results stay consistent.',
-  quickInstall:
+  // `winget install netscli` leads, and the shell script follows.
+  //
+  // os-tabs.ts already swapped these per-OS at runtime -- Windows visitors
+  // got the winget line and the script moved down. But the SERVER-rendered
+  // default was the `curl … | bash` pipeline, so the most prominent command
+  // on the page was a bash pipeline until JavaScript ran, and stayed one for
+  // anyone without it and for every crawler reading the HTML.
+  //
+  // `netscli`, not `fstubner.netscli`: `Moniker: netscli` is published in the
+  // winget catalog, so the short form resolves. The canonical identifier
+  // stays in the install guide for anyone who wants to be unambiguous.
+  quickInstall: 'winget install netscli',
+  quickInstallAlt:
     'curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash',
   installLinkLabel: 'More install options ↓',
   heroImage: '/assets/tui-discover.png',

--- a/site/src/data/site-content/install.ts
+++ b/site/src/data/site-content/install.ts
@@ -22,21 +22,27 @@ const MACOS_UNSIGNED_HINT = 'Unsigned — right-click → Open on first launch';
  * straight from GitHub Releases with nothing checking it, and was being told
  * otherwise at the moment they did it. The checksums are real and published;
  * this now points at them. */
-const WINDOWS_UNSIGNED_HINT =
-  'Unsigned — SmartScreen may warn; checksums are published with the release';
+const WINDOWS_UNSIGNED_HINT = 'Unsigned — SmartScreen may warn; checksums published';
 
 /* Both of these check the download against a SHA256 in their own manifest
  * and abort on a mismatch, which is the thing the direct-download row cannot
  * do for you. Stated on both rather than only on winget: scoop does it too,
- * and naming one would have implied the other does not. */
-const WINDOWS_MANAGER_HASH_HINT = 'Verifies the download against the hash in its manifest';
+ * and naming one would have implied the other does not.
+ *
+ * Two words, not a sentence. It appears on four rows in a single Windows
+ * panel -- winget and scoop, under both Desktop app and CLI -- and four
+ * copies of "Verifies the download against the hash in its manifest" is most
+ * of what made that panel read as a wall. The full explanation is in the
+ * install guide; here it only has to distinguish these rows from the
+ * download below them. */
+const WINDOWS_MANAGER_HASH_HINT = 'Hash-verified';
 
 export const installByPlatform: Record<Platform, PlatformInstall> = {
   windows: {
     cli: [
       {
         label: 'Winget',
-        command: 'winget install fstubner.netscli',
+        command: 'winget install netscli',
         hint: WINDOWS_MANAGER_HASH_HINT,
       },
       {
@@ -50,15 +56,11 @@ export const installByPlatform: Record<Platform, PlatformInstall> = {
         command:
           'iwr -useb https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.ps1 | iex',
       },
-      {
-        label: 'Cargo',
-        command: 'cargo install netscli',
-      },
     ],
     desktop: [
       {
         label: 'Winget',
-        command: 'winget install fstubner.netscli.gui',
+        command: 'winget install netscli-gui',
         hint: WINDOWS_MANAGER_HASH_HINT,
       },
       {
@@ -84,10 +86,6 @@ export const installByPlatform: Record<Platform, PlatformInstall> = {
         label: 'Install script',
         command:
           'curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash',
-      },
-      {
-        label: 'Cargo',
-        command: 'cargo install netscli',
       },
     ],
     desktop: [
@@ -126,10 +124,6 @@ export const installByPlatform: Record<Platform, PlatformInstall> = {
         label: 'Homebrew',
         command: 'brew tap fstubner/tap && brew install netscli',
       },
-      {
-        label: 'Cargo',
-        command: 'cargo install netscli',
-      },
     ],
     desktop: [
       {
@@ -163,10 +157,6 @@ export const tryCommands: TryCommand[] = [
     command: 'netscli scan router.local -p 22,80,443',
   },
   {
-    comment: 'Resolve DNS records with structured output available',
-    command: 'netscli dns google.com',
-  },
-  {
     comment: 'Expose NetsCLI tools to Claude, Cursor, and other MCP clients',
     command: 'netscli serve',
   },
@@ -180,5 +170,10 @@ export const tryCommands: TryCommand[] = [
 // to point at the top of the install guide, which had no verification steps
 // anywhere on it -- the promise was real (assets are signed) but nobody
 // following it could act on it.
+/* One line, three jobs: the routes this panel no longer lists, the
+ * verification steps, and the packet-capture builds. The panel used to carry
+ * a Cargo row per platform -- the same command three times -- and every
+ * alternative route for every platform, which is what made it read as a wall
+ * rather than a choice. */
 export const installBinariesNote =
-  'Every asset is checksummed and signed with <a href="https://docs.sigstore.dev/cosign/overview/">Sigstore cosign</a> — see <a href="/docs/install/#verifying-a-download">how to verify a download</a>, plus standalone CLI binaries and packet-capture builds.';
+  'Rust users can <code>cargo install netscli</code>. Every asset is checksummed and signed with <a href="https://docs.sigstore.dev/cosign/overview/">Sigstore cosign</a> — see <a href="/docs/install/#verifying-a-download">how to verify a download</a>, plus standalone binaries and packet-capture builds.';

--- a/site/src/data/site-content/types.ts
+++ b/site/src/data/site-content/types.ts
@@ -41,7 +41,12 @@ export interface Hero {
   heading: string;
   subhead: string;
   /** Shell command shown in the hero's highlighted install block. */
+  /** The prominent hero command. Swapped per-OS at runtime by os-tabs.ts;
+   *  this is what a visitor sees before that runs, and what a crawler sees. */
   quickInstall: string;
+  /** The smaller command under it — a genuinely different route, never a
+   *  restatement of the one above. */
+  quickInstallAlt: string;
   /** Jump-to-install link label. */
   installLinkLabel: string;
   /** Path to the hero screenshot. */

--- a/site/src/scripts/landing/os-tabs.ts
+++ b/site/src/scripts/landing/os-tabs.ts
@@ -116,7 +116,10 @@ export function initOsTabs(): void {
     // genuinely different route.
     const heroCommands: Record<OperatingSystem, { primary: string; secondary: string }> = {
       windows: {
-        primary: "winget install fstubner.netscli",
+        // Moniker, matching the hero's server-rendered default. `Moniker:
+        // netscli` is published in the winget catalog alongside the
+        // canonical `fstubner.netscli`, so both resolve.
+        primary: "winget install netscli",
         secondary:
           "iwr -useb https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.ps1 | iex",
       },


### PR DESCRIPTION
Two of the open items: swap the winget and shell-script bars (using `winget install netscli`), and thin an install section that read as a wall.

### The swap had already happened — but only in JavaScript

`os-tabs.ts` picks hero commands per OS, and Windows visitors already got `winget install fstubner.netscli` as the primary bar with the PowerShell script below it. The **server-rendered** default did not: it was `curl … install.sh | bash` as the most prominent command on the page, until a script ran.

So the bash pipeline was the loudest thing on the page for anyone without JavaScript, and for every crawler reading the HTML. The static markup now matches what Windows visitors were already being shown, and the runtime swap still adapts it for macOS and Linux.

### `winget install netscli` — checked, not assumed

I looked at the live catalog rather than trusting the local templates:

```
manifests/f/fstubner/netscli/       Moniker: netscli
manifests/f/fstubner/netscli/gui/   Moniker: netscli-gui
```

Both short forms resolve. The canonical `fstubner.netscli` / `fstubner.netscli.gui` stay in the install guide for anyone who wants to be unambiguous.

> **Worth knowing, found while checking this.** The published catalog holds `0.2.0`, then `v0.2.2`, `v0.2.3`, `v0.2.4`, `v0.2.5`, `v0.2.6` — the `PackageVersion: v0.2.6` prefix bug that #264 fixed **has already shipped five times**. Only the hand-written `0.2.0` and the GUI's `0.2.6` are correct. #264 stops it recurring; it does not clean up what is already there, and the mixed set will affect `winget upgrade` ordering. That needs a decision, not a patch.

### What made the panel dense

Two things, both measurable:

- **Cargo had a row on all three platforms** — the identical `cargo install netscli`, three times. It is one clause in the note under the panel now, beside the verification and packet-capture links.
- **"Verifies the download against the hash in its manifest" appeared four times in a single Windows panel** — winget and scoop, under both *Desktop app* and *CLI*. It is `Hash-verified` now. The full sentence lives in the install guide; on the row it only has to separate those from the direct download below them.

20 install rows → 17 · 6 Try it commands → 5 · 26 copy controls on the page.

### The green download button

Accent text on an accent tint inside an accent border — the loudest control in the section, sitting on the row that is the *least* recommended route. A direct download is unsigned and unverified; the package-manager rows above it check a hash. The colour was pointing at the wrong option.

Neutral now, matching the command bars beside it, with the accent kept for hover and focus so it still reads as a control.

### Verification

`astro check` 0 errors across 54 files · a11y 0 violations in both themes · CSS budget 42 · hero primary/secondary confirmed swapped in the built HTML.
