### PR TITLE
Answer the two search queries the data actually shows

### DIFF
--- a/site/src/data/site-content/faq.ts
+++ b/site/src/data/site-content/faq.ts
@@ -21,17 +21,17 @@ export const faq: FaqItem[] = [
   {
     group: 'Install and updates',
     q: 'How do I install NetsCLI?',
-    a: 'Install the netscli package for the CLI, terminal UI, and MCP server. On Windows, run: winget install fstubner.netscli. On Linux or macOS, run: curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash. For the Windows desktop app, run: winget install fstubner.netscli.gui. With Rust installed you can also run: cargo install netscli. Prebuilt binaries and desktop installers are attached to GitHub releases when available for that platform.',
+    a: 'Install the netscli package for the CLI, terminal UI, and MCP server. On Windows, run: winget install netscli (the full identifier fstubner.netscli also works). On Linux or macOS, run: curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash. For the Windows desktop app, run: winget install netscli-gui. With Rust installed you can also run: cargo install netscli. Prebuilt binaries and desktop installers are attached to GitHub releases when available for that platform.',
     aHtml: `
       <p>Install the <code>netscli</code> package for the CLI, terminal UI, and MCP server:</p>
       <div class="faq-command-list" aria-label="Install commands">
-        <div class="faq-command"><span>Windows</span><code>winget install fstubner.netscli</code></div>
+        <div class="faq-command"><span>Windows</span><code>winget install netscli</code></div>
         <div class="faq-command"><span>Linux/macOS</span><code>curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash</code></div>
         <div class="faq-command"><span>Rust</span><code>cargo install netscli</code></div>
       </div>
       <p>Install the Windows desktop app separately:</p>
       <div class="faq-command-list" aria-label="Desktop app install command">
-        <div class="faq-command"><span>Windows app</span><code>winget install fstubner.netscli.gui</code></div>
+        <div class="faq-command"><span>Windows app</span><code>winget install netscli-gui</code></div>
       </div>
       <p>Prebuilt binaries and desktop installers for Windows, Linux, and macOS are attached to <a href="https://github.com/fstubner/netscli/releases/latest">GitHub releases</a> when available for that platform.</p>
     `,
@@ -87,12 +87,12 @@ export const faq: FaqItem[] = [
   {
     group: 'Install and updates',
     q: 'Is NetsCLI a free network scanner for Windows, macOS, or Linux?',
-    a: 'Yes. NetsCLI is MIT-licensed and free for personal, open-source, and commercial use. Windows users can install the CLI/TUI with `winget install fstubner.netscli` and the desktop app with `winget install fstubner.netscli.gui`. macOS and Linux users can install through the script, Homebrew, Cargo, or packaged release artifacts.',
+    a: 'Yes. NetsCLI is MIT-licensed and free for personal, open-source, and commercial use. Windows users can install the CLI/TUI with `winget install netscli` and the desktop app with `winget install netscli-gui`. macOS and Linux users can install through the script, Homebrew, Cargo, or packaged release artifacts.',
     aHtml: `
       <p>Yes. NetsCLI is MIT-licensed and free for personal, open-source, and commercial use.</p>
       <div class="faq-command-list" aria-label="Package manager commands">
-        <div class="faq-command"><span>Windows CLI/TUI/MCP</span><code>winget install fstubner.netscli</code></div>
-        <div class="faq-command"><span>Windows app</span><code>winget install fstubner.netscli.gui</code></div>
+        <div class="faq-command"><span>Windows CLI/TUI/MCP</span><code>winget install netscli</code></div>
+        <div class="faq-command"><span>Windows app</span><code>winget install netscli-gui</code></div>
         <div class="faq-command"><span>Windows</span><code>scoop bucket add fstubner https://github.com/fstubner/scoop-bucket &amp;&amp; scoop install netscli</code></div>
         <div class="faq-command"><span>macOS</span><code>brew tap fstubner/tap &amp;&amp; brew install netscli</code></div>
         <div class="faq-command"><span>Linux</span><code>curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash</code></div>
@@ -103,10 +103,17 @@ export const faq: FaqItem[] = [
   },
   {
     group: 'Network workflows',
-    q: 'Can NetsCLI replace nmap for simple network scans?',
-    a: 'For host discovery, basic TCP port scans, DNS lookups, and ARP-table inspection on a local network, NetsCLI can cover the simpler cases with direct subcommands and structured output. For advanced service detection, NSE scripts, OS fingerprinting, and raw packet workflows, nmap remains the better tool.',
+    q: 'Can NetsCLI replace nmap, and does it have a TUI?',
+    a: 'NetsCLI covers the simpler cases nmap is often reached for: host discovery, basic TCP port scans, DNS lookups, and ARP-table inspection on a local network, with direct subcommands and structured output. It also ships a terminal UI — run netscli with no arguments to get an interactive, keyboard-driven scanner in the terminal, which nmap itself does not provide. For advanced service detection, NSE scripts, OS fingerprinting, and raw packet workflows, nmap remains the better tool.',
     aHtml:
-      'For host discovery, basic TCP port scans, DNS lookups, and ARP-table inspection on a local network, NetsCLI can cover the simpler cases with direct subcommands and structured output. For advanced service detection, NSE scripts, OS fingerprinting, and raw packet workflows, nmap remains the better tool.',
+      'NetsCLI covers the simpler cases nmap is often reached for: host discovery, basic TCP port scans, DNS lookups, and ARP-table inspection on a local network, with direct subcommands and structured output. It also ships a <a href="#surfaces">terminal UI</a> — run <code>netscli</code> with no arguments to get an interactive, keyboard-driven scanner in the terminal, which nmap itself does not provide. For advanced service detection, NSE scripts, OS fingerprinting, and raw packet workflows, nmap remains the better tool.',
+  },
+  {
+    group: 'Network workflows',
+    q: 'Is there a netscan command for Linux or Windows?',
+    a: 'There is no standard netscan command on Linux, macOS, or Windows — it is not part of any of those systems. People searching for one usually want a command-line network scanner, which is what NetsCLI is: netscli discover lists live hosts on your subnet, netscli scan checks TCP ports on a host, and netscli sweep does both across a range. Several unrelated third-party tools also use the name NetScan, so check which one you mean before installing.',
+    aHtml:
+      '<p>There is no standard <code>netscan</code> command on Linux, macOS, or Windows — it is not part of any of those systems. People searching for one usually want a command-line network scanner, which is what NetsCLI is:</p><div class="faq-command-list" aria-label="Scanning commands"><div class="faq-command"><span>Live hosts</span><code>netscli discover</code></div><div class="faq-command"><span>Ports on a host</span><code>netscli scan router.local -p 22,80,443</code></div><div class="faq-command"><span>Both, across a range</span><code>netscli sweep</code></div></div><p>Several unrelated third-party tools also use the name NetScan, so check which one you mean before installing.</p>',
   },
   {
     group: 'Network workflows',


### PR DESCRIPTION
Reviewed the FAQ against the Search Console export you attached, rather than against intuition about what people search for.

### What the data can and cannot support

486 impressions and 18 clicks over twelve months. That is small enough that most of it is noise — a query with 2 impressions tells you nothing about click-through. Two patterns survive that bar; everything else I left alone and say why below.

### 1. A "netscan" phrasing cluster nobody was answering

Five distinct queries use *netscan* as the word for a command-line network scanner:

| query | impressions | position |
|---|---|---|
| linux netscan | 4 | 47.75 |
| netscan linux | 2 | 39 |
| netscan command | 2 | 45.5 |
| netscan cmd | 2 | 50 |
| network scanner cmd | 1 | 49 |

Eleven impressions ranking 39–50 — because the word appears **nowhere** on the site. Five separate queries with the same shape is a pattern, not a fluke.

New FAQ entry, answered straight: there is no standard `netscan` command on Linux, macOS or Windows, this is the kind of tool people mean, here are the three commands that do it — and several unrelated third-party products use that name, so check which one you mean.

### 2. `nmap tui` — position 5.5, no clicks

The FAQ answered the nmap comparison but never connected it to the terminal UI, which is the half of that query NetsCLI actually satisfies: nmap has no TUI. The question is now *"Can NetsCLI replace nmap, and does it have a TUI?"* and the answer says `netscli` with no arguments opens one.

It also **leads with the subject** now. It began *"For host discovery, basic TCP port scans…"* — these answers are embedded verbatim into `FAQPage` JSON-LD and get quoted a sentence at a time by generative engines, where a sentence that never names its subject is useless.

### 3. Install commands aligned

`winget install netscli` / `winget install netscli-gui`, matching #270, with the canonical identifier noted once.

### What I deliberately did not change

- **Title and description.** They are already reasoned about in `meta.ts` and nothing in the data contradicts them.
- **The other eleven questions.** No signal points at them.
- **Anything for the remaining queries** — `netcli`, `sedcli.exe`, `opencli rust`, `how to open .net cli` are name collisions with unrelated software. Chasing them would mean writing about things this project is not.
- **Per-page work.** 443 of 486 impressions are the landing page; there is not yet enough signal about any docs page to act on.

### Verification

13 FAQ entries, all rendering into the `FAQPage` JSON-LD graph (checked in the built HTML) · `astro check` 0 errors · a11y 0 violations in both themes.
