### PR TITLE
Compare the token JSON with line endings normalised

### DIFF
--- a/scripts/design-tokens.mjs
+++ b/scripts/design-tokens.mjs
@@ -117,12 +117,19 @@ const generated = Object.fromEntries(
 );
 const serialized = `${JSON.stringify(generated, null, 2)}\n`;
 
+// Compared with line endings normalised, not byte for byte. `.gitattributes`
+// sets `* text=auto`, so this file is checked out CRLF on Windows and LF on the
+// Linux runner while the generator always emits LF. A byte comparison therefore
+// passed CI and failed on every Windows working copy -- a guard that is green
+// where nobody reads it and red where the maintainer works is worse than none.
+const normalise = (text) => text.replace(/\r\n/g, '\n');
+
 if (process.argv.includes('--write')) {
   fs.writeFileSync(jsonPath, serialized);
   console.log(`Wrote ${path.relative(repoRoot, jsonPath)}`);
 } else if (!fs.existsSync(jsonPath)) {
   failures.push('design-tokens.json is missing; run: node scripts/design-tokens.mjs --write');
-} else if (fs.readFileSync(jsonPath, 'utf8') !== serialized) {
+} else if (normalise(fs.readFileSync(jsonPath, 'utf8')) !== normalise(serialized)) {
   failures.push(
     'design-tokens.json is out of date with tokens.css; run: node scripts/design-tokens.mjs --write',
   );


### PR DESCRIPTION
The design-token guard added in #283 **passes CI and fails on every Windows working copy.** I hit it on `main` immediately after merging.

`.gitattributes` sets `* text=auto` and `core.autocrlf` is `true`, so `design-tokens.json` is checked out **CRLF** on Windows and **LF** on the Ubuntu runner, while the generator always writes LF. The byte-for-byte comparison therefore reports the file as out of date on the maintainer's own machine, and green where nobody is looking:

```
$ node scripts/design-tokens.mjs          # on main, Windows
Design token check failed:
  design-tokens.json is out of date with tokens.css; run: node scripts/design-tokens.mjs --write
```

That is the exact failure the script's own header argues against, one layer up. A check that is green where it is read and red where the work happens doesn't just fail to help — it teaches people to ignore it.

The comparison now normalises line endings. Writing is unchanged (LF; git converts on checkout as configured).

### Verification

| file | result |
| --- | --- |
| CRLF copy (14 CRLF, 0 LF) | exit 0 — passes |
| LF copy (0 CRLF, 14 LF) | exit 0 — passes |
| CRLF copy with one drifted value | exit 1 — **still caught** |
| LF copy with one drifted value | exit 1 — **still caught** |

The last two matter: normalising must not make the check lenient about real drift. It doesn't — a `#959dae` → `#7a8499` change is reported under both.
