### PR TITLE
Stop reporting a crash, and a refused stop, as a clean cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ its heading and collects entries; the date and the link go on with the tag.
 
 ### Fixed
 
+- **A crash in an operation is no longer reported as though you cancelled it.**
+  The task's result channel closes the same way whether the task was aborted or
+  panicked, and both came back as "Operation cancelled" — so a fault in the
+  scanner was indistinguishable from pressing Stop, and nothing recorded it.
+  A cancel deregisters the operation and a crash does not, which is now how the
+  two are told apart; a crash says so instead.
+- **Stopping a run no longer shows a result for it.** The in-flight guard was
+  cleared only after the backend answered, and a run that finished inside that
+  window still matched, took the success path, and wrote a result and a history
+  entry for a run that had been stopped.
+- **A refused stop says so, and stays stoppable.** The cancel call swallowed
+  its own failure, cleared the busy state and dropped the operation id, so a
+  run that could not be stopped carried on with nothing on screen saying so and
+  no way to try again. Closing a tab whose operation cannot be stopped now
+  reports it too, since there is no tab left to show it on.
+
 - **A failed export, copy or file-open no longer says nothing at all.** At
   stock settings every failure outside a run was reported as an interaction
   toast, and that toast defaults to off — so exporting to a folder the app

--- a/apps/netscli-gui/src-tauri/src/commands/operations/mod.rs
+++ b/apps/netscli-gui/src-tauri/src/commands/operations/mod.rs
@@ -75,7 +75,29 @@ where
             registry: manager.registry(),
             op_id: op_id.clone(),
         };
-        rx.await.map_err(|_| "Operation cancelled".to_string())?
+        match rx.await {
+            Ok(result) => result,
+            Err(_) => {
+                // The sender was dropped without sending. That happens when the
+                // task is aborted -- a real cancel -- and also when it panics,
+                // and both used to be reported to the user as "Operation
+                // cancelled": a crash in the scanner was indistinguishable from
+                // the user pressing Stop, and nothing recorded it anywhere.
+                //
+                // `cancel` removes the entry before aborting, so a still
+                // registered operation was not cancelled by anyone.
+                if manager.is_registered(&op_id).await {
+                    // Reaches a terminal only in a debug build; release sets
+                    // windows_subsystem = "windows" and has no console. The
+                    // returned message is what the user actually sees.
+                    eprintln!("operation {op_id} ended without returning a result");
+                    Err("The operation stopped unexpectedly and returned no result.                          This is a fault in netscli rather than a cancellation."
+                        .to_string())
+                } else {
+                    Err("Operation cancelled".to_string())
+                }
+            }
+        }
     } else {
         job().await
     }

--- a/apps/netscli-gui/src-tauri/src/state.rs
+++ b/apps/netscli-gui/src-tauri/src/state.rs
@@ -50,6 +50,21 @@ impl OperationManager {
         Arc::clone(&self.tasks)
     }
 
+    /// Whether an operation is still registered.
+    ///
+    /// `cancel` removes the entry before aborting the task, so an operation
+    /// whose task ended without producing a result while still registered was
+    /// not cancelled -- it died on its own. That is the only way to tell the
+    /// two apart from `run_json_operation`, which sees an identical dropped
+    /// sender either way.
+    ///
+    /// `register` also aborts a task when an op id is re-used, which would
+    /// look the same. Op ids are UUIDs minted per run (`generateId('op')`), so
+    /// that path is unreachable in practice.
+    pub(crate) async fn is_registered(&self, op_id: &str) -> bool {
+        self.tasks.lock().await.contains_key(op_id)
+    }
+
     pub(crate) async fn cancel(&self, op_id: &str) -> bool {
         let mut tasks = self.tasks.lock().await;
         if let Some(handle) = tasks.remove(op_id) {
@@ -87,4 +102,44 @@ impl ArtifactRegistry {
 
 fn canonical_artifact_path(path: &Path) -> Result<PathBuf, String> {
     std::fs::canonicalize(path).map_err(|e| format!("Artifact path is not accessible: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The invariant `run_json_operation` leans on to tell a cancelled
+    /// operation from one that died on its own.
+    ///
+    /// Both drop the oneshot sender, so the receiver sees the same error
+    /// either way, and both were reported to the user as "Operation
+    /// cancelled" -- a panic in the scanner was indistinguishable from
+    /// pressing Stop. The difference is here: `cancel` removes the entry
+    /// before aborting, while a task that ends by itself leaves it behind.
+    #[tokio::test]
+    async fn cancel_deregisters_and_a_task_ending_by_itself_does_not() {
+        let manager = OperationManager::default();
+
+        let never_finishes = tauri::async_runtime::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+        manager.register("op-cancelled".into(), never_finishes, None).await;
+        assert!(manager.is_registered("op-cancelled").await);
+
+        assert!(manager.cancel("op-cancelled").await);
+        assert!(
+            !manager.is_registered("op-cancelled").await,
+            "a cancelled operation must leave the map, or a real cancel reads as a crash"
+        );
+
+        let finishes = tauri::async_runtime::spawn(async {});
+        manager.register("op-finished".into(), finishes, None).await;
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            manager.is_registered("op-finished").await,
+            "a task that ended on its own must stay registered, or a crash reads as a cancel"
+        );
+    }
 }

--- a/apps/netscli-gui/src-tauri/src/state.rs
+++ b/apps/netscli-gui/src-tauri/src/state.rs
@@ -123,7 +123,9 @@ mod tests {
         let never_finishes = tauri::async_runtime::spawn(async {
             tokio::time::sleep(std::time::Duration::from_secs(60)).await;
         });
-        manager.register("op-cancelled".into(), never_finishes, None).await;
+        manager
+            .register("op-cancelled".into(), never_finishes, None)
+            .await;
         assert!(manager.is_registered("op-cancelled").await);
 
         assert!(manager.cancel("op-cancelled").await);

--- a/apps/netscli-gui/src/workspace/operations.cancel.test.ts
+++ b/apps/netscli-gui/src/workspace/operations.cancel.test.ts
@@ -1,0 +1,76 @@
+// Cancelling a run used to be able to lie in two different directions.
+//
+// F1: the in-flight guard was deleted *after* awaiting the backend, so a run
+// that finished inside that await still matched its own id, took the success
+// path, and wrote a result and a history entry for a run the user had stopped.
+//
+// F2: the backend call was `.catch(() => undefined)`. A refused cancel still
+// cleared `busy` and dropped the op id, so the operation kept running with
+// nothing on screen saying so and no id left to cancel it with.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cancelWorkspaceTab } from './operations';
+
+const cancelOperation = vi.hoisted(() => vi.fn());
+vi.mock('../services/netscli', () => ({ cancelOperation }));
+vi.mock('../services/env', () => ({ isTauri: () => true }));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('cancelling a run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stops claiming the run before the backend has answered', async () => {
+    const pending = deferred<void>();
+    cancelOperation.mockReturnValue(pending.promise);
+    const activeOps = { current: { 'tab-1': 'op-1' } };
+
+    const done = cancelWorkspaceTab('tab-1', activeOps as never, vi.fn());
+    await Promise.resolve();
+
+    // The guard the completion path checks must already be gone: this is the
+    // window a finishing run used to slip through and be shown as a success.
+    expect(activeOps.current['tab-1']).toBeUndefined();
+
+    pending.resolve();
+    await done;
+  });
+
+  it('says so, and stays cancellable, when the backend refuses', async () => {
+    cancelOperation.mockRejectedValue(new Error('operation not found'));
+    const activeOps = { current: { 'tab-1': 'op-1' } };
+    const patchTab = vi.fn();
+
+    await cancelWorkspaceTab('tab-1', activeOps as never, patchTab);
+
+    // The operation is still running, so the id has to come back or Stop can
+    // never be pressed again.
+    expect(activeOps.current['tab-1']).toBe('op-1');
+    const patches = patchTab.mock.calls.map(([, patch]) => patch);
+    expect(patches.some((patch) => /operation not found/i.test(String(patch.error)))).toBe(true);
+    // And it must not report the run as stopped when it is not.
+    expect(patches.some((patch) => patch.busy === false)).toBe(false);
+  });
+
+  it('clears the tab when the cancel succeeds', async () => {
+    cancelOperation.mockResolvedValue(undefined);
+    const activeOps = { current: { 'tab-1': 'op-1' } };
+    const patchTab = vi.fn();
+
+    await cancelWorkspaceTab('tab-1', activeOps as never, patchTab);
+
+    expect(activeOps.current['tab-1']).toBeUndefined();
+    expect(patchTab).toHaveBeenCalledWith('tab-1', { busy: false, progress: null, error: null });
+  });
+});

--- a/apps/netscli-gui/src/workspace/operations.ts
+++ b/apps/netscli-gui/src/workspace/operations.ts
@@ -123,10 +123,33 @@ export async function cancelWorkspaceTab(
   patchTab: (id: string, patch: Partial<WorkspaceTab>) => void,
 ) {
   const opId = activeOps.current[tabId];
-  if (opId && isTauri()) {
-    await netscli.cancelOperation(opId).catch(() => undefined);
+  if (!opId || !isTauri()) {
+    delete activeOps.current[tabId];
+    patchTab(tabId, { busy: false, progress: null, error: null });
+    return;
   }
+
+  // Claim the cancel *before* awaiting the backend. The run's own completion
+  // path guards on this id still matching, and the await is long enough for a
+  // run to finish inside it -- which took the success path, wrote the result
+  // and the history entry, and only then had the tab set idle underneath it.
+  // The user pressed Stop and got a result. `cancelOperationIds` in
+  // useTabLifecycle already ordered this correctly; the two disagreed.
   delete activeOps.current[tabId];
+
+  try {
+    await netscli.cancelOperation(opId);
+  } catch (error) {
+    // The backend refused the cancel, so the operation is still running.
+    // Clearing `busy` here used to claim it had stopped, and dropping the id
+    // meant Stop could never be pressed again -- the run became invisible and
+    // uncancellable. Put the id back and say what happened.
+    activeOps.current[tabId] = opId;
+    const message = error instanceof Error ? error.message : String(error);
+    patchTab(tabId, { error: `Failed to stop the operation: ${message}` });
+    return;
+  }
+
   patchTab(tabId, { busy: false, progress: null, error: null });
 }
 

--- a/apps/netscli-gui/src/workspace/useTabLifecycle.ts
+++ b/apps/netscli-gui/src/workspace/useTabLifecycle.ts
@@ -5,6 +5,7 @@ import * as netscli from '../services/netscli';
 import { createTab } from '../tools/registry';
 import type { ToolKind, WorkspaceTab } from '../tools/types';
 import type { DefaultInterfaceInfo, InterfaceInfo } from '../types/netscli';
+import type { WorkspaceToast } from './types';
 import { applyContextDefaults, shouldAutoRun } from './networkDefaults';
 
 interface UseTabLifecycleArgs {
@@ -16,6 +17,7 @@ interface UseTabLifecycleArgs {
   defaultInterface: DefaultInterfaceInfo | null;
   trafficInterfaceName: string | null;
   interfaces: InterfaceInfo[];
+  showToast: (toast: Omit<WorkspaceToast, 'id'>) => void;
 }
 
 /** Tab CRUD (create/close) plus the auto-run flag that App.tsx's own
@@ -31,6 +33,7 @@ export function useTabLifecycle({
   defaultInterface,
   trafficInterfaceName,
   interfaces,
+  showToast,
 }: UseTabLifecycleArgs) {
   const activeOps = useRef<Record<string, string>>({});
   // Read at operation completion, not when the run started: a caller's
@@ -63,7 +66,18 @@ export function useTabLifecycle({
       autoRunTabIds.current.delete(tabId);
       const opId = activeOps.current[tabId];
       if (opId && isTauri()) {
-        void netscli.cancelOperation(opId).catch(() => undefined);
+        // A toast rather than an error strip: these tabs are being closed, so
+        // there is no strip left to write to. It uses the ungated `error`
+        // kind, because a swallowed failure here leaves an operation running
+        // with no tab, no id and nothing on screen -- the run cannot be
+        // stopped or even observed again.
+        void netscli.cancelOperation(opId).catch((error: unknown) => {
+          const message = error instanceof Error ? error.message : String(error);
+          showToast({
+            kind: 'error',
+            message: `A closed tab's operation could not be stopped: ${message}`,
+          });
+        });
       }
       delete activeOps.current[tabId];
     }

--- a/apps/netscli-gui/src/workspace/useWorkspace.ts
+++ b/apps/netscli-gui/src/workspace/useWorkspace.ts
@@ -76,6 +76,7 @@ export function useWorkspace(options: WorkspaceOptions): WorkspaceModel {
     defaultInterface,
     trafficInterfaceName,
     interfaces,
+    showToast,
   });
 
   const { selectRow, selectRowInTab, selectAllRows } = useSelection({


### PR DESCRIPTION
The three remaining findings from the independent acceptance pass — R1, F1, F2 — which it summarised as *"the three ways this app can currently tell a user something that is not true."*

### R1 — a crash read as a cancel

`run_json_operation` awaits a oneshot whose sender is dropped **both** when the task is aborted and when it panics, and mapped either to `"Operation cancelled"`. A fault in the core scanner was indistinguishable from the user pressing Stop, and nothing recorded it anywhere.

The distinction was already in the state, unused: `cancel` removes the entry from the task map *before* aborting, so an operation still registered when its channel closes was not cancelled by anyone. That is what separates them now, and it carries **the crate's first test** (`cargo test -p netscli-gui` previously printed `running 0 tests`).

Note on logging: release builds set `windows_subsystem = "windows"` and have no console, so `eprintln!` reaches nobody there. The returned message is what the user actually sees — and since #288 that lands on the tab's error strip rather than a dropped toast.

### F1 — stopping a run could still show its result

`cancelWorkspaceTab` deleted the in-flight guard only *after* awaiting the backend. The run's completion path guards on that same id, so a run finishing inside the await still matched, took the success path, and wrote a result **and a history entry** for a run the user had stopped.

`cancelOperationIds` in `useTabLifecycle` already ordered this correctly. The two disagreed, and the wrong one was behind the Stop button.

### F2 — a refused stop was swallowed

`.catch(() => undefined)`. A failed cancel still cleared `busy` and dropped the op id, so the operation carried on with nothing on screen saying so and no id left to try again with. The id goes back, the tab keeps showing busy, and the strip says what happened.

The tab-close path can't use a strip — the tab is going away — so it reports through the ungated `error` toast kind added in #288. That is exactly the "app-scoped failure with no tab" case that kind exists for.

### Verification

- **All three fixes have tests that fail against the old code.** The two TypeScript ones report a dropped toast and a guard still set; the Rust one fails with `a cancelled operation must leave the map, or a real cancel reads as a crash` when `cancel` is made to leave its entry behind.
- 191 unit tests (188 + 3), `cargo clippy -p netscli-gui --all-targets` clean, `tsc` 0, `eslint` 0.
- **Full render suite green**, which matters here specifically: every operation returns through the path R1 changed. Verified it actually ran by artifact timestamps, not just the exit code.

### What I did not verify, and why it matters

**No test drives Stop in the running app — before or after this change.** I tried to build one and could not reliably get a long-enough operation started through the harness; a `/19` sweep returned before I could click Stop. The e2e suite has no cancel coverage either (its only `cancel` matches are `cancelable: true` on synthetic events).

That gap is *why F1 and F2 survived in the first place*, so it is worth closing on its own rather than being quietly absorbed into this PR.
