### PR TITLE
Say how to run the desktop app, and what happens if you don't

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,9 @@ cargo build -p netscli
 cargo build -p netscli --features pcap   # with packet capture
 cargo build --release -p netscli          # optimized build
 
-# GUI
-cd apps/netscli-gui && npm install && npm run tauri dev
+# GUI -- use one of these two. See the warning below before reaching for
+# `cargo build -p netscli-gui`.
+cd apps/netscli-gui && npm install && npm run tauri:dev
 cd apps/netscli-gui && npm run tauri build    # build installer
 
 # Tests
@@ -61,6 +62,36 @@ cd apps/netscli-gui && npm run lint           # ESLint for the GUI frontend
 # OUI database refresh
 cd scripts && cargo run --bin generate-oui
 ```
+
+### Running the desktop app
+
+**`cargo build -p netscli-gui` does not produce a runnable app.** It produces
+a *dev* binary that loads `devUrl` from `tauri.conf.json` --
+`http://localhost:1420` -- rather than embedding the frontend. Launching
+`target/debug/netscli-gui.exe` on its own opens a window showing the
+browser's connection-error page, with the app's own title replaced by
+`localhost`. There is no message saying why, and the process runs and stays
+up, so it looks like it worked.
+
+Use `npm run tauri:dev`. It runs the Vite dev server and the app together,
+which is why this never bites when you follow the command above.
+
+If you do launch the binary directly -- the render-automation harness in
+`e2e/tauri-render/` does -- Vite has to already be listening on 1420. How to
+tell the difference from outside the window:
+
+```bash
+# Blank window: the page is the dev URL and the title is the host, not the app
+curl -s http://127.0.0.1:<debug-port>/json | grep -o '"title":"[^"]*"'
+#   "title":"localhost"   -> dev server is down
+#   "title":"NetsCLI"     -> the UI is up
+```
+
+One more trap in the same area: a frontend-only change does not make
+`cargo build` relink, so `Finished in 1.35s` after `npm run build` means the
+binary was **not** updated. That does not matter under `tauri:dev`, which
+serves the frontend live -- but it does matter for anything running the
+binary directly.
 
 ## Toolchain
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,19 @@ tool is visible in the GUI, but it shows setup guidance and cannot run unless
 the desktop backend was built with the `pcap` feature and a working
 Npcap/libpcap runtime is installed.
 
-To build from source instead:
+To run it from source:
+
+```bash
+cd apps/netscli-gui
+npm install
+npm run tauri:dev
+```
+
+That starts the Vite dev server and the app together. Building the Tauri
+crate on its own — `cargo build -p netscli-gui` — gives you a binary that
+expects that dev server on `localhost:1420` rather than one with the
+frontend inside it, so running it directly opens an empty window with no
+explanation. Use `tauri:dev`, or build an installer:
 
 ```bash
 cd apps/netscli-gui


### PR DESCRIPTION
`cargo build -p netscli-gui` **does not produce a runnable app.** It produces a *dev* binary that loads `devUrl` from `tauri.conf.json` — `http://localhost:1420` — rather than embedding the frontend. Launching `target/debug/netscli-gui.exe` on its own opens a window showing the browser's connection-error page.

The process starts, stays up, and says nothing. It looks like it worked. Only the window title gives it away:

```
"title":"localhost"   -> dev server is down, window is blank
"title":"NetsCLI"     -> the UI is up
```

### Why this needed writing down

`AGENTS.md` already said `npm run tauri dev`, and that was always the right answer. What it did not say is what the other, obvious-looking command does instead — so there was nothing to correct a wrong guess, and I spent a chunk of today reporting "the app is running" from a process ID while the window was empty.

Both docs now name the trap next to the fix, with the check for telling the two apart from outside the window.

### Also documented

A frontend-only change does not make `cargo build` relink, so `Finished in 1.35s` after `npm run build` means the binary was **not** updated. Irrelevant under `tauri:dev`, which serves the frontend live — but it matters for `e2e/tauri-render/`, which launches the binary directly.

### Verification

Commands checked against `package.json` rather than transcribed from memory: `tauri:dev` → `tauri dev`, `dev` → `vite`, `build` → `tsc -b && vite build`. Fence markers balanced in both files. File-size guard passes.