### PR TITLE
Walk the tab strip, and record the keyboard bug it turned up

### DIFF
--- a/ux-walkthrough.md
+++ b/ux-walkthrough.md
@@ -58,9 +58,15 @@ questions you ask once discovery has told you an address exists.
 ## Managing tabs
 
 Each tool opens in a tab, and the strip is the only place they can be
-reordered or closed. Walked at 1100x800 with three tabs open — one
-`Discover 192.168.1.0/24` and two `Scan 127.0.0.1` — because the disabled
-states below only appear once a tab has neighbours on both sides.
+reordered or closed. Walked at 1100x800 with three tabs open, which the strip
+labels `Discover: 192.168.1.0/24`, `Scan: 127.0.0.1 #2` and
+`Scan: 127.0.0.1 #3` — three because the disabled states below only appear
+once a tab has neighbours on both sides.
+
+Those numbers are worth reading before the steps: a tab whose identifier is
+shared with another gets `#` and its **position in the strip**, not its place
+among the duplicates. So the first duplicate here is `#2`, there is no `#1`,
+and reordering renames tabs. See Known gaps.
 
 1. **Drag a tab to reorder it.** Press on a tab and move sideways; past about
    5px of travel the press becomes a drag. The strip reorders **live** —
@@ -123,6 +129,16 @@ Recorded so an acceptance pass does not report them as new:
   verify interaction findings both ways before believing either.
 - The MSI has never been tested on a clean machine without WebView2
   preinstalled.
+- **Reordering renames tabs, and the numbers can end up non-contiguous.**
+  Duplicate tabs are numbered by their position in the strip rather than by
+  which duplicate they are (`tabDisplay.ts`, `#${index + 1}`), so the number
+  is not a name — it moves when anything around it moves. Observed: from
+  `[Discover: 192.168.1.0/24, Scan: 127.0.0.1 #2, Scan: 127.0.0.1 #3]`,
+  moving the Discover tab one place right gives
+  `[Scan: 127.0.0.1 #1, Discover: 192.168.1.0/24, Scan: 127.0.0.1 #3]` — the
+  tab that was `#2` is now `#1`, and the two duplicates read `#1` and `#3`
+  with no `#2` between them. A drag is the most likely way to hit this, which
+  makes it awkward for the section above.
 - **Ctrl+Shift+Arrow leaves focus behind.** The tab moves, but focus stays on
   the position it left, so a second press moves whatever slid into that slot
   instead of continuing to move the same tab — two tabs ping-pong. Observed

--- a/ux-walkthrough.md
+++ b/ux-walkthrough.md
@@ -55,6 +55,42 @@ questions you ask once discovery has told you an address exists.
 7. **Take the results away.** Export JSON or CSV, copy selected rows, or
    save a result bundle.
 
+## Managing tabs
+
+Each tool opens in a tab, and the strip is the only place they can be
+reordered or closed. Walked at 1100x800 with three tabs open — one
+`Discover 192.168.1.0/24` and two `Scan 127.0.0.1` — because the disabled
+states below only appear once a tab has neighbours on both sides.
+
+1. **Drag a tab to reorder it.** Press on a tab and move sideways; past about
+   5px of travel the press becomes a drag. The strip reorders **live** —
+   crossing a neighbour's midpoint swaps them while the button is still down,
+   so the order under the cursor is the order you get. Observed: from
+   `[Discover, Scan, Scan]`, dragging the first tab past the second gives
+   `[Scan, Discover, Scan]` while still held, and releasing keeps it.
+
+   The strip's own drag-to-scroll still applies to the space around the tabs,
+   and the wheel scrolls either way. Grabbing a tab reorders it instead,
+   because otherwise there is no gesture left for the thing a tab drag is
+   expected to do.
+2. **A cancelled drag puts the tab back.** A drag the system interrupts
+   (`pointercancel`) returns to the order before the press, not to wherever
+   the gesture died — by then the tab has usually moved several times.
+   Observed: dragged to `[Discover, Scan, Scan]`, cancelled, back to
+   `[Scan, Discover, Scan]`.
+3. **Ctrl+Shift+Left/Right moves the focused tab** one place, so reordering is
+   not pointer-only. It stops at the ends rather than wrapping. Plain
+   Left/Right moves the *selection* instead and does wrap: from the last tab,
+   Right selects the first. See Known gaps — focus does not currently follow
+   the tab it moved.
+4. **Right-click a tab for the close menu**: Close, Close others, Close to the
+   right, Close to the left, then Close all after a separator. Items that
+   would do nothing are disabled rather than hidden, so the menu keeps the
+   same shape as you move along the strip. Observed on the first of three
+   tabs, "Close to the left" is disabled; on the last, "Close to the right"
+   is. With a single tab open, others / right / left are all disabled while
+   Close and Close all stay enabled.
+
 ## States
 
 Each of these is a real state the app can be in, and each is worth
@@ -71,6 +107,9 @@ exercising deliberately.
 | **Completion, tab in background** | A toast carrying an "Open tab" action, *only with operation toasts enabled* — which is not the default. At defaults this state is silent, and that is correct. |
 | **Completion, tab in foreground** | No toast. The result arriving in the table is the signal; repeating it teaches people to ignore toasts. |
 | **Preferences at defaults** | Toasts off; concurrency 256; opens on Discover. A profile left at 1 probe by the pre-0.3.1 defect is repaired once, on upgrade. |
+| **Tab dragged, button still down** | The strip has already reordered and the dragged tab is faded in its new slot. Nothing is committed until release, but nothing is hidden either — what you see is what you will get. |
+| **Drag cancelled** | The order returns to what it was before the press. |
+| **No tabs open** — the last tab closed, or Close all | The workspace shows "No Tabs Open" with "Choose Scan" and "Choose Tool" actions. Closing everything is a legitimate state, not a blank window. |
 
 ## Known gaps
 
@@ -84,6 +123,15 @@ Recorded so an acceptance pass does not report them as new:
   verify interaction findings both ways before believing either.
 - The MSI has never been tested on a clean machine without WebView2
   preinstalled.
+- **Ctrl+Shift+Arrow leaves focus behind.** The tab moves, but focus stays on
+  the position it left, so a second press moves whatever slid into that slot
+  instead of continuing to move the same tab — two tabs ping-pong. Observed
+  from `[Discover, Scan, Scan]`: one press gives `[Scan, Discover, Scan]` with
+  focus still on index 0, and the next press undoes it. Reproduced with both
+  synthetic and native key events, so it is not the harness artifact described
+  above. `tabStripKeyboard.ts` and the pull request that added it both state
+  that focus follows the tab so a repeated press keeps moving the same one;
+  that is the intent, not the behaviour.
 
 ---
 

--- a/ux-walkthrough.md
+++ b/ux-walkthrough.md
@@ -85,10 +85,14 @@ and reordering renames tabs. See Known gaps.
    Observed: dragged to `[Discover, Scan, Scan]`, cancelled, back to
    `[Scan, Discover, Scan]`.
 3. **Ctrl+Shift+Left/Right moves the focused tab** one place, so reordering is
-   not pointer-only. It stops at the ends rather than wrapping. Plain
-   Left/Right moves the *selection* instead and does wrap: from the last tab,
-   Right selects the first. See Known gaps — focus does not currently follow
-   the tab it moved.
+   not pointer-only. Focus travels with the tab, so a repeated press walks the
+   same tab down the strip rather than swapping a pair back and forth. It stops
+   at the ends rather than wrapping. Plain Left/Right moves the *selection*
+   instead and does wrap: from the last tab, Right selects the first.
+
+   Observed with native key events, from `[Discover, Scan #2, Scan #3]` with
+   Discover focused: one press gives `[Scan, Discover, Scan]` with focus on
+   index 1, a second gives `[Scan, Scan, Discover]` with focus on index 2.
 4. **Right-click a tab for the close menu**: Close, Close others, Close to the
    right, Close to the left, then Close all after a separator. Items that
    would do nothing are disabled rather than hidden, so the menu keeps the
@@ -139,15 +143,6 @@ Recorded so an acceptance pass does not report them as new:
   tab that was `#2` is now `#1`, and the two duplicates read `#1` and `#3`
   with no `#2` between them. A drag is the most likely way to hit this, which
   makes it awkward for the section above.
-- **Ctrl+Shift+Arrow leaves focus behind.** The tab moves, but focus stays on
-  the position it left, so a second press moves whatever slid into that slot
-  instead of continuing to move the same tab — two tabs ping-pong. Observed
-  from `[Discover, Scan, Scan]`: one press gives `[Scan, Discover, Scan]` with
-  focus still on index 0, and the next press undoes it. Reproduced with both
-  synthetic and native key events, so it is not the harness artifact described
-  above. `tabStripKeyboard.ts` and the pull request that added it both state
-  that focus follows the tab so a repeated press keeps moving the same one;
-  that is the intent, not the behaviour.
 
 ---
 


### PR DESCRIPTION
The desktop walkthrough covered launching, running, reading and exporting a result, but said nothing about reordering or closing tabs — so the acceptance gate structurally could not catch a regression in any of it.

Written the way the rest of the file claims to be: **by driving the running app and recording what it did**, not by reading the components I wrote. Every figure quoted is from a run at 1100x800 with three tabs open (`Discover 192.168.1.0/24` and two `Scan 127.0.0.1`) — three because the disabled menu states only appear once a tab has neighbours on both sides.

### It turned up a defect

**`Ctrl+Shift+Arrow` leaves focus behind.** The tab moves, but focus stays on the position it left, so a second press moves whatever slid into that slot instead of continuing to move the same tab. Two tabs ping-pong:

```
start                      [Discover, Scan, Scan]   focus index 0 (Discover)
native Ctrl+Shift+Right #1 [Scan, Discover, Scan]   focus index 0 (Scan)
native Ctrl+Shift+Right #2 [Discover, Scan, Scan]   focus index 0 (Discover)
```

Reproduced with **both synthetic and native key events**, so it is not the selenium artifact this file already warns about — that was worth checking, because the file's own Known gaps section says a synthetic result can mislead in exactly this way.

`tabStripKeyboard.ts` and #281 both state that focus follows the tab so a repeated press keeps moving the same one. That is the intent, not the behaviour. **Recorded under Known gaps rather than fixed here**, so the fix gets reviewed on its own rather than riding along in a docs change.

### What else got written down, all observed

- The strip reorders **live**, not on release: crossing a neighbour's midpoint swaps them while the button is still down.
- A **cancelled** drag reverts to the order before the press, not to wherever the gesture died.
- **Plain** arrows move the selection and **wrap** (from the last tab, Right selects the first); **Ctrl+Shift** moves the tab and **clamps** at the ends.
- The close menu is Close / Close others / Close to the right / Close to the left / Close all, and **disables rather than hides** items that would do nothing — first of three has "Close to the left" disabled, last has "Close to the right", a lone tab has all three disabled.
- **Closing every tab** lands on "No Tabs Open" with "Choose Scan" and "Choose Tool" — a legitimate state, not a blank window.

Three new rows in the States table cover the mid-drag, cancelled-drag and no-tabs states.

### Note on the gate

`accept-check.js` still reports CONDITIONAL, and this PR does not change that: `A-independent` is `not_evaluated` because I wrote the code being walked. `A-ux-walkthrough` passes. `D-frontend` reads `not_evaluated` at the repository root because there is no `package.json` there — scoped to `apps/netscli-gui` the frontend checker reports SHIP. That root-scoping artifact is worth fixing separately.
