### PR TITLE
Pass preferences down as one value, and drop App.tsx's size exception

### DIFF
--- a/apps/netscli-gui/src/App.tsx
+++ b/apps/netscli-gui/src/App.tsx
@@ -27,6 +27,9 @@ import { useWorkspace } from './workspace/useWorkspace';
 const APP_VERSION = __APP_VERSION__;
 
 function App() {
+  const preferences = usePreferences();
+  // Only the values App itself reads. The setters exist to build dialog
+  // props, and the dialogs take `preferences` whole now.
   const {
     addressPreference,
     commandBarVisible,
@@ -36,21 +39,10 @@ function App() {
     operationToasts,
     persistentHistory,
     releaseNotifications,
-    setAddressPreference,
-    setCommandBarVisible,
-    setDarkMode,
-    setInteractionToasts,
-    setMaxConcurrentProbes,
-    setOperationToasts,
-    setPersistentHistory,
-    setReleaseNotifications,
-    setTrafficDisplayUnit,
-    setTrafficIndicators,
-    setTrafficPrecision,
     trafficDisplayUnit,
     trafficIndicators,
     trafficPrecision,
-  } = usePreferences();
+  } = preferences;
   const [openMenu, setOpenMenu] = useState<string | null>(null);
   const [contentContextMenu, setContentContextMenu] = useState<{
     cell?: ResultCellContext;
@@ -265,51 +257,30 @@ function App() {
       />
       <AppDialogs
         aboutOpen={aboutOpen}
+        preferences={preferences}
         activeTab={activeTab}
-        addressPreference={addressPreference}
-        animateTrafficArrows={trafficIndicators}
         appVersion={APP_VERSION}
         chooseSaveFolder={chooseSaveFolder}
         clearSaveFolder={clearSaveFolder}
-        commandBarVisible={commandBarVisible}
         contentContextMenu={contentContextMenu}
-        darkMode={darkMode}
         defaultInterface={workspace.defaultInterface}
         fileSavePreferences={fileSavePreferences}
-        interactionToasts={interactionToasts}
         interfaces={workspace.interfaces}
-        maxConcurrentProbes={maxConcurrentProbes}
         onCloseAbout={() => setAboutOpen(false)}
         onCloseContentContextMenu={() => setContentContextMenu(null)}
         onCloseSettings={() => setSettingsOpen(false)}
         onCloseWorkspaceSearch={() => setWorkspaceSearchOpen(false)}
         onConfirmHistoryDisable={() => {
           setPendingHistoryDisable(false);
-          setPersistentHistory(false);
+          preferences.setPersistentHistory(false);
         }}
         onConfirmPendingRun={(tabId) => void workspace.runTab(tabId)}
-        onSetAddressPreference={setAddressPreference}
-        onSetDarkMode={setDarkMode}
-        onSetMaxConcurrentProbes={setMaxConcurrentProbes}
-        onSetTrafficDisplayUnit={setTrafficDisplayUnit}
-        onSetTrafficPrecision={setTrafficPrecision}
-        onToggleCommandBar={() => setCommandBarVisible((prev) => !prev)}
         onToggleFileSaveAskEachTime={() => void toggleFileSaveAskEachTime()}
-        onToggleInteractionToasts={() => setInteractionToasts((prev) => !prev)}
-        onToggleOperationToasts={() => setOperationToasts((prev) => !prev)}
-        onToggleReleaseNotifications={() => setReleaseNotifications((prev) => !prev)}
-        onToggleTrafficArrowAnimation={() => setTrafficIndicators((prev) => !prev)}
-        operationToasts={operationToasts}
         pendingHistoryDisable={pendingHistoryDisable}
         pendingRun={pendingRun}
-        persistentHistory={persistentHistory}
-        releaseNotifications={releaseNotifications}
         setPendingHistoryDisable={setPendingHistoryDisable}
         setPendingRun={setPendingRun}
-        setPersistentHistory={setPersistentHistory}
         settingsOpen={settingsOpen}
-        trafficDisplayUnit={trafficDisplayUnit}
-        trafficPrecision={trafficPrecision}
         workspace={workspace}
         workspaceSearchOpen={workspaceSearchOpen}
       />

--- a/apps/netscli-gui/src/components/shell/AppDialogs.tsx
+++ b/apps/netscli-gui/src/components/shell/AppDialogs.tsx
@@ -7,11 +7,7 @@ import type { ResultCellContext } from '../../tools/types';
 import type { OperationGuard } from '../../workspace/operationGuards';
 import type { FileSavePreferences } from '../../types/netscli';
 import type { WorkspaceModel } from '../../workspace/types';
-import type {
-  AddressPreference,
-  TrafficDisplayUnit,
-  TrafficPrecision,
-} from '../../hooks/usePreferences';
+import type { Preferences } from '../../hooks/usePreferences';
 
 type ContentContextMenuState = {
   cell?: ResultCellContext;
@@ -20,97 +16,59 @@ type ContentContextMenuState = {
 } | null;
 
 type AppDialogsProps = {
+  /** The whole preferences hook value, passed down rather than unpacked:
+   *  every member below the App is either read or set by the settings
+   *  dialog, and naming them one at a time here and again in the call was
+   *  60-odd lines of plumbing across three files. */
+  preferences: Preferences;
   aboutOpen: boolean;
   activeTab: WorkspaceModel['activeTab'];
-  addressPreference: AddressPreference;
-  animateTrafficArrows: boolean;
   appVersion: string;
   chooseSaveFolder: () => Promise<void>;
   clearSaveFolder: () => Promise<void>;
-  commandBarVisible: boolean;
   contentContextMenu: ContentContextMenuState;
-  darkMode: boolean;
   defaultInterface: WorkspaceModel['defaultInterface'];
   fileSavePreferences: FileSavePreferences;
-  interactionToasts: boolean;
   interfaces: WorkspaceModel['interfaces'];
-  maxConcurrentProbes: number;
   onCloseAbout: () => void;
   onCloseContentContextMenu: () => void;
   onCloseSettings: () => void;
   onCloseWorkspaceSearch: () => void;
   onConfirmHistoryDisable: () => void;
   onConfirmPendingRun: (tabId: string) => void;
-  onSetAddressPreference: (value: AddressPreference) => void;
-  onSetDarkMode: (value: boolean) => void;
-  onSetMaxConcurrentProbes: (value: number) => void;
-  onSetTrafficDisplayUnit: (value: TrafficDisplayUnit) => void;
-  onSetTrafficPrecision: (value: TrafficPrecision) => void;
-  onToggleCommandBar: () => void;
   onToggleFileSaveAskEachTime: () => void;
-  onToggleInteractionToasts: () => void;
-  onToggleOperationToasts: () => void;
-  onToggleReleaseNotifications: () => void;
-  onToggleTrafficArrowAnimation: () => void;
-  operationToasts: boolean;
   pendingHistoryDisable: boolean;
   pendingRun: { tabId: string; guard: OperationGuard } | null;
-  persistentHistory: boolean;
-  releaseNotifications: boolean;
   setPendingHistoryDisable: (value: boolean) => void;
   setPendingRun: (value: { tabId: string; guard: OperationGuard } | null) => void;
-  setPersistentHistory: (value: boolean) => void;
   settingsOpen: boolean;
-  trafficDisplayUnit: TrafficDisplayUnit;
-  trafficPrecision: TrafficPrecision;
   workspace: WorkspaceModel;
   workspaceSearchOpen: boolean;
 };
 
 export function AppDialogs({
+  preferences,
   aboutOpen,
   activeTab,
-  addressPreference,
-  animateTrafficArrows,
   appVersion,
   chooseSaveFolder,
   clearSaveFolder,
-  commandBarVisible,
   contentContextMenu,
-  darkMode,
   defaultInterface,
   fileSavePreferences,
-  interactionToasts,
   interfaces,
-  maxConcurrentProbes,
   onCloseAbout,
   onCloseContentContextMenu,
   onCloseSettings,
   onCloseWorkspaceSearch,
   onConfirmHistoryDisable,
   onConfirmPendingRun,
-  onSetAddressPreference,
-  onSetDarkMode,
-  onSetMaxConcurrentProbes,
-  onSetTrafficDisplayUnit,
-  onSetTrafficPrecision,
-  onToggleCommandBar,
   onToggleFileSaveAskEachTime,
-  onToggleInteractionToasts,
-  onToggleOperationToasts,
-  onToggleReleaseNotifications,
-  onToggleTrafficArrowAnimation,
-  operationToasts,
   pendingHistoryDisable,
   pendingRun,
-  persistentHistory,
-  releaseNotifications,
   setPendingHistoryDisable,
   setPendingRun,
-  setPersistentHistory,
   settingsOpen,
-  trafficDisplayUnit,
-  trafficPrecision,
   workspace,
   workspaceSearchOpen,
 }: AppDialogsProps) {
@@ -139,43 +97,23 @@ export function AppDialogs({
       )}
       {settingsOpen && (
         <SettingsDialog
-          animateTrafficArrows={animateTrafficArrows}
-          addressPreference={addressPreference}
-          commandBarVisible={commandBarVisible}
-          darkMode={darkMode}
+          preferences={preferences}
           defaultInterface={defaultInterface}
-          interactionToasts={interactionToasts}
           interfaces={interfaces}
-          maxConcurrentProbes={maxConcurrentProbes}
-          operationToasts={operationToasts}
-          persistentHistory={persistentHistory}
-          releaseNotifications={releaseNotifications}
-          trafficDisplayUnit={trafficDisplayUnit}
           fileSavePreferences={fileSavePreferences}
-          trafficPrecision={trafficPrecision}
           trafficInterfaceName={workspace.trafficInterfaceName}
           onClose={onCloseSettings}
           onChooseSaveFolder={() => void chooseSaveFolder()}
           onClearSaveFolder={() => void clearSaveFolder()}
           onSelectTrafficInterface={workspace.setTrafficInterfaceName}
-          onSetAddressPreference={onSetAddressPreference}
-          onSetDarkMode={onSetDarkMode}
-          onSetMaxConcurrentProbes={onSetMaxConcurrentProbes}
-          onSetTrafficDisplayUnit={onSetTrafficDisplayUnit}
-          onSetTrafficPrecision={onSetTrafficPrecision}
           onToggleFileSaveAskEachTime={onToggleFileSaveAskEachTime}
-          onToggleInteractionToasts={onToggleInteractionToasts}
-          onToggleOperationToasts={onToggleOperationToasts}
           onTogglePersistentHistory={() => {
-            if (persistentHistory) {
+            if (preferences.persistentHistory) {
               setPendingHistoryDisable(true);
               return;
             }
-            setPersistentHistory(true);
+            preferences.setPersistentHistory(true);
           }}
-          onToggleReleaseNotifications={onToggleReleaseNotifications}
-          onToggleCommandBar={onToggleCommandBar}
-          onToggleTrafficArrowAnimation={onToggleTrafficArrowAnimation}
         />
       )}
       {workspaceSearchOpen && (

--- a/apps/netscli-gui/src/components/shell/SettingsDialog.test.tsx
+++ b/apps/netscli-gui/src/components/shell/SettingsDialog.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+//
+// The settings controls reach their setters.
+//
+// These used to arrive as ~22 individual props, each a one-line lambda
+// defined in App and threaded through AppDialogs. They now come from the
+// `preferences` object the dialog receives whole. That is a rewiring of
+// every control in here, and nothing but a rendered click proves a switch
+// still moves anything -- the types would be equally happy with a handler
+// wired to the wrong setter.
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SettingsDialog } from './SettingsDialog';
+import type { Preferences } from '../../hooks/usePreferences';
+
+function preferencesDouble(): Preferences {
+  return {
+    addressPreference: 'ipv4',
+    commandBarVisible: false,
+    darkMode: true,
+    interactionToasts: true,
+    maxConcurrentProbes: 256,
+    operationToasts: true,
+    persistentHistory: false,
+    releaseNotifications: true,
+    trafficDisplayUnit: 'Mbps',
+    trafficIndicators: true,
+    trafficPrecision: 1,
+    setAddressPreference: vi.fn(),
+    setCommandBarVisible: vi.fn(),
+    setDarkMode: vi.fn(),
+    setInteractionToasts: vi.fn(),
+    setMaxConcurrentProbes: vi.fn(),
+    setOperationToasts: vi.fn(),
+    setPersistentHistory: vi.fn(),
+    setReleaseNotifications: vi.fn(),
+    setTrafficDisplayUnit: vi.fn(),
+    setTrafficIndicators: vi.fn(),
+    setTrafficPrecision: vi.fn(),
+  } as unknown as Preferences;
+}
+
+function renderDialog() {
+  const preferences = preferencesDouble();
+  render(
+    <SettingsDialog
+      preferences={preferences}
+      defaultInterface={null}
+      fileSavePreferences={{ ask_each_time: true, default_directory: null } as never}
+      interfaces={[]}
+      trafficInterfaceName={null}
+      onClose={vi.fn()}
+      onChooseSaveFolder={vi.fn()}
+      onClearSaveFolder={vi.fn()}
+      onSelectTrafficInterface={vi.fn()}
+      onToggleFileSaveAskEachTime={vi.fn()}
+      onTogglePersistentHistory={vi.fn()}
+    />,
+  );
+  return preferences;
+}
+
+describe('settings dialog wiring', () => {
+  it('renders against a preferences object rather than a prop per setting', () => {
+    renderDialog();
+
+    expect(screen.getByTestId('settings-dialog')).toBeTruthy();
+  });
+
+  it('the theme switch sets dark mode, inverted from its current value', () => {
+    const preferences = renderDialog();
+
+    fireEvent.click(screen.getByTestId('settings-theme-toggle'));
+
+    // The double starts dark, so the switch must ask for light.
+    expect(preferences.setDarkMode).toHaveBeenCalledWith(false);
+  });
+
+  it('every checkbox row in the dialog reaches a setter', () => {
+    const preferences = renderDialog();
+    // `SettingsSwitch` renders a native checkbox inside a label, so these are
+    // checkboxes rather than `role="switch"` -- only the theme control is the
+    // latter.
+    const rows = screen.getAllByRole('checkbox');
+
+    for (const row of rows) fireEvent.click(row);
+
+    const fired = Object.entries(preferences)
+      .filter(([key]) => key.startsWith('set'))
+      .filter(([, fn]) => (fn as { mock?: { calls: unknown[] } }).mock?.calls.length)
+      .map(([key]) => key)
+      .sort();
+
+    expect(rows.length).toBeGreaterThan(3);
+    // Each row is wired to its own setter, so clicking all of them should
+    // reach several distinct ones -- not the same one repeatedly, which is
+    // what a copy-paste slip in the rewiring would look like.
+    expect(fired.length).toBeGreaterThanOrEqual(4);
+    expect(fired).toContain('setCommandBarVisible');
+  });
+
+});

--- a/apps/netscli-gui/src/components/shell/SettingsDialog.tsx
+++ b/apps/netscli-gui/src/components/shell/SettingsDialog.tsx
@@ -11,48 +11,25 @@ import {
 } from 'lucide-react';
 
 import type { DefaultInterfaceInfo, FileSavePreferences, InterfaceInfo } from '../../types/netscli';
-import type {
-  AddressPreference,
-  MaxConcurrentProbes,
-  TrafficDisplayUnit,
-  TrafficPrecision,
-} from '../../hooks/usePreferences';
+import type { Preferences } from '../../hooks/usePreferences';
 import { useModalFocus } from '../primitives/focus';
 import { NetworkActivitySection } from './NetworkActivitySection';
 import { SettingsNumberInput, SettingsSwitch } from './SettingsControls';
 
 interface SettingsDialogProps {
-  animateTrafficArrows: boolean;
-  addressPreference: AddressPreference;
-  commandBarVisible: boolean;
-  darkMode: boolean;
+  /** Read and written directly; the settings dialog is the one place that
+   *  touches most of these, so unpacking them into props gained nothing. */
+  preferences: Preferences;
   defaultInterface: DefaultInterfaceInfo | null;
   fileSavePreferences: FileSavePreferences;
-  interactionToasts: boolean;
   interfaces: InterfaceInfo[];
-  maxConcurrentProbes: MaxConcurrentProbes;
-  operationToasts: boolean;
-  persistentHistory: boolean;
-  releaseNotifications: boolean;
-  trafficDisplayUnit: TrafficDisplayUnit;
   trafficInterfaceName: string | null;
-  trafficPrecision: TrafficPrecision;
   onClose: () => void;
   onChooseSaveFolder: () => void;
   onClearSaveFolder: () => void;
   onSelectTrafficInterface: (name: string) => void;
-  onSetAddressPreference: (preference: AddressPreference) => void;
-  onSetDarkMode: (enabled: boolean) => void;
-  onSetMaxConcurrentProbes: (value: MaxConcurrentProbes) => void;
-  onSetTrafficDisplayUnit: (unit: TrafficDisplayUnit) => void;
-  onSetTrafficPrecision: (precision: TrafficPrecision) => void;
   onToggleFileSaveAskEachTime: () => void;
-  onToggleInteractionToasts: () => void;
-  onToggleOperationToasts: () => void;
   onTogglePersistentHistory: () => void;
-  onToggleReleaseNotifications: () => void;
-  onToggleCommandBar: () => void;
-  onToggleTrafficArrowAnimation: () => void;
 }
 
 function defaultSaveFolderLabel(): string {
@@ -64,38 +41,30 @@ function defaultSaveFolderLabel(): string {
 }
 
 export function SettingsDialog({
-  animateTrafficArrows,
-  addressPreference,
-  commandBarVisible,
-  darkMode,
+  preferences,
   defaultInterface,
   fileSavePreferences,
-  interactionToasts,
   interfaces,
-  maxConcurrentProbes,
-  operationToasts,
-  persistentHistory,
-  releaseNotifications,
-  trafficDisplayUnit,
   trafficInterfaceName,
-  trafficPrecision,
   onClose,
   onChooseSaveFolder,
   onClearSaveFolder,
   onSelectTrafficInterface,
-  onSetAddressPreference,
-  onSetDarkMode,
-  onSetMaxConcurrentProbes,
-  onSetTrafficDisplayUnit,
-  onSetTrafficPrecision,
   onToggleFileSaveAskEachTime,
-  onToggleInteractionToasts,
-  onToggleOperationToasts,
   onTogglePersistentHistory,
-  onToggleReleaseNotifications,
-  onToggleCommandBar,
-  onToggleTrafficArrowAnimation,
 }: SettingsDialogProps) {
+  const {
+    addressPreference,
+    commandBarVisible,
+    darkMode,
+    interactionToasts,
+    maxConcurrentProbes,
+    operationToasts,
+    persistentHistory,
+    releaseNotifications,
+    trafficDisplayUnit,
+    trafficPrecision,
+  } = preferences;
   const dialogRef = useRef<HTMLElement | null>(null);
 
   useModalFocus({ dialogRef, onClose });
@@ -139,7 +108,7 @@ export function SettingsDialog({
                 data-testid="settings-theme-toggle"
                 role="switch"
                 type="button"
-                onClick={() => onSetDarkMode(!darkMode)}
+                onClick={() => preferences.setDarkMode(!darkMode)}
               >
                 <span className="theme-switch-track">
                   <span className="theme-switch-thumb">{darkMode ? <Moon size={13} /> : <Sun size={13} />}</span>
@@ -152,7 +121,7 @@ export function SettingsDialog({
               label="CLI Command Bar"
               note="Show the equivalent command under the result panes."
               testId="settings-command-bar-toggle"
-              onClick={onToggleCommandBar}
+              onClick={() => preferences.setCommandBarVisible((prev) => !prev)}
             />
           </section>
 
@@ -166,21 +135,21 @@ export function SettingsDialog({
               label="Interaction Toasts"
               note="Confirm copy, export, and preference actions."
               testId="settings-interaction-toasts-toggle"
-              onClick={onToggleInteractionToasts}
+              onClick={() => preferences.setInteractionToasts((prev) => !prev)}
             />
             <SettingsSwitch
               checked={operationToasts}
               label="Operation Toasts"
               note="Report when scans and lookups start, finish, or fail."
               testId="settings-operation-toasts-toggle"
-              onClick={onToggleOperationToasts}
+              onClick={() => preferences.setOperationToasts((prev) => !prev)}
             />
             <SettingsSwitch
               checked={releaseNotifications}
               label="Release Notifications"
               note="Check GitHub for newer NetsCLI releases."
               testId="settings-release-notifications-toggle"
-              onClick={onToggleReleaseNotifications}
+              onClick={() => preferences.setReleaseNotifications((prev) => !prev)}
             />
           </section>
 
@@ -198,7 +167,7 @@ export function SettingsDialog({
                 label="Max Concurrent Probes"
                 testId="settings-max-concurrent-probes"
                 value={maxConcurrentProbes}
-                onChange={onSetMaxConcurrentProbes}
+                onChange={preferences.setMaxConcurrentProbes}
               />
             </div>
           </section>
@@ -256,17 +225,17 @@ export function SettingsDialog({
 
           <NetworkActivitySection
             addressPreference={addressPreference}
-            animateTrafficArrows={animateTrafficArrows}
+            animateTrafficArrows={preferences.trafficIndicators}
             defaultInterface={defaultInterface}
             interfaces={interfaces}
             trafficDisplayUnit={trafficDisplayUnit}
             trafficInterfaceName={trafficInterfaceName}
             trafficPrecision={trafficPrecision}
             onSelectTrafficInterface={onSelectTrafficInterface}
-            onSetAddressPreference={onSetAddressPreference}
-            onSetTrafficDisplayUnit={onSetTrafficDisplayUnit}
-            onSetTrafficPrecision={onSetTrafficPrecision}
-            onToggleTrafficArrowAnimation={onToggleTrafficArrowAnimation}
+            onSetAddressPreference={preferences.setAddressPreference}
+            onSetTrafficDisplayUnit={preferences.setTrafficDisplayUnit}
+            onSetTrafficPrecision={preferences.setTrafficPrecision}
+            onToggleTrafficArrowAnimation={() => preferences.setTrafficIndicators((prev) => !prev)}
           />
         </div>
       </section>

--- a/apps/netscli-gui/src/hooks/usePreferences.ts
+++ b/apps/netscli-gui/src/hooks/usePreferences.ts
@@ -132,6 +132,16 @@ function initialPersistentHistory(): boolean {
   return window.localStorage.getItem('netscli-persistent-history') !== 'off';
 }
 
+/**
+ * Everything the preferences hook owns, as one value.
+ *
+ * Named so it can be passed down whole. App, AppDialogs and SettingsDialog
+ * each used to declare all 22 members as individual props and forward them
+ * one at a time, which is 60-odd lines of plumbing across three files that
+ * says nothing except "these travel together".
+ */
+export type Preferences = ReturnType<typeof usePreferences>;
+
 export function usePreferences() {
   const [darkMode, setDarkMode] = useState(initialDarkMode);
   const [trafficIndicators, setTrafficIndicators] = useState(initialTrafficIndicators);

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -50,19 +50,6 @@ const transitionExceptions = new Map([
     },
   ],
   [
-    'apps/netscli-gui/src/App.tsx',
-    {
-      maxLines: 325,
-      reason:
-        'top-level GUI composition; workspace view extracted. The dialog/preference ' +
-        'wiring split is now overdue -- the file sat at 319 against a 320 cap, so any ' +
-        'change to it failed this guard, and adding three props for the tab context ' +
-        'menu is what surfaced that. `usePreferences()` returns one object that App ' +
-        'destructures into 22 locals and re-passes to AppDialogs one prop at a time; ' +
-        'passing it whole is ~40 lines back and the next thing to do here.',
-    },
-  ],
-  [
     'site/src/scripts/docs-header.ts',
     {
       maxLines: 280,


### PR DESCRIPTION
Follow-up to #273, where I raised `App.tsx`'s size cap from 320 to 325 rather than do this. **That was the wrong call** — the file had been sitting at 319 against a 320 cap, so every change to it failed the guard, and raising a cap to fit a feature is how a cap stops meaning anything.

### What the plumbing looked like

`usePreferences()` returns one object. Then:

- **App** destructured it into 22 locals and passed them to `AppDialogs` a prop at a time
- **AppDialogs** declared all 22 in its props type and forwarded them to `SettingsDialog` a prop at a time
- **ten of them** were one-line lambdas — `() => setCommandBarVisible((prev) => !prev)` and its siblings — defined in App purely to be threaded down to the one component that calls them

Sixty-odd lines across three files saying nothing except "these travel together".

### After

The object is passed whole, typed as `Preferences`. App keeps only the eleven values it reads itself. The toggle lambdas move into `SettingsDialog`, where each was used exactly once.

| file | before | after |
|---|---|---|
| `App.tsx` | 322 | **293** |
| `AppDialogs.tsx` | 219 | **157** |
| `SettingsDialog.tsx` | 275 | **244** |

`App.tsx`'s transition exception is **deleted, not lowered** — at 293 it clears the 300-line limit on its own.

### This rewires every control in the settings dialog

Types would be equally happy with a switch pointed at the wrong setter, so `SettingsDialog.test.tsx` renders the dialog and clicks. Verified against a deliberate mis-wiring — command-bar switch pointed at `setInteractionToasts`:

```
AssertionError: expected [ 'setInteractionToasts', …(3) ] to include 'setCommandBarVisible'
```

### Not verified in the running app

The e2e suite covers these toggles (`shell.mjs` clicks `settings-activity-animation-toggle`), but its build step runs `tauri build` inside a sandbox that cannot see `cargo` on this machine, and `gui-render.yml` is schedule/manual only — so it will not run on this PR either. The unit test above is what stands in for it.

**166 tests**, up from 163. `tsc`, `eslint` and the file-size guard all clean.
