### PR TITLE
Assert the winget PackageVersion, and write down what shipped wrong

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -195,7 +195,28 @@ jobs:
         shell: bash
         env:
           TAG: ${{ env.TAG }}
-        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          # Assert, do not just strip.
+          #
+          # `${TAG#v}` alone already produced the right answer, and the
+          # catalog still ended up with `v0.2.2` through `v0.2.6` published,
+          # because before that expression existed the tag went through
+          # untouched and nothing downstream objected: winget-pkgs accepted
+          # every one of them. Microsoft's validation does not enforce this,
+          # so it has to be enforced here or not at all.
+          #
+          # Nothing else in the release is shaped like this -- crates.io and
+          # the AUR both take `${TAG#v}` too -- so a tag that fails this
+          # check means the tag itself is wrong, not just this job.
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::PackageVersion '${version}' (from tag '${TAG}') is not MAJOR.MINOR.PATCH." >&2
+            echo "winget-pkgs will accept it anyway and it is permanent once merged." >&2
+            exit 1
+          fi
+          echo "→ PackageVersion ${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Submit netscli to microsoft/winget-pkgs
         uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
@@ -400,7 +421,28 @@ jobs:
         shell: bash
         env:
           TAG: ${{ env.TAG }}
-        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          # Assert, do not just strip.
+          #
+          # `${TAG#v}` alone already produced the right answer, and the
+          # catalog still ended up with `v0.2.2` through `v0.2.6` published,
+          # because before that expression existed the tag went through
+          # untouched and nothing downstream objected: winget-pkgs accepted
+          # every one of them. Microsoft's validation does not enforce this,
+          # so it has to be enforced here or not at all.
+          #
+          # Nothing else in the release is shaped like this -- crates.io and
+          # the AUR both take `${TAG#v}` too -- so a tag that fails this
+          # check means the tag itself is wrong, not just this job.
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::PackageVersion '${version}' (from tag '${TAG}') is not MAJOR.MINOR.PATCH." >&2
+            echo "winget-pkgs will accept it anyway and it is permanent once merged." >&2
+            exit 1
+          fi
+          echo "→ PackageVersion ${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Submit netscli-gui to microsoft/winget-pkgs
         uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -339,6 +339,57 @@ on the directory name, and a mismatch files a conflicting duplicate.
 
 Needs `WINGET_TOKEN` (classic PAT, `public_repo`).
 
+### PackageVersion carries no `v`, and five published versions do
+
+The catalog currently holds, for `fstubner.netscli`:
+
+```
+0.2.0  v0.2.2  v0.2.3  v0.2.4  v0.2.5  v0.2.6
+```
+
+Only `0.2.0` is right. It was submitted by hand; the other five came from the
+`winget` job, which passed the git tag straight through as `PackageVersion`
+before that was fixed. `fstubner.netscli.gui` is unaffected — its single
+`0.2.6` was also hand-submitted.
+
+**This does not break upgrades.** winget normalises a leading `v` when
+comparing, checked against the client rather than assumed:
+
+```
+> winget list --id fstubner.netscli
+netscli  fstubner.netscli  0.2.0  v0.2.6  winget      # offers the upgrade
+
+> winget show fstubner.netscli --version 0.2.6        # resolves v0.2.6
+> winget show fstubner.netscli --version 0.2.9        # finds nothing
+```
+
+What it does do is display a version the project never issued, and put the
+two packages side by side inconsistently in `winget search`:
+
+```
+netscli          fstubner.netscli      v0.2.6
+NetsCLI Desktop  fstubner.netscli.gui  0.2.6
+```
+
+The next correctly-versioned release fixes the display, since `winget search`
+and `winget install` use the latest version. The old directories stay in the
+catalog unless someone removes them.
+
+**Removing them is optional and not automated.** It means a PR to
+`microsoft/winget-pkgs` deleting `manifests/f/fstubner/netscli/v0.2.*/`, which
+breaks anyone pinned to one of those versions with
+`winget install --version`. Weigh that against a tidy version list; doing
+nothing is a defensible answer.
+
+Do **not** set the action's `max-versions-to-keep` to prune them. That deletes
+versions from the public catalog as a side effect of an ordinary release,
+which is not something a release should do quietly.
+
+The `Resolve PackageVersion` step now asserts `MAJOR.MINOR.PATCH` and fails
+the job otherwise. Stripping the `v` was already enough to produce the right
+answer; the assertion exists because winget-pkgs accepted all five bad ones
+without complaint, so nothing downstream will catch a recurrence.
+
 ## AUR
 
 Two packages pushed over SSH by `KSXGitHub/github-actions-deploy-aur`, which


### PR DESCRIPTION
#264 stopped the winget jobs passing the git tag straight through as `PackageVersion`. This adds the assertion that should have caught it in the first place, and records the state of the catalog it left behind.

### I got the impact wrong, and the correction changes what needs doing

I reported that the mixed version set "will affect `winget upgrade` ordering". **It does not.** winget normalises a leading `v` when comparing versions. Checked against the client rather than reasoned about:

```
> winget list --id fstubner.netscli
netscli  fstubner.netscli  0.2.0  v0.2.6  winget      # offers the upgrade

> winget show fstubner.netscli --version 0.2.6        # resolves v0.2.6
> winget show fstubner.netscli --version 0.2.9        # finds nothing
```

The filter is real and the prefix is normalised, so `0.3.1` will compare correctly against `v0.2.6`.

**What is actually wrong is display.** The catalog shows a version this project never issued, and the two packages sit inconsistently beside each other:

```
netscli          fstubner.netscli      v0.2.6
NetsCLI Desktop  fstubner.netscli.gui  0.2.6
```

The next correctly-versioned release fixes that, since `winget search` and `winget install` use the latest version.

### The guard

`Resolve PackageVersion` now requires `MAJOR.MINOR.PATCH` and fails the job otherwise. `${TAG#v}` was already producing the right answer, so this is not belt-and-braces on the arithmetic — it is the check that was missing entirely. **winget-pkgs accepted all five bad versions without complaint**, so nothing downstream will catch a recurrence, and a merged manifest is permanent.

Tested against real inputs:

| input | result |
|---|---|
| `v0.3.1`, `v0.2.6`, `0.3.1`, `v1.0.0`, `v0.4.0-rc.1` | accept |
| `v0.2.6` unstripped, `main`, `latest`, empty | **reject** |

The last two are what a `workflow_dispatch` re-run would have produced before #264 fixed `release-tag`.

### The decision I did not make for you

`docs/PUBLISHING.md` now records the catalog contents, the measurements above, and the one thing left open: removing `manifests/f/fstubner/netscli/v0.2.*/` is a PR against **microsoft/winget-pkgs**, a third-party repo, and it breaks anyone pinned to one of those versions with `winget install --version`. That is your call, not something to automate, and doing nothing is a defensible answer given the display self-corrects on the next release.

It also says explicitly **not** to reach for the action's `max-versions-to-keep` to prune them — that deletes public catalog entries as a side effect of an ordinary release, which is not something a release should do quietly.

All nine workflow files parse. `actionlint` is not installed here, so this is a parse check plus review, and the winget jobs cannot be exercised outside a real publish.
