### PR TITLE
Make the warning icon quieter, the docs link work, and Stop errors readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ its heading and collects entries; the date and the link go on with the tag.
 
 ### Fixed
 
+- **"Open setup docs" opens something.** The button asked the system to open
+  `github.com/fstubner/netscli#packet-capture`, which the app's own URL
+  allowlist did not cover — it permitted the repository URL and paths beneath
+  it, but not a fragment — and the refusal was swallowed by a `window.open`
+  fallback that does nothing inside a desktop window. It now opens the Packet
+  Capture page on netscli.com, and a browser that cannot be opened says so
+  instead of leaving the button looking dead.
+- **A failed Stop no longer shows internal text.** It reported the backend's
+  own message, so pressing Stop could put ``invalid args `opId` for command
+  `cancel_operation` `` on screen. It now says the run may still be going and
+  that Stop is worth pressing again; the detail goes to the console.
+  The unexpected-stop message also carried a run of stray spaces from a
+  mangled line continuation.
+
 - **A crash in an operation is no longer reported as though you cancelled it.**
   The task's result channel closes the same way whether the task was aborted or
   panicked, and both came back as "Operation cancelled" — so a fault in the
@@ -77,6 +91,10 @@ its heading and collects entries; the date and the link go on with the tag.
   and labelling every row `Up` spent width on a word that never varied.
   Addresses are monospaced, matching the rule that monospace means "this is
   literal".
+- **The warning icon in confirmation dialogs lost its amber box.** It sat in a
+  32px square with an amber border and wash, which read as decoration next to
+  every confirmation. It is now the icon alone, matching the packet-capture
+  notice, which had always done it that way.
 
 ## [0.3.1]
 

--- a/apps/netscli-gui/src-tauri/capabilities/main.json
+++ b/apps/netscli-gui/src-tauri/capabilities/main.json
@@ -13,8 +13,10 @@
     {
       "identifier": "opener:allow-open-url",
       "allow": [
+        { "url": "https://netscli.com/*" },
         { "url": "https://github.com/fstubner/netscli" },
-        { "url": "https://github.com/fstubner/netscli/*" }
+        { "url": "https://github.com/fstubner/netscli/*" },
+        { "url": "https://github.com/fstubner/netscli#*" }
       ]
     }
   ]

--- a/apps/netscli-gui/src-tauri/src/commands/operations/mod.rs
+++ b/apps/netscli-gui/src-tauri/src/commands/operations/mod.rs
@@ -91,8 +91,10 @@ where
                     // windows_subsystem = "windows" and has no console. The
                     // returned message is what the user actually sees.
                     eprintln!("operation {op_id} ended without returning a result");
-                    Err("The operation stopped unexpectedly and returned no result.                          This is a fault in netscli rather than a cancellation."
-                        .to_string())
+                    Err(
+                        "The operation stopped unexpectedly and produced no result. This is a fault in NetsCLI, not a cancellation."
+                            .to_string(),
+                    )
                 } else {
                     Err("Operation cancelled".to_string())
                 }

--- a/apps/netscli-gui/src/components/results/PcapUnavailableState.tsx
+++ b/apps/netscli-gui/src/components/results/PcapUnavailableState.tsx
@@ -1,9 +1,13 @@
+import { useState } from 'react';
 import { AlertTriangle, ExternalLink } from 'lucide-react';
 
 import { openAllowedExternalUrl } from '../../services/externalLinks';
 import type { PcapCapability } from '../../types/netscli';
 
 export function PcapUnavailableState({ capability }: { capability: PcapCapability }) {
+  // Reported next to the button rather than as a toast: this panel is the
+  // whole view, and the failure belongs to the control that was pressed.
+  const [openError, setOpenError] = useState<string | null>(null);
   const buildWithoutPcap = !capability.compiled || capability.message?.includes("built without feature 'pcap'");
   const title = buildWithoutPcap ? 'Packet Capture is not included in this build' : 'Packet Capture needs a capture driver';
   const body = buildWithoutPcap
@@ -20,11 +24,20 @@ export function PcapUnavailableState({ capability }: { capability: PcapCapabilit
       </div>
       <button
         type="button"
-        onClick={() => void openAllowedExternalUrl('https://github.com/fstubner/netscli#packet-capture')}
+        onClick={() => {
+          setOpenError(null);
+          openAllowedExternalUrl('https://netscli.com/docs/packet-capture/').catch(
+            () =>
+              setOpenError(
+                'Could not open your browser. The setup notes are at netscli.com/docs/packet-capture.',
+              ),
+          );
+        }}
       >
         <ExternalLink size={14} />
         <span>Open setup docs</span>
       </button>
+      {openError ? <p className="pcap-unavailable-open-error">{openError}</p> : null}
     </div>
   );
 }

--- a/apps/netscli-gui/src/components/shell/AboutDialog.tsx
+++ b/apps/netscli-gui/src/components/shell/AboutDialog.tsx
@@ -14,7 +14,9 @@ export function AboutDialog({ appVersion, onClose }: AboutDialogProps) {
   useModalFocus({ dialogRef, onClose });
 
   function openProjectUrl(url: string) {
-    void openAllowedExternalUrl(url);
+    // Nothing on screen owns this failure, so it goes to the console rather
+    // than nowhere. The ungated toast is not reachable from here.
+    openAllowedExternalUrl(url).catch((error: unknown) => console.error('Opening the link failed', error));
   }
 
   return (

--- a/apps/netscli-gui/src/components/shell/ToastHost.tsx
+++ b/apps/netscli-gui/src/components/shell/ToastHost.tsx
@@ -55,7 +55,9 @@ function ToastButton({
       type="button"
       onClick={() => {
         if (toast.actionUrl) {
-          void openAllowedExternalUrl(toast.actionUrl);
+          openAllowedExternalUrl(toast.actionUrl).catch((error: unknown) =>
+            console.error('Opening the link failed', error),
+          );
           if (toast.releaseVersion) {
             window.localStorage.setItem('netscli-dismissed-release-version', toast.releaseVersion);
           }

--- a/apps/netscli-gui/src/services/externalLinks.ts
+++ b/apps/netscli-gui/src/services/externalLinks.ts
@@ -1,21 +1,27 @@
 import { openUrl } from '@tauri-apps/plugin-opener';
 
-const ALLOWED_EXTERNAL_URLS = [
-  'https://github.com/fstubner/netscli',
-  'https://github.com/fstubner/netscli/',
-];
+/**
+ * Where the app is allowed to send a browser: its own documentation site, and
+ * its own repository. Nothing else, and https only.
+ *
+ * Kept in step with `src-tauri/capabilities/main.json`, which enforces the same
+ * list one layer down -- this check is the readable one, that one is the one an
+ * attacker has to get past.
+ */
+const ALLOWED_EXTERNAL_HOSTS: Record<string, (pathname: string) => boolean> = {
+  'netscli.com': () => true,
+  'github.com': (pathname) =>
+    pathname === '/fstubner/netscli' ||
+    pathname === '/fstubner/netscli/' ||
+    pathname.startsWith('/fstubner/netscli/'),
+};
 
 export function isAllowedExternalUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return (
-      parsed.protocol === 'https:' &&
-      parsed.hostname === 'github.com' &&
-      (parsed.pathname === '/fstubner/netscli' ||
-        parsed.pathname === '/fstubner/netscli/' ||
-        parsed.pathname.startsWith('/fstubner/netscli/')) &&
-      ALLOWED_EXTERNAL_URLS.some((base) => url.startsWith(base))
-    );
+    if (parsed.protocol !== 'https:') return false;
+    const allows = ALLOWED_EXTERNAL_HOSTS[parsed.hostname];
+    return allows ? allows(parsed.pathname) : false;
   } catch {
     return false;
   }
@@ -26,9 +32,14 @@ export async function openAllowedExternalUrl(url: string): Promise<void> {
     throw new Error('External URL is not allowed');
   }
 
-  try {
-    await openUrl(url);
-  } catch {
-    window.open(url, '_blank', 'noopener,noreferrer');
-  }
+  // No `window.open` fallback. It opens nothing in a Tauri window and throws
+  // nothing, which is exactly how "Open setup docs" came to look inert: the
+  // capability allowed the bare repository URL and `netscli/*`, the button asks
+  // for `netscli#packet-capture`, that matched neither, and the refusal was
+  // swallowed here.
+  //
+  // The rejection is left to propagate rather than rewrapped: what the user
+  // should be told depends on which control they pressed, and only the caller
+  // knows that.
+  await openUrl(url);
 }

--- a/apps/netscli-gui/src/styles/pcap.css
+++ b/apps/netscli-gui/src/styles/pcap.css
@@ -57,3 +57,10 @@
   border-color: color-mix(in srgb, var(--mint), transparent 35%);
   color: var(--mint);
 }
+
+.pcap-unavailable-open-error {
+  grid-column: 1 / -1;
+  margin: 8px 0 0;
+  color: var(--red);
+  font-size: 12px;
+}

--- a/apps/netscli-gui/src/styles/shell/dialogs.css
+++ b/apps/netscli-gui/src/styles/shell/dialogs.css
@@ -24,14 +24,20 @@
   border-bottom: 1px solid var(--border-subtle);
 }
 
+/*
+ * The icon alone, with no surface of its own.
+ *
+ * It used to sit in a 32px box with an amber border and an amber wash, which
+ * put a filled square next to every confirmation and read as decoration --
+ * design-direction.md reserves amber for state. The app's other warning
+ * surface, `.pcap-unavailable`, already did it this way: a bare amber glyph
+ * beside the text. The two now match.
+ */
 .confirm-dialog-icon {
-  width: 32px;
-  height: 32px;
   display: inline-grid;
   place-items: center;
-  border: 1px solid color-mix(in srgb, var(--amber), transparent 58%);
+  padding-top: 2px;
   color: var(--amber);
-  background: color-mix(in srgb, var(--amber), transparent 91%);
 }
 
 .confirm-dialog h2 {

--- a/apps/netscli-gui/src/workspace/operations.cancel.test.ts
+++ b/apps/netscli-gui/src/workspace/operations.cancel.test.ts
@@ -58,7 +58,13 @@ describe('cancelling a run', () => {
     // never be pressed again.
     expect(activeOps.current['tab-1']).toBe('op-1');
     const patches = patchTab.mock.calls.map(([, patch]) => patch);
-    expect(patches.some((patch) => /operation not found/i.test(String(patch.error)))).toBe(true);
+    const errors = patches.map((patch) => String(patch.error ?? ''));
+    // What the user needs: the run may still be going, and Stop is worth
+    // pressing again.
+    expect(errors.some((message) => /still be running/i.test(message))).toBe(true);
+    // And not the backend's own words. This path once put
+    // "invalid args `opId` for command `cancel_operation`" on screen.
+    expect(errors.some((message) => /operation not found/i.test(message))).toBe(false);
     // And it must not report the run as stopped when it is not.
     expect(patches.some((patch) => patch.busy === false)).toBe(false);
   });

--- a/apps/netscli-gui/src/workspace/operations.ts
+++ b/apps/netscli-gui/src/workspace/operations.ts
@@ -145,8 +145,16 @@ export async function cancelWorkspaceTab(
     // meant Stop could never be pressed again -- the run became invisible and
     // uncancellable. Put the id back and say what happened.
     activeOps.current[tabId] = opId;
-    const message = error instanceof Error ? error.message : String(error);
-    patchTab(tabId, { error: `Failed to stop the operation: ${message}` });
+    // Deliberately not the backend's own message. What comes back here is
+    // internal -- a Tauri command or argument error -- and means nothing to
+    // the person reading it; the first version of this put
+    // "invalid args `opId` for command `cancel_operation`" on screen. What
+    // they need is that the run did not stop and that pressing Stop again is
+    // worth trying. The detail goes to the console for a bug report.
+    console.error('Stopping the operation failed', error);
+    patchTab(tabId, {
+      error: 'Could not stop the operation, so it may still be running. Try Stop again.',
+    });
     return;
   }
 


### PR DESCRIPTION
Three things reported from the running app.

### The amber box behind the warning icon

It sat in a 32px square with an amber border and an amber wash, so every confirmation carried a filled box next to the text. `design-direction.md` reserves amber for **state, not decoration** — and the app's other warning surface, the packet-capture notice, already used a bare amber glyph. Two treatments for one idea; they match now.

Measured on the rebuilt app: `background: rgba(0, 0, 0, 0)`, `border: 0px none`, glyph still `rgb(245, 165, 36)`.

### "Open setup docs" opened nothing

The button asked for `github.com/fstubner/netscli#packet-capture`. The Tauri capability allowed the bare repository URL and `netscli/*` — **neither matches a fragment** — so the opener refused it:

```
Not allowed to open url https://github.com/fstubner/netscli#packet-capture
```

The refusal was then swallowed by a `window.open` fallback, which opens nothing and throws nothing inside a desktop window. That is why the button looked inert rather than broken.

It now points at **the Packet Capture page on the docs site** (`netscli.com/docs/packet-capture/`) rather than a README anchor — route confirmed against the built site. The allowlist and the Tauri capability both cover it, verified by driving the rebuilt binary. A browser that cannot be opened now reports beside the button; the other two callers log instead of discarding.

### Stop showed internal text

It reported the backend's own message, so with the argument-casing defect present it put this on the error strip:

```
invalid args `opId` for command `cancel_operation`
```

Nothing a person can act on. It now says the run may still be going and that Stop is worth pressing again, with the detail going to the console — the caller knows the context, so the service no longer invents user copy either.

**The unexpected-stop message was worse than ugly.** `cargo fmt` folded the line continuation I wrote in #289 into a literal run of 26 spaces inside the string, and a later attempt turned it into an escaped newline. It is one plain sentence now, and `cargo fmt --check` is stable on it.

### Verification

- Icon, docs URL and suite all checked against the **rebuilt** binary — the capability is compiled in, so a stale build would have proved nothing. Confirmed by timestamp and by finding the new pattern inside the executable.
- 191 unit tests, `tsc` 0, `eslint` 0, `cargo fmt --check` 0, clippy clean, full render suite green.
- The cancel test now asserts the user-facing wording **and** that the backend's own words do not appear.

One note: at one point a run reported 172 tests in 30 files instead of 191 in 34. That was a stale run racing my file writes, not a regression — a clean re-run gives 191/34. Flagging it because a shrinking test count is exactly the kind of thing worth not shipping on.
