### PR TITLE
Let focus travel with the tab it moved

### DIFF
--- a/apps/netscli-gui/src/components/shell/TabStrip.a11y.test.tsx
+++ b/apps/netscli-gui/src/components/shell/TabStrip.a11y.test.tsx
@@ -4,7 +4,8 @@
 // role, no tabIndex, and no tab-switching shortcut anywhere in the app — so
 // they could not be reached or operated by keyboard at all.
 
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { TabStrip } from './TabStrip';
@@ -127,5 +128,90 @@ describe('tab strip keyboard access', () => {
     screen.getAllByRole('tab')[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
     expect(onSelectTab).toHaveBeenCalledWith(tabs[1].id);
     expect(onMoveTab).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The strip with real reordering, which `renderStrip` cannot do: its
+ * `onMoveTab` is a mock, so the tabs never actually move and anything that
+ * depends on the re-render -- focus, most of all -- is invisible to it. That
+ * is why "moves the focused tab with Ctrl+Shift+Arrow" above passed while
+ * focus was being left behind.
+ */
+function StatefulStrip() {
+  const [tabs, setTabs] = useState(() => [createTab('scan'), createTab('arp'), createTab('dns')]);
+  const [activeTabId, setActiveTabId] = useState(() => tabs[0].id);
+  return (
+    <TabStrip
+      tabs={tabs}
+      activeTabId={activeTabId}
+      openMenu={null}
+      toolCapabilities={{} as never}
+      onAddScanTab={vi.fn()}
+      onAddToolTab={vi.fn()}
+      onCloseAllTabs={vi.fn()}
+      onCloseOtherTabs={vi.fn()}
+      onCloseTab={vi.fn()}
+      onCloseTabsBeside={vi.fn()}
+      onMoveTab={(tabId, toIndex) => {
+        setTabs((previous) => {
+          const from = previous.findIndex((tab) => tab.id === tabId);
+          if (from < 0) return previous;
+          const next = [...previous];
+          const [moved] = next.splice(from, 1);
+          next.splice(toIndex, 0, moved);
+          return next;
+        });
+      }}
+      onSelectTab={setActiveTabId}
+      setOpenMenu={vi.fn()}
+    />
+  );
+}
+
+describe('moving a tab with the keyboard', () => {
+  const move = (element: HTMLElement, key: string) =>
+    act(() => {
+      element.dispatchEvent(
+        new KeyboardEvent('keydown', { key, ctrlKey: true, shiftKey: true, bubbles: true }),
+      );
+    });
+
+  it('carries focus with the tab, so a repeated press keeps moving the same one', () => {
+    render(<StatefulStrip />);
+    const before = screen.getAllByRole('tab').map((tab) => tab.getAttribute('aria-label'));
+    const moved = screen.getAllByRole('tab')[0];
+    moved.focus();
+
+    move(moved, 'ArrowRight');
+
+    const afterOne = screen.getAllByRole('tab');
+    expect(afterOne.map((tab) => tab.getAttribute('aria-label'))).toEqual([
+      before[1], before[0], before[2],
+    ]);
+    // The whole point: focus is on the tab that moved, not on the slot it left.
+    expect(document.activeElement).toBe(moved);
+    expect(afterOne[1]).toBe(moved);
+
+    // Pressing again must carry the same tab onward rather than swapping the
+    // pair back and forth, which is what happens when focus stays put.
+    move(document.activeElement as HTMLElement, 'ArrowRight');
+
+    const afterTwo = screen.getAllByRole('tab');
+    expect(afterTwo.map((tab) => tab.getAttribute('aria-label'))).toEqual([
+      before[1], before[2], before[0],
+    ]);
+    expect(afterTwo[2]).toBe(moved);
+  });
+
+  it('leaves focus alone at the end of the strip, where there is no move to make', () => {
+    render(<StatefulStrip />);
+    const last = screen.getAllByRole('tab')[2];
+    last.focus();
+
+    move(last, 'ArrowRight');
+
+    expect(screen.getAllByRole('tab')[2]).toBe(last);
+    expect(document.activeElement).toBe(last);
   });
 });

--- a/apps/netscli-gui/src/components/shell/tabStripKeyboard.ts
+++ b/apps/netscli-gui/src/components/shell/tabStripKeyboard.ts
@@ -47,10 +47,16 @@ export function handleTabStripKeyDown(
 
     event.preventDefault();
     onMoveTab(tab.id, to);
-    // Follow the tab to its new slot, so a repeated press keeps moving the
-    // same one rather than whatever landed under the focus.
-    const sibling = event.currentTarget.parentElement?.children[to];
-    if (sibling instanceof HTMLElement) sibling.focus();
+    // Focus is deliberately left alone. It is already on this tab's own
+    // element, and the strip is keyed by tab id, so React reorders by moving
+    // that node rather than recreating it -- focus travels with the tab for
+    // free.
+    //
+    // This used to focus `parentElement.children[to]`, which ran before React
+    // had re-rendered and so read the pre-move DOM: it grabbed the neighbour,
+    // the tab about to slide into the slot being vacated. The effect was the
+    // exact opposite of the intent -- focus stuck to the index, two tabs
+    // ping-ponged, and a repeated press never carried one tab down the strip.
     return;
   }
 


### PR DESCRIPTION
`Ctrl+Shift+Arrow` moved the tab but left focus on the index it came from, so a second press moved whatever had slid into that slot. Two tabs ping-ponged instead of one walking down the strip:

```
start                [Discover, Scan, Scan]  focus index 0 (Discover)
Ctrl+Shift+Right #1  [Scan, Discover, Scan]  focus index 0 (Scan)
Ctrl+Shift+Right #2  [Discover, Scan, Scan]  focus index 0 (Discover)
```

### The focus-follow code was what broke focus-follow

```js
onMoveTab(tab.id, to);
const sibling = event.currentTarget.parentElement?.children[to];
if (sibling instanceof HTMLElement) sibling.focus();
```

That runs **synchronously, before React re-renders**, so `children[to]` reads the pre-move DOM and grabs the *neighbour* — the tab about to slide into the slot being vacated. React then reorders and carries that neighbour back to the old index, with focus sitting on it.

**The fix is to delete it.** Focus is already on this tab's own element, and the list is keyed by `tab.id`, so React reorders by moving that node rather than recreating it. Focus travels with the tab without any help.

### Why the existing test did not catch it

`renderStrip`'s `onMoveTab` is a mock, so the tabs never actually move. Everything that depends on the re-render — focus above all — is invisible to it, and "moves the focused tab with Ctrl+Shift+Arrow" passed happily throughout while asserting only that the callback fired.

The new test renders a strip that really reorders, then checks the moved element still holds focus and that a second press carries **the same tab** onward rather than swapping the pair back.

### Verification

- **The new test fails against the old code** on exactly the focus assertion (`document.activeElement` is the ARP tab, not the moved Scan tab) and passes with the fix. That is the regression pinned, not just a green suite.
- 186 unit tests pass (184 + 2 new), `tsc` exit 0, `eslint` clean.
- **Outstanding: not yet confirmed in the running app.** The bug was originally observed there with native keystrokes, and this fix has so far only been proven at the unit level. I will drive the real app and post the before/after here before this is merged — a jsdom reorder is not proof that WebView2 behaves the same way, and this repo's own walkthrough warns that synthetic and native input can diverge.

### Sequencing note

#286 records this under Known gaps in `ux-walkthrough.md`. Whichever of the two lands second needs to move that entry out of Known gaps and into the Managing tabs steps as working behaviour — this branch is cut from `main`, so it does not contain that text yet.
