### PR TITLE
Revert the preview host flags: Astro's default was already right

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -7,9 +7,9 @@
     "node": ">=22"
   },
   "scripts": {
-    "dev": "astro dev --host 127.0.0.1",
+    "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview --host 127.0.0.1",
+    "preview": "astro preview",
     "check": "astro check",
     "check:changelog": "node ./scripts/changelog-dates.mjs",
     "check:css": "node ./scripts/css-shadowing.mjs --max 24",


### PR DESCRIPTION
#276 made `npm run dev` and `npm run preview` pass `--host 127.0.0.1`. **That was wrong, and it broke the thing it was meant to fix** — you hit `ERR_CONNECTION_REFUSED` in Edge on the server I had just "fixed".

### Windows resolves `localhost` to IPv6 first

```
> ping -n 1 localhost
Pinging Workstation [::1] with 32 bytes of data

> dns.lookup('localhost', { all: true })
::1 (IPv6), 127.0.0.1 (IPv4)
```

Binding IPv4-only means a browser asking for `localhost` finds nothing there. `curl` masked this for me because it falls back to the second address; Edge does not.

Astro's default passes `localhost` to `listen()` and Node resolves it **per-OS** — `::1` on Windows, `127.0.0.1` on most Linux. It adapts to whatever the browser on that machine will ask for. That is the behaviour worth having, and I replaced it with a hardcoded guess.

### The original symptom was mine, not the repo's

My checks curled `127.0.0.1` while the server was on `::1`. The fix for that is to check `localhost` and let it resolve — not to pin the server to one family.

Scripts that genuinely need a fixed address already pass their own and are unaffected:

- `scripts/a11y.mjs:163` → `spawn(node, [astroCli, 'preview', '--host', host, ...])`
- `.claude/launch.json` → `astro dev --host 127.0.0.1 --port 4322`

### Verified after reverting

```
TCP  [::1]:4321  LISTENING
http://localhost:4321/  -> 200
```

a11y gate: 0 violations in both themes. `astro check`: 0 errors.

### Separately — a local trap worth knowing about

The wrapper around `astro preview` on this machine is a **singleton**. Asking for a second one on a different port returns the first and ignores `--port`:

```
Starting Astro preview at http://127.0.0.1:4336
Preview server already running at http://localhost:4321 (pid 3520)
Error: Timed out waiting for http://127.0.0.1:4336
```

Its `astro preview status` also reported *"No preview server is running"* while a server was alive and listening. That is what made the original diagnosis take three attempts, and it is why the a11y gate failed once mid-investigation — it passes cleanly once no other preview is running. **Not** encoded into any repo script, because CI runs stock foreground `astro preview` with no such wrapper; `netstat -ano` and the bind address are what to trust locally.
