### PR TITLE
Bind the site's dev and preview servers to IPv4

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "astro dev",
+    "dev": "astro dev --host 127.0.0.1",
     "build": "astro build",
-    "preview": "astro preview",
+    "preview": "astro preview --host 127.0.0.1",
     "check": "astro check",
     "check:changelog": "node ./scripts/changelog-dates.mjs",
     "check:css": "node ./scripts/css-shadowing.mjs --max 24",


### PR DESCRIPTION
`npm run preview` printed a URL that did not answer. The server *was* running — bound to the IPv6 loopback only:

```
TCP    [::1]:4321    [::]:0    LISTENING    44248

http://[::1]:4321/      -> 200
http://127.0.0.1:4321/  -> 000   (connection refused)
```

Node 17+ resolves a bare `localhost` IPv6-first and Astro passes that straight to `listen()`, so nothing was reachable over IPv4 — which is what a browser opening `http://localhost:4321` can end up trying, and what every tool here using an explicit `127.0.0.1` *was* trying.

### The repo already knew

Both other places that start these servers pass the flag:

- `.claude/launch.json` → `astro dev --host 127.0.0.1 --port 4322`
- `scripts/a11y.mjs:163` → `spawn(node, [astroCli, 'preview', '--host', host, ...])`, `host` defaulting to `127.0.0.1`

The two scripts a person runs by hand were the only ones without it. That is why the a11y gate has always worked while `npm run preview` looked broken.

### After

```
bind: 127.0.0.1:4321
http://127.0.0.1:4321/  -> 200
http://localhost:4321/  -> 200
```

### One thing that made this harder to see

The local wrapper around `astro preview` daemonises it and returns immediately, and its own `astro preview status` reported **"No preview server is running"** while the process was alive and listening on `[::1]:4321`. The bind address in `netstat -ano` is the thing to trust, not the wrapper's status — noted in the commit message so the next person does not chase it.

`astro check` 0 errors · CSS budget 24 · changelog check · file-size guard.
