### PR TITLE
Send Tauri command arguments under the names Tauri looks for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ its heading and collects entries; the date and the link go on with the tag.
 
 ### Fixed
 
+- **Stop actually stops a run now, and progress shows real counts.** Every
+  command argument was sent under its Rust name (`op_id`, `max_concurrent`)
+  where Tauri expects the camelCase form, so the keys never matched. Stop
+  failed outright — the error was swallowed, so the button looked like it
+  worked while the run carried on — and because the operation id never reached
+  the backend, no operation registered for progress events either: the bar sat
+  on its opening message for the whole run instead of counting. Found by the
+  first test to drive Stop in the app.
+
 - **A crash in an operation is no longer reported as though you cancelled it.**
   The task's result channel closes the same way whether the task was aborted or
   panicked, and both came back as "Operation cancelled" — so a fault in the

--- a/apps/netscli-gui/e2e/tauri-render.mjs
+++ b/apps/netscli-gui/e2e/tauri-render.mjs
@@ -26,6 +26,7 @@ import {
   exerciseInterfaces,
   exerciseMenusAndToolbar,
   exercisePcapValidation,
+  exerciseCancel,
   exerciseScan,
   exerciseSweep,
 } from './tauri-render/scenarios.mjs';
@@ -139,6 +140,12 @@ async function main() {
 
     await exerciseArp(driver);
     await saveScreenshot(driver, 'screen-arp.png');
+
+    // Last of the tool scenarios: a stopped run deliberately leaves no result
+    // table behind, and the scenarios above reach for one. Placing it here
+    // keeps that from failing them somewhere unrelated.
+    await exerciseCancel(driver);
+    await saveScreenshot(driver, 'screen-cancel.png');
 
     if (await exercisePcapValidation(driver)) {
       await saveScreenshot(driver, 'screen-pcap-validation.png');

--- a/apps/netscli-gui/e2e/tauri-render/scenarios.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios.mjs
@@ -1,3 +1,4 @@
+export { exerciseCancel } from './scenarios/cancel.mjs';
 export { exerciseScan } from './scenarios/scan.mjs';
 export { exerciseMenusAndToolbar } from './scenarios/shell.mjs';
 export {

--- a/apps/netscli-gui/e2e/tauri-render/scenarios/cancel.mjs
+++ b/apps/netscli-gui/e2e/tauri-render/scenarios/cancel.mjs
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+
+import { By } from '../driver.mjs';
+import {
+  addToolTab,
+  assertNoErrorStrip,
+  replaceInput,
+  runActiveTool,
+  waitForNoElement,
+  waitForText,
+  withElement,
+} from '../ui.mjs';
+
+/**
+ * Press Stop on a running operation and check what the app is left claiming.
+ *
+ * Nothing drove Stop in the app before this, in any test, which is how two
+ * defects in the cancel path reached an acceptance review: a run finishing
+ * inside the cancel await still took the success path and wrote a result for a
+ * run the user had stopped, and a refused cancel was swallowed so the tab went
+ * idle over an operation that was still going.
+ *
+ * The invariant asserted here is the one both violated: after Stop the tab is
+ * idle, and no result ever arrives for it. This does not reproduce the first
+ * defect's race deterministically -- that needs the run to complete inside the
+ * cancel await, which cannot be timed from out here -- but it does pin the
+ * behaviour the race produced.
+ *
+ * 1024 ports on localhost is the load. Deliberately not more: 1025 crosses
+ * `LARGE_PORT_CONFIRM_PROBES` and opens the "Confirm Large Port Set" dialog,
+ * which swallows the click on Run and leaves this waiting for a run that never
+ * started. Measured at ~1.8s of busy on this machine across repeated runs --
+ * long enough to reach the Stop button without the test depending on timing.
+ *
+ * It also makes the after-Stop assertion unambiguous: a run allowed to finish
+ * puts 1024 rows on screen, so "no rows" cannot pass by accident.
+ */
+export async function exerciseCancel(driver) {
+  const tabsBefore = await driver.executeScript(
+    'return document.querySelectorAll(".work-tab").length;',
+  );
+  await addToolTab(driver, 'Port Scan');
+  await replaceInput(driver, '[data-testid="scan-host-input"]', '127.0.0.1');
+  await replaceInput(driver, '[data-testid="result-filter"]', '');
+  await replaceInput(driver, '[data-testid="scan-ports-input"]', '1-1024');
+  await runActiveTool(driver);
+
+  // The whole test rests on catching the run in flight. `armed` is set from
+  // the tab's own busy flag, so waiting for it -- rather than sleeping -- is
+  // what stops this passing vacuously against a run that already finished.
+  await withElement(driver, '.stop-button.armed', 15_000);
+
+  const beforeStop = await driver.executeScript(`
+    return {
+      rows: document.querySelectorAll('[data-testid^="result-row-"]').length,
+      stopEnabled: !document.querySelector('.stop-button').disabled,
+    };`);
+  assert.equal(beforeStop.stopEnabled, true, 'Stop should be enabled while a run is in flight');
+  assert.equal(beforeStop.rows, 0, 'a run in flight should not have written rows yet');
+
+  // Progress copy carries live counts, which only happens if the operation id
+  // reached the backend and registered for progress events. Asserted here
+  // because the same missing id broke both: the run could not be cancelled,
+  // and its progress sat frozen on its opening message.
+  //
+  // Waited for rather than sampled: the first progress event lands a beat
+  // after the tab goes busy, so reading it the instant Stop arms is a race.
+  await waitForText(driver, '.operation-progress', /\d+\s*\/\s*1024/, 8000);
+
+  await driver.findElement(By.css('.stop-button')).click();
+
+  // Busy clears: the tab stops claiming a run is going.
+  await waitForNoElement(driver, '.stop-button.armed');
+
+  // A user-initiated stop is not a failure, so nothing should be on the strip.
+  await assertNoErrorStrip(driver);
+
+  // And no result may arrive afterwards. This is the assertion that would have
+  // caught a stopped run being reported as a completed one.
+  const settle = 2500;
+  await new Promise((resolve) => setTimeout(resolve, settle));
+  const afterStop = await driver.executeScript(`
+    const strip = document.querySelector('[data-testid="command-strip"]');
+    return {
+      rows: document.querySelectorAll('[data-testid^="result-row-"]').length,
+      busy: !!document.querySelector('.stop-button.armed'),
+      status: (document.querySelector('[data-testid="statusbar"]') || {}).innerText || '',
+      command: strip ? strip.innerText : '',
+    };`);
+  assert.equal(afterStop.busy, false, 'the tab should still be idle after a stop');
+  assert.equal(
+    afterStop.rows,
+    0,
+    `a stopped run must not deliver a result; got ${afterStop.rows} row(s) ${settle}ms after Stop `
+      + '(this run yields 1024 rows if it is allowed to finish)',
+  );
+  assert.doesNotMatch(
+    afterStop.status,
+    /\bRunning\b/i,
+    'the status bar should not still report the run as running',
+  );
+
+  // Leave the workspace as it was found. A stopped run has no result table,
+  // and the light/narrow screenshot passes that follow render whatever tab is
+  // active -- so an abandoned tab here changes images that have nothing to do
+  // with cancelling.
+  await driver.executeScript(`
+    const tabs = [...document.querySelectorAll('.work-tab')];
+    const active = tabs.find((tab) => tab.classList.contains('active')) ?? tabs[tabs.length - 1];
+    active?.querySelector('.tab-close')?.click();`);
+  await driver.wait(
+    async () =>
+      (await driver.executeScript('return document.querySelectorAll(".work-tab").length;')) ===
+      tabsBefore,
+    5000,
+    'the tab opened by the cancel scenario should be closed again',
+  );
+}

--- a/apps/netscli-gui/src/services/netscli.ts
+++ b/apps/netscli-gui/src/services/netscli.ts
@@ -37,7 +37,7 @@ export async function discoverNetwork(
   resolve_hostnames?: boolean,
   max_concurrent?: number,
 ): Promise<Host[]> {
-  return invoke<Host[]>('discover_network', { op_id, subnet, resolve_hostnames, max_concurrent });
+  return invoke<Host[]>('discover_network', { opId: op_id, subnet, resolveHostnames: resolve_hostnames, maxConcurrent: max_concurrent });
 }
 
 export async function scanPorts(
@@ -46,7 +46,7 @@ export async function scanPorts(
   op_id?: string,
   max_concurrent?: number,
 ): Promise<PortResult[]> {
-  return invoke<PortResult[]>('scan_ports', { op_id, host, ports, max_concurrent });
+  return invoke<PortResult[]>('scan_ports', { opId: op_id, host, ports, maxConcurrent: max_concurrent });
 }
 
 export async function pingHost(
@@ -54,7 +54,7 @@ export async function pingHost(
   count?: number,
   op_id?: string,
 ): Promise<PingSummary> {
-  return invoke<PingSummary>('ping_host', { op_id, host, count });
+  return invoke<PingSummary>('ping_host', { opId: op_id, host, count });
 }
 
 export async function traceRoute(
@@ -63,14 +63,14 @@ export async function traceRoute(
   resolve?: boolean,
   op_id?: string,
 ): Promise<TraceResult> {
-  return invoke<TraceResult>('trace_route_cmd', { op_id, host, max_hops, resolve });
+  return invoke<TraceResult>('trace_route_cmd', { opId: op_id, host, maxHops: max_hops, resolve });
 }
 
 export async function reverseDnsLookup(
   ip: string,
   op_id?: string,
 ): Promise<ReverseDnsResult> {
-  return invoke<ReverseDnsResult>('reverse_dns_lookup', { op_id, ip });
+  return invoke<ReverseDnsResult>('reverse_dns_lookup', { opId: op_id, ip });
 }
 
 export async function inspectHost(
@@ -78,7 +78,7 @@ export async function inspectHost(
   ports?: string,
   op_id?: string,
 ): Promise<InspectResult> {
-  return invoke<InspectResult>('inspect_host_cmd', { op_id, host, ports });
+  return invoke<InspectResult>('inspect_host_cmd', { opId: op_id, host, ports });
 }
 
 export async function sweepNetwork(
@@ -88,7 +88,7 @@ export async function sweepNetwork(
   resolve_hostnames?: boolean,
   max_concurrent?: number,
 ): Promise<SweepEntry[]> {
-  return invoke<SweepEntry[]>('sweep_network', { op_id, subnet, ports, resolve_hostnames, max_concurrent });
+  return invoke<SweepEntry[]>('sweep_network', { opId: op_id, subnet, ports, resolveHostnames: resolve_hostnames, maxConcurrent: max_concurrent });
 }
 
 export async function dnsLookup(
@@ -96,7 +96,7 @@ export async function dnsLookup(
   record?: string,
   op_id?: string,
 ): Promise<DnsRecord[]> {
-  return invoke<DnsRecord[]>('dns_lookup', { op_id, host, record });
+  return invoke<DnsRecord[]>('dns_lookup', { opId: op_id, host, record });
 }
 
 export async function discoverMdns(
@@ -104,11 +104,11 @@ export async function discoverMdns(
   service_types?: string[],
   op_id?: string,
 ): Promise<MdnsService[]> {
-  return invoke<MdnsService[]>('discover_mdns', { op_id, timeout_ms, service_types });
+  return invoke<MdnsService[]>('discover_mdns', { opId: op_id, timeoutMs: timeout_ms, serviceTypes: service_types });
 }
 
 export async function listInterfaces(op_id?: string): Promise<InterfaceInfo[]> {
-  return invoke<InterfaceInfo[]>('list_interfaces', { op_id });
+  return invoke<InterfaceInfo[]>('list_interfaces', { opId: op_id });
 }
 
 /** Flush the OS neighbour cache. Requires administrator rights. */
@@ -117,7 +117,7 @@ export async function clearArpTable(): Promise<void> {
 }
 
 export async function getArpTable(op_id?: string): Promise<ArpEntry[]> {
-  return invoke<ArpEntry[]>('get_arp_table', { op_id });
+  return invoke<ArpEntry[]>('get_arp_table', { opId: op_id });
 }
 
 export async function capturePcap(
@@ -130,16 +130,16 @@ export async function capturePcap(
   op_id?: string,
 ): Promise<PcapResult> {
   return invoke<PcapResult>('capture_pcap', {
-    op_id,
+    opId: op_id,
     interface: params.interface,
     filter: params.filter,
     duration: params.duration,
-    max_packets: params.max_packets,
+    maxPackets: params.max_packets,
   });
 }
 
 export async function openPcapFile(max_packets?: number): Promise<PcapParseResult> {
-  return invoke<PcapParseResult>('open_pcap_file', { max_packets });
+  return invoke<PcapParseResult>('open_pcap_file', { maxPackets: max_packets });
 }
 
 export async function getPcapCapability(): Promise<PcapCapability> {
@@ -155,7 +155,7 @@ export async function getFileSavePreferences(): Promise<FileSavePreferences> {
 }
 
 export async function setFileSaveAskEachTime(ask_each_time: boolean): Promise<FileSavePreferences> {
-  return invoke<FileSavePreferences>('set_file_save_ask_each_time', { ask_each_time });
+  return invoke<FileSavePreferences>('set_file_save_ask_each_time', { askEachTime: ask_each_time });
 }
 
 export async function chooseFileSaveDefaultDirectory(): Promise<FileSavePreferences> {
@@ -167,7 +167,7 @@ export async function clearFileSaveDefaultDirectory(): Promise<FileSavePreferenc
 }
 
 export async function cancelOperation(op_id: string): Promise<void> {
-  return invoke<void>('cancel_operation', { op_id });
+  return invoke<void>('cancel_operation', { opId: op_id });
 }
 
 export async function getNetworkStats(interfaceName?: string | null): Promise<NetworkStats> {
@@ -188,7 +188,7 @@ export async function exportTextFile(
   filename: string,
   contents: string,
 ): Promise<string> {
-  return invoke<string>('export_text_file', { filename, contents, target_path: null });
+  return invoke<string>('export_text_file', { filename, contents, targetPath: null });
 }
 
 export async function saveResultBundle(contents: string): Promise<string> {


### PR DESCRIPTION
You asked for a test that drives Stop in the app — the gap that let two cancel defects reach an acceptance review. **On its first run it found that Stop has never worked.**

```
Failed to stop the operation: invalid args `opId` for command
`cancel_operation`: command cancel_operation missing required key opId
```

### One root cause, three symptoms

Every payload was built with the **Rust** parameter names — `op_id`, `max_concurrent`, `resolve_hostnames`, `max_hops`, `timeout_ms` — where Tauri matches the **camelCase** form. The keys never matched.

`cancel_operation` takes `op_id: String`. A required argument, so the mismatch was a hard error every single time — swallowed until yesterday by `.catch(() => undefined)`, which is exactly how a completely broken Stop button looked like a working one. #289 removed that swallow; this test then walked straight into it.

Every other command takes `op_id: Option<String>`, where an unmatched key **is not an error** — it silently becomes `None`. So no operation ever registered with the manager, and none emitted progress events.

**That is the acceptance pass's W2**, which recorded the progress bar stuck on its opening message and noted it "could not explain" why counts never arrived. Measured after this change, the same scan reports `1 / 1024`, then `244 / 1024`.

### The test

`exerciseCancel` starts a 1024-port localhost scan, waits for the tab to actually be busy, presses Stop, and asserts the tab goes idle, no error strip appears, and **no result ever arrives**.

Details that took a few attempts to get right, recorded in the file:

- **1024 ports, deliberately not more.** 1025 crosses `LARGE_PORT_CONFIRM_PROBES` and opens the "Confirm Large Port Set" dialog, which swallows the click on Run. My first version waited 15s for a run that never started — the app was right and the test was wrong.
- **Waits for `.stop-button.armed`** rather than sleeping, so it cannot pass vacuously against a run that already finished.
- **A finished run yields 1024 rows**, so "no rows after Stop" cannot pass by accident.
- **Waits for the progress count** rather than sampling — the first event lands a beat after the tab goes busy.
- **Runs late and closes its own tab.** A stopped run leaves no result table, and earlier scenarios reach for one; my first placement failed `exerciseMenusAndToolbar` somewhere unrelated.

### Verification

Both assertions are pinned, checked by reverting each key on its own:

| Reverted | Result |
| --- | --- |
| `cancel_operation` key | fails with `missing required key opId` |
| `scan_ports` key | times out waiting for a progress count |

191 unit tests, `tsc` 0, `eslint` 0, `cargo fmt --check` 0, clippy clean, full render suite green.

### What I could not establish

**Whether `maxConcurrent` now reaches the core.** I tried to measure it by setting Max Concurrent Probes to 1 and timing a 1024-port scan: 2642ms before the fix, 2513ms after — no difference either way. But I could not confirm my probe actually applied the setting, so that measurement is worthless in both directions rather than evidence of anything. It needs checking on its own, and it matters: `PRODUCT.md` treats concurrency as a safety limit.
