### PR TITLE
Bring every colour pair to 4.5:1, and keep it there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,13 @@ jobs:
           node-version-file: .nvmrc
       - name: File size guard
         run: node scripts/check-file-size.mjs
+      # Contrast is invisible until someone cannot read something, and the
+      # light theme gets far less use than the dark one, so a regression there
+      # can sit for months. This also fails if design-tokens.json has drifted
+      # from tokens.css, which is the only thing keeping the generated file
+      # honest.
+      - name: Design token contrast
+        run: node scripts/design-tokens.mjs
 
   # Installer scripts aren't exercised by any other job, so lint them
   # directly. shellcheck and PSScriptAnalyzer are both preinstalled on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ its heading and collects entries; the date and the link go on with the tag.
 
 ### Fixed
 
+- **Muted text, and several status colours, were below the readability bar.**
+  Eight colour tokens failed WCAG AA (4.5:1) against surfaces they are actually
+  painted on. The worst were in the light theme, which gets far less use than
+  the dark one and had drifted furthest: the mint accent failed as text on every
+  light surface, down to 3.85:1. In the dark theme the description lines under
+  every setting in the Settings dialog sat at 4.13:1, and the red "Down" label
+  on a hovered interface row at 3.76:1. All 84 foreground/surface combinations
+  now clear 4.5:1, and a check keeps them there.
 - **The interface picker shows the address you would actually use.** Each row
   rendered the first two addresses in whatever order the OS returned them,
   then cut the result off mid-token to fit. On a real machine that meant every

--- a/apps/netscli-gui/design-tokens.json
+++ b/apps/netscli-gui/design-tokens.json
@@ -1,0 +1,14 @@
+{
+  "dark": {
+    "surface-base": "#20242d",
+    "text-main": "#e4e7ef",
+    "text-muted": "#959dae",
+    "accent": "#3eddb0"
+  },
+  "light": {
+    "surface-base": "#eef1f5",
+    "text-main": "#17202b",
+    "text-muted": "#626d7d",
+    "accent": "#007c59"
+  }
+}

--- a/apps/netscli-gui/package.json
+++ b/apps/netscli-gui/package.json
@@ -17,6 +17,7 @@
     "tauri:dev:pcap": "tauri dev --features pcap",
     "test:maintainability": "node ../../scripts/check-file-size.mjs",
     "test:tauri-render": "node e2e/tauri-render.mjs",
+    "test:tokens": "node ../../scripts/design-tokens.mjs",
     "test:unit": "vitest run"
   },
   "dependencies": {

--- a/apps/netscli-gui/src/styles/tokens.css
+++ b/apps/netscli-gui/src/styles/tokens.css
@@ -64,13 +64,13 @@ button {
   --border-strong: #343b49;
   --text-primary: #e4e7ef;
   --text-secondary: #9aa2b3;
-  --text-muted: #7a8499;
+  --text-muted: #959dae;
   --mint: #3eddb0;
   --mint-deep: #0aae7a;
   --focus-ring: color-mix(in srgb, var(--mint), transparent 35%);
   --focus-surface: color-mix(in srgb, var(--mint), transparent 88%);
   --cyan: #1edcff;
-  --red: #ef4456;
+  --red: #f47582;
   --amber: #f5a524;
   --shadow: rgba(0, 0, 0, 0.35);
   --z-form: 260;
@@ -145,14 +145,14 @@ button {
   --border-strong: #c2cad6;
   --text-primary: #17202b;
   --text-secondary: #4d5a6b;
-  --text-muted: #687484;
-  --mint: #008a63;
+  --text-muted: #626d7d;
+  --mint: #007c59;
   --mint-deep: #007052;
   --focus-ring: color-mix(in srgb, var(--mint), transparent 24%);
   --focus-surface: color-mix(in srgb, var(--mint), transparent 90%);
-  --cyan: #0476a8;
+  --cyan: #0473a4;
   --red: #c6293d;
-  --amber: #a96700;
+  --amber: #9b5e00;
   --shadow: rgba(35, 45, 60, 0.14);
 }
 

--- a/scripts/design-tokens.mjs
+++ b/scripts/design-tokens.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+//
+// Reads the desktop app's real colour tokens out of `tokens.css`, checks every
+// foreground against every surface for WCAG contrast, and writes the
+// `design-tokens.json` that the frontend checker reads.
+//
+//   node scripts/design-tokens.mjs           # check (CI)
+//   node scripts/design-tokens.mjs --write   # regenerate the JSON
+//
+// Why generated rather than hand-written: `tokens.css` is the single source of
+// truth and a hand-maintained JSON copy drifts from it. A drifted copy is worse
+// than no copy, because the contrast gate then passes against values that are
+// not what ships -- a green check standing in for an unchecked property.
+//
+// Why the full cross-product rather than an audited list of pairs that real CSS
+// rules combine: an audited list needs updating every time a rule pairs a new
+// colour with a new surface, and the update is exactly what gets forgotten. The
+// cross-product is stricter than reality and needs no maintenance. It is also
+// what caught `--red` on `--bg-selected` at 3.76 -- the "Down" label on a
+// hovered interface row, which an audited list did not have in it.
+//
+// The 4.5:1 bar is WCAG AA for body text. Several of these colours are only
+// ever used at 11px, which is squarely body text; none of them qualify for the
+// 3:1 large-text allowance.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const cssPath = path.join(repoRoot, 'apps/netscli-gui/src/styles/tokens.css');
+const jsonPath = path.join(repoRoot, 'apps/netscli-gui/design-tokens.json');
+
+const THEMES = {
+  dark: '.container',
+  light: '.container.theme-light',
+};
+
+/** Tokens that are painted as text or as an icon on top of a surface. */
+const FOREGROUNDS = ['text-primary', 'text-secondary', 'text-muted', 'mint', 'cyan', 'red', 'amber'];
+/** Tokens used as a background behind that text. */
+const SURFACES = ['bg-body', 'bg-base', 'bg-elevated', 'bg-input', 'bg-toolbar', 'bg-selected'];
+
+/**
+ * The keys the frontend checker requires, mapped onto this app's names.
+ *
+ * `surface-base` is deliberately the *tightest* surface per theme rather than
+ * the nominal base one: bg-elevated is the lightest dark surface and bg-body
+ * the darkest light one, so each is where contrast is worst. Mapping the easy
+ * surface would let the gate pass while the dialog it actually ships stayed
+ * unreadable -- bg-base scored text-muted at 4.54 while bg-elevated, the
+ * settings dialog's own background, was at 4.13.
+ */
+const CHECKER_KEYS = {
+  dark: { 'surface-base': 'bg-elevated', 'text-main': 'text-primary', 'text-muted': 'text-muted', accent: 'mint' },
+  light: { 'surface-base': 'bg-body', 'text-main': 'text-primary', 'text-muted': 'text-muted', accent: 'mint' },
+};
+
+function parseTokens(css, selector) {
+  // Match the selector's own block. The escape matters: `.container` would
+  // otherwise also match `.container.theme-light` and silently read the wrong
+  // theme's values.
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const block = new RegExp(`^${escaped}\\s*\\{([^}]*)\\}`, 'm').exec(css);
+  if (!block) throw new Error(`No rule for ${selector} in tokens.css`);
+  const tokens = {};
+  for (const [, name, value] of block[1].matchAll(/--([a-z0-9-]+):\s*(#[0-9a-fA-F]{3,8})\s*;/g)) {
+    tokens[name] = value.toLowerCase();
+  }
+  return tokens;
+}
+
+function relativeLuminance(hex) {
+  const channels = hex.replace('#', '').match(/../g).map((pair) => {
+    const value = parseInt(pair, 16) / 255;
+    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrast(a, b) {
+  const [x, y] = [relativeLuminance(a), relativeLuminance(b)];
+  return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
+}
+
+const css = fs.readFileSync(cssPath, 'utf8');
+const themes = Object.fromEntries(
+  Object.entries(THEMES).map(([name, selector]) => [name, parseTokens(css, selector)]),
+);
+
+// Light inherits from the dark block, so only overridden tokens are restated.
+themes.light = { ...themes.dark, ...themes.light };
+
+const failures = [];
+let checked = 0;
+for (const [theme, tokens] of Object.entries(themes)) {
+  for (const fg of FOREGROUNDS) {
+    for (const bg of SURFACES) {
+      if (!tokens[fg] || !tokens[bg]) {
+        failures.push(`${theme}: missing token --${tokens[fg] ? bg : fg}`);
+        continue;
+      }
+      checked += 1;
+      const ratio = contrast(tokens[fg], tokens[bg]);
+      if (ratio < 4.5) {
+        failures.push(`${theme}: --${fg} (${tokens[fg]}) on --${bg} (${tokens[bg]}) = ${ratio.toFixed(2)} < 4.5`);
+      }
+    }
+  }
+}
+
+const generated = Object.fromEntries(
+  Object.entries(CHECKER_KEYS).map(([theme, mapping]) => [
+    theme,
+    Object.fromEntries(Object.entries(mapping).map(([key, token]) => [key, themes[theme][token]])),
+  ]),
+);
+const serialized = `${JSON.stringify(generated, null, 2)}\n`;
+
+if (process.argv.includes('--write')) {
+  fs.writeFileSync(jsonPath, serialized);
+  console.log(`Wrote ${path.relative(repoRoot, jsonPath)}`);
+} else if (!fs.existsSync(jsonPath)) {
+  failures.push('design-tokens.json is missing; run: node scripts/design-tokens.mjs --write');
+} else if (fs.readFileSync(jsonPath, 'utf8') !== serialized) {
+  failures.push(
+    'design-tokens.json is out of date with tokens.css; run: node scripts/design-tokens.mjs --write',
+  );
+}
+
+if (failures.length > 0) {
+  console.error('Design token check failed:');
+  for (const failure of failures) console.error(`  ${failure}`);
+  process.exitCode = 1;
+} else {
+  console.log(`Design tokens OK: ${checked} contrast pairs >= 4.5:1 across ${Object.keys(themes).length} themes.`);
+}


### PR DESCRIPTION
`F-tokens-contrast` had been sitting at `not_evaluated` because the app has no `design-tokens.json`. Extracting one turned out not to be paperwork: **eight tokens fail WCAG AA against surfaces they are actually painted on.**

### What was measured

Not the theoretical cross-product — these are pairs real CSS rules put together:

| Theme | Pair | Ratio | Where you see it |
| --- | --- | --- | --- |
| dark | `--text-muted` on `--bg-elevated` | **4.13** | the description line under every setting in the Settings dialog |
| dark | `--text-muted` on `--bg-selected` | **3.36** | muted text on a hovered/selected row |
| dark | `--red` on `--bg-selected` | **3.76** | the `Down` label on a hovered interface row |
| light | `--mint` on `--bg-selected` | **3.88** | the accent, as text — it failed on *every* light surface |
| light | `--text-muted` on `--bg-body` | **4.19** | |
| light | `--amber` on `--bg-base` | **4.34** | |
| light | `--cyan` on `--bg-body` | **4.45** | |

The light theme had drifted furthest, which is what you would expect of the theme nobody looks at. **Two of these are in code merged earlier today** (#282): the picker's address line is `--text-muted` on the dialog background, and the red `Down` label is exactly what a hovered down interface renders.

### The fix

Each token moves in **lightness only** — hue and saturation untouched, so the palette reads the same. Values are the minimum that clears 4.6:1 against every surface, found by search rather than by taste. All 84 foreground×surface combinations now clear 4.5:1.

### The guard

`scripts/design-tokens.mjs` reads `tokens.css`, checks the cross-product, and generates `design-tokens.json`. Runs in CI and as `npm run test:tokens`.

Two decisions worth arguing with:

- **The JSON is generated, never hand-written.** `tokens.css` is the single source of truth; a hand-maintained copy drifts, and a drifted copy is *worse than none* — the contrast gate then passes against values that are not what ships. The check fails if the committed JSON no longer matches its source. (`site/design-tokens.json` is hand-written and has this defect; it should get the same treatment separately.)
- **`surface-base` maps to the tightest surface per theme**, not the nominal base one. `--bg-base` scored `--text-muted` at 4.54 while `--bg-elevated` — the Settings dialog's own background — was at 4.13. Mapping the easy surface would have passed the gate with the dialog still unreadable.

The **cross-product** is checked rather than an audited list of real pairs. An audited list needs updating whenever a rule pairs a new colour with a new surface, and that update is what gets forgotten. It is stricter than reality, currently satisfied, and needs no maintenance — and it is what found `--red` on `--bg-selected`, which was not on my hand-written list.

### Verification

- **84 pairs ≥ 4.5:1** across both themes.
- **Sabotage-checked**: restoring the old `--text-muted` makes the guard fail with all three of its dark-theme pairs named, *and* flags the JSON as out of date. Restored, green again.
- The frontend checker now reports **SHIP** — `F-tokens-contrast: 4 pair(s) >= 4.5:1 across 2 theme(s)`, up from `not_evaluated`.
- 184 unit tests, `tsc` exit 0, `eslint` clean, file-size guard clean, full Tauri render suite green (it asserts themes, and these are colour changes).
