### PR TITLE
Say so when an export, copy or open fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ its heading and collects entries; the date and the link go on with the tag.
 
 ### Fixed
 
+- **A failed export, copy or file-open no longer says nothing at all.** At
+  stock settings every failure outside a run was reported as an interaction
+  toast, and that toast defaults to off — so exporting to a folder the app
+  could not create wrote no file and showed no message, which on screen is
+  indistinguishable from success. Those failures now go to the tab's error
+  strip, which is not preference-gated; the two with no tab to attach to (the
+  progress listener and the interface poll) use a toast kind that is never
+  suppressed. Found by an independent acceptance pass.
 - **The site's small grey text was unreadable on card surfaces.** The docs
   footer, built-with row and mobile section labels use `--sl-color-gray-3`,
   much of it at 12px. It was raised once already to clear 4.5:1 against the

--- a/apps/netscli-gui/src/hooks/usePreferences.ts
+++ b/apps/netscli-gui/src/hooks/usePreferences.ts
@@ -112,6 +112,13 @@ function initialCommandBarVisible(): boolean {
 //
 // Errors are not covered by these: a failure still surfaces, because the
 // alternative is a table that stays empty with no reason given.
+//
+// That was untrue for every action outside a run until 2026-08-29. Export,
+// copy, bundle-open, capture open/reveal, the progress listener and the
+// interface poll all reported failure as an `interaction` toast, which this
+// default drops -- so at stock settings a failed export said nothing at all.
+// Tab-scoped failures now go to the tab's error strip and app-scoped ones use
+// the ungated `error` toast kind, which is what makes the sentence above true.
 function initialInteractionToasts(): boolean {
   if (typeof window === 'undefined') return false;
   return window.localStorage.getItem('netscli-interaction-toasts') === 'on';

--- a/apps/netscli-gui/src/workspace/types.ts
+++ b/apps/netscli-gui/src/workspace/types.ts
@@ -77,7 +77,13 @@ export interface WorkspaceOptions {
 export interface WorkspaceToast {
   id: string;
   message: string;
-  kind: 'interaction' | 'operation' | 'update';
+  /**
+   * `interaction` and `operation` are the preference-gated commentary kinds and
+   * both default to off. `update` and `error` are not gated: an error the user
+   * cannot see is the failure mode this product exists to avoid, so a failure
+   * with no tab to attach an error strip to is reported regardless.
+   */
+  kind: 'interaction' | 'operation' | 'update' | 'error';
   tabId?: string;
   persistent?: boolean;
   actionUrl?: string;

--- a/apps/netscli-gui/src/workspace/useNetworkStatus.ts
+++ b/apps/netscli-gui/src/workspace/useNetworkStatus.ts
@@ -171,7 +171,7 @@ export function useNetworkStatus(showToast: (toast: Omit<WorkspaceToast, 'id'>) 
       interfaceFailures.current += 1;
       if (interfaceFailures.current !== INTERFACE_FAILURES_BEFORE_WARNING) return;
       showToast({
-        kind: 'interaction',
+        kind: 'error',
         message: 'Network interfaces are not responding. Interface-dependent tools may be unavailable.',
       });
     };

--- a/apps/netscli-gui/src/workspace/useOperationProgress.ts
+++ b/apps/netscli-gui/src/workspace/useOperationProgress.ts
@@ -44,7 +44,7 @@ export function useOperationProgress({ activeOps, setTabs, showToast }: UseOpera
       // (B-15). Every other Tauri call in the codebase is already guarded.
       .catch((error: unknown) => {
         showToast({
-          kind: 'interaction',
+          kind: 'error',
           message: `Progress updates unavailable: ${error instanceof Error ? error.message : String(error)}`,
         });
       });

--- a/apps/netscli-gui/src/workspace/useResultActions.failures.test.tsx
+++ b/apps/netscli-gui/src/workspace/useResultActions.failures.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+//
+// B1: at stock settings, a failed action said nothing at all.
+//
+// Interaction toasts default to off, and every failure outside a run was
+// reported as one, so the toast was dropped and nothing replaced it. A failed
+// export wrote no file and showed no message -- on screen, indistinguishable
+// from a success. PRODUCT.md names that exact shape as the thing this product
+// most has to avoid, and `usePreferences.ts` carried a comment claiming it
+// could not happen.
+//
+// These assert the channel rather than the wording: a failure has to reach the
+// tab's error strip while the toast preferences sit at their defaults.
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useResultActions } from './useResultActions';
+import type { WorkspaceTab } from '../tools/types';
+
+vi.mock('../services/netscli', () => ({
+  openFilesystemPath: vi.fn(() => Promise.reject(new Error('no such path'))),
+  revealFilesystemPath: vi.fn(() => Promise.reject(new Error('no such path'))),
+}));
+
+function setup(commandPreview = 'netscli discover 192.168.1.0/24') {
+  const tab = { id: 'tab-1', kind: 'discover', error: null } as unknown as WorkspaceTab;
+  let tabs: WorkspaceTab[] = [tab];
+  const showToast = vi.fn();
+  const setTabs = vi.fn((update) => {
+    tabs = typeof update === 'function' ? update(tabs) : update;
+  });
+
+  const hook = renderHook(() =>
+    useResultActions({
+      activeTab: tab,
+      columns: [],
+      rows: [],
+      selectedRow: undefined,
+      selectedRows: [],
+      commandPreview,
+      setTabs,
+      setActiveTabId: vi.fn(),
+      showToast,
+    } as never),
+  );
+  return { hook, showToast, errorOf: () => tabs[0]?.error };
+}
+
+describe('a failed action is visible at default settings', () => {
+  it('puts a failed copy on the tab error strip', async () => {
+    // jsdom has no clipboard, which is the "clipboard unavailable" branch.
+    expect(navigator.clipboard).toBeUndefined();
+    const { hook, showToast, errorOf } = setup();
+
+    await act(async () => {
+      await hook.result.current.copyCommand();
+    });
+
+    expect(errorOf()).toMatch(/clipboard unavailable/i);
+    // Not a toast: that channel is preference-gated and off by default, which
+    // is precisely how this failure used to disappear.
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('puts a failed capture open on the tab error strip', async () => {
+    const { hook, showToast, errorOf } = setup();
+
+    await act(async () => {
+      await hook.result.current.openCaptureFile('C:/nope/capture.pcap');
+    });
+
+    expect(errorOf()).toMatch(/Open failed/i);
+    expect(showToast).not.toHaveBeenCalled();
+  });
+});

--- a/apps/netscli-gui/src/workspace/useResultActions.ts
+++ b/apps/netscli-gui/src/workspace/useResultActions.ts
@@ -40,6 +40,30 @@ export function useResultActions({
   setActiveTabId,
   showToast,
 }: UseResultActionsArgs) {
+  /**
+   * Report a failed action where the user will actually see it.
+   *
+   * The tab's error strip, not a toast: toasts are preference-gated and the
+   * gate defaults to off, so every failure below used to be silent at stock
+   * settings -- a failed export wrote nothing and said nothing, which is
+   * indistinguishable from a successful one. `clearArpThenRun` already learned
+   * this and routes its own failure here; these paths were not converted with
+   * it.
+   *
+   * With no tab to attach to there is no strip, so those fall back to the
+   * ungated `error` toast kind rather than being dropped.
+   */
+  function reportActionFailure(message: string) {
+    const tabId = activeTab?.id;
+    if (!tabId) {
+      showToast({ message, kind: 'error' });
+      return;
+    }
+    setTabs((previous) =>
+      previous.map((tab) => (tab.id === tabId ? { ...tab, error: message } : tab)),
+    );
+  }
+
   function showExportToast(path: string | null | undefined, fallback: string) {
     if (path === undefined) return;
     showToast({ message: path ? `Exported to ${path}` : fallback, kind: 'interaction' });
@@ -47,7 +71,7 @@ export function useResultActions({
 
   function showExportError(error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    showToast({ message: `Export failed: ${message}`, kind: 'interaction' });
+    reportActionFailure(`Export failed: ${message}`);
   }
 
   function exportCurrent(format: 'json' | 'csv') {
@@ -89,7 +113,7 @@ export function useResultActions({
       showToast({ message: 'Result bundle opened', kind: 'interaction' });
     } catch (error) {
       if (!/cancelled/i.test(String(error))) {
-        showToast({ message: `Open failed: ${String(error)}`, kind: 'interaction' });
+        reportActionFailure(`Open failed: ${String(error)}`);
       }
     }
   }
@@ -105,7 +129,7 @@ export function useResultActions({
    */
   async function copyToClipboard(label: string, text: string) {
     if (!navigator.clipboard) {
-      showToast({ message: `${label} failed: clipboard unavailable`, kind: 'interaction' });
+      reportActionFailure(`${label} failed: clipboard unavailable`);
       return;
     }
     try {
@@ -113,7 +137,7 @@ export function useResultActions({
       showToast({ message: `${label} copied`, kind: 'interaction' });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      showToast({ message: `${label} copy failed: ${message}`, kind: 'interaction' });
+      reportActionFailure(`${label} copy failed: ${message}`);
     }
   }
 
@@ -130,14 +154,14 @@ export function useResultActions({
   async function openCaptureFile(path: string) {
     if (!path) return;
     await netscli.openFilesystemPath(path).catch((error) => {
-      showToast({ message: `Open failed: ${String(error)}`, kind: 'interaction' });
+      reportActionFailure(`Open failed: ${String(error)}`);
     });
   }
 
   async function revealCaptureFile(path: string) {
     if (!path) return;
     await netscli.revealFilesystemPath(path).catch((error) => {
-      showToast({ message: `Reveal failed: ${String(error)}`, kind: 'interaction' });
+      reportActionFailure(`Reveal failed: ${String(error)}`);
     });
   }
 

--- a/ux-walkthrough.md
+++ b/ux-walkthrough.md
@@ -53,7 +53,11 @@ questions you ask once discovery has told you an address exists.
    shows the `netscli …` invocation matching the current form, so anything
    done in the UI can be reproduced in a shell or a script.
 7. **Take the results away.** Export JSON or CSV, copy selected rows, or
-   save a result bundle.
+   save a result bundle. Success is confirmed by a toast *only with
+   interaction toasts enabled*, which is not the default; the file appearing
+   is the signal. **Failure is not optional** — it goes to the tab's error
+   strip whatever the toast preferences say, because a failed export writes
+   nothing, and a silent nothing is indistinguishable from a success.
 
 ## States
 


### PR DESCRIPTION
An independent acceptance pass returned BLOCK on this: **at stock settings, a failed export is indistinguishable from a successful one.** Reproduced and then fixed, both in the running app.

### The proof

Point `NETSCLI_EXPORT_DIR` at a drive that does not exist, run a discover, export. Default toast preferences (`interaction: off`, `operation: off`):

```
before:  {"bodyMentionsFail": false, "errorStrip": null, "toast": null}

after :  errorStrip = "Export failed: Failed to create export directory:
                       The system cannot find the path specified. (os error 3)"
         {"bodyMentionsFail": true, "toast": null}
```

No toast in either case, which is correct — that channel is off by default. The difference is that the failure now has somewhere else to go.

### The mechanism was one line

`showExportError` and its five siblings sent `kind: 'interaction'`. `showToast` drops interaction toasts when the preference is off, and off is the default. **Nothing took the dropped toast's place**, so the app wrote no file and said nothing.

`PRODUCT.md` names this exact shape as the failure the product most has to avoid, and 0.3.1 exists because of three more of them.

Worse, [usePreferences.ts:113](apps/netscli-gui/src/hooks/usePreferences.ts) asserted it could not happen:

> *"Errors are not covered by these: a failure still surfaces, because the alternative is a table that stays empty with no reason given."*

False for every path outside a run. Corrected rather than deleted — the intent was right, only the coverage was missing.

### Split by what the failure belongs to

The report that found this listed six paths as one problem. They are not:

- **Tab-scoped** — export, copy, bundle-open, capture open/reveal. These patch the tab's **error strip**, matching `clearArpThenRun.ts`, which had already learned this lesson and was the only path ever converted. Its own comment says so: *"Toasts are preference-gated and default to off, so reporting it that way made a failed clear silent."*
- **App-scoped** — the progress listener and the interface poll fire outside any operation, so there is no tab and no strip to attach to. Routing them to a strip was not possible; they use a new `error` toast kind that `showToast` never suppresses. `update` was already an ungated kind, so this follows an existing precedent rather than inventing one.

Success toasts are untouched. Those really are the optional commentary the preference is for.

### Verification

- **The new tests fail against the old code.** With the strip routing reverted, both report a dropped toast and no error on the tab; restored, both pass. They assert the *channel*, not the wording.
- 186 unit tests, `tsc` exit 0, `eslint` clean.
- Confirmed in the running app, above — not just at the unit level.

`ux-walkthrough.md` step 7 gains the observable outcome it lacked, which was the other half of the acceptance finding.

### Still open from that review

Not addressed here, and worth their own change — the three ways this app can still report something untrue: `R1` (a panic in an operation task is shown to the user as "Operation cancelled"), `F1` (a run finishing inside the cancel window takes the success path), `F2` (`cancelOperation(...).catch(() => undefined)` clears `busy` while the operation keeps running).
