### PR TITLE
Fail the build when the app links at a page the site does not have

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,10 @@ jobs:
       # honest.
       - name: Design token contrast
         run: node scripts/design-tokens.mjs
+      # The app links at the docs site, and neither project knows what the
+      # other publishes. Runs in site.yml too, since either side can break it.
+      - name: App doc links
+        run: node scripts/check-app-doc-links.mjs
 
   # Installer scripts aren't exercised by any other job, so lint them
   # directly. shellcheck and PSScriptAnalyzer are both preinstalled on

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -78,6 +78,11 @@ jobs:
       - name: Design token contrast
         run: node scripts/design-tokens.mjs
 
+      # Deleting or renaming a docs page can strand a link inside the desktop
+      # app, which no site check would otherwise notice.
+      - name: App doc links
+        run: node scripts/check-app-doc-links.mjs
+
       # A ratchet on dead CSS, not a target. `css-shadowing.mjs` proves a
       # declaration can never affect the page -- same selector, same media
       # context, a later rule of equal-or-greater importance. It was written

--- a/scripts/check-app-doc-links.mjs
+++ b/scripts/check-app-doc-links.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+//
+// Every netscli.com URL the desktop app links to must be a page the site
+// actually builds.
+//
+//   node scripts/check-app-doc-links.mjs
+//
+// Why this exists: the "Open setup docs" button pointed at a GitHub README
+// anchor that the app's own URL allowlist refused, and the refusal was
+// swallowed, so the button silently did nothing. Repointing it at the docs
+// site fixed the swallow but introduced the opposite hazard -- an app that
+// links confidently at a page the site may not have. Nothing in either
+// project would have noticed: the app does not know what the site publishes,
+// and the site does not know what the app links to.
+//
+// Checked against the content sources rather than `site/dist`, so this needs
+// no build and can run in both workflows. Starlight maps
+// `src/content/docs/<path>.md` to `/<path>/` one-to-one; the routes outside
+// that collection come from `src/pages/*.astro`, which is why both are
+// consulted.
+//
+// It cannot tell whether the site is deployed. A page present here and absent
+// from netscli.com is a deployment gap, and this check will not see it.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const appSource = path.join(repoRoot, 'apps/netscli-gui/src');
+const docsRoot = path.join(repoRoot, 'site/src/content/docs');
+const pagesRoot = path.join(repoRoot, 'site/src/pages');
+
+const SITE_ORIGIN = 'https://netscli.com';
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+
+function sourceFiles(dir, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) sourceFiles(full, found);
+    else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) found.push(full);
+  }
+  return found;
+}
+
+/** Every netscli.com link in the app, with the file that writes it. */
+function findLinks() {
+  const links = [];
+  for (const file of sourceFiles(appSource)) {
+    const text = fs.readFileSync(file, 'utf8');
+    for (const match of text.matchAll(/https:\/\/netscli\.com[^\s'"`)]*/g)) {
+      links.push({ url: match[0], file: path.relative(repoRoot, file).replaceAll(path.sep, '/') });
+    }
+  }
+  return links;
+}
+
+/** Whether the site builds a page at this path. */
+function siteHasRoute(pathname) {
+  const slug = pathname.replace(/^\/+/, '').replace(/\/+$/, '');
+
+  // The site root and anything under src/pages.
+  const pageCandidates = slug
+    ? [`${slug}.astro`, path.join(slug, 'index.astro')]
+    : ['index.astro'];
+  if (pageCandidates.some((candidate) => fs.existsSync(path.join(pagesRoot, candidate)))) {
+    return true;
+  }
+  if (!slug) return false;
+
+  // Starlight content: /docs/packet-capture/ -> src/content/docs/docs/packet-capture.md
+  const contentCandidates = [
+    `${slug}.md`,
+    `${slug}.mdx`,
+    path.join(slug, 'index.md'),
+    path.join(slug, 'index.mdx'),
+  ];
+  return contentCandidates.some((candidate) => fs.existsSync(path.join(docsRoot, candidate)));
+}
+
+const failures = [];
+const links = findLinks();
+
+for (const { url, file } of links) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    failures.push(`${file}: "${url}" is not a URL`);
+    continue;
+  }
+  if (parsed.origin !== SITE_ORIGIN) continue;
+  if (!siteHasRoute(parsed.pathname)) {
+    failures.push(
+      `${file}: links to ${url}, which the site does not build. ` +
+        `Expected site/src/content/docs${parsed.pathname.replace(/\/$/, '')}.md or a matching page.`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error('App links to site pages that do not exist:');
+  for (const failure of failures) console.error(`  ${failure}`);
+  process.exitCode = 1;
+} else {
+  console.log(`App doc links OK: ${links.length} netscli.com link(s), all built by the site.`);
+}


### PR DESCRIPTION
The desktop app now links at netscli.com for its setup notes, and **nothing connected the two**: the app does not know what the site publishes, and the site does not know what the app links to.

That gap is not hypothetical. The link this replaced pointed at a GitHub README anchor that the app's own allowlist refused, and it went unnoticed for as long as it did because the refusal was swallowed. Repointing it at the docs site fixed the swallow and introduced the opposite hazard — an app linking confidently at a page the site might not build.

### What it does

`scripts/check-app-doc-links.mjs` reads every `netscli.com` URL out of the app sources and asserts the site builds a page for it.

**Checked against the content sources, not `site/dist`** — so it needs no build, runs in milliseconds, and can sit in both workflows. Starlight maps `src/content/docs/<path>.md` to `/<path>/` one-to-one; routes outside that collection come from `src/pages/*.astro`, so both are consulted.

### Why both workflows

`ci.yml` gates on `code` and `site.yml` on `site`, and **either side alone can break the pairing**:

- renaming or deleting a docs page strands a link inside the app — a site-only PR, invisible to `ci.yml`
- retargeting a link in the app can miss the site entirely — an app-only PR, invisible to `site.yml`

Same reasoning as the design-token check, which is already duplicated across the two for the same reason.

### Verification

Sabotage-checked from both directions, then restored:

| | |
| --- | --- |
| typo in the app's link (`/docs/pakcet-capture/`) | exit 1, names the file and the expected page |
| docs page deleted while the app still links to it | exit 1 |
| both restored | exit 0 — `1 netscli.com link(s), all built by the site` |

Workflow YAML validated and the step confirmed present in both.

### What it deliberately cannot do

**It cannot tell whether the site is deployed.** `netscli.com` currently serves the landing page and no `/docs` at all — its own nav still points at GitHub — so the link this guards is correct against the repository and 404s in the world. That is a deployment gap, and this check will not see it. The script header says so rather than leaving the next person to assume a green tick means the page is reachable.
