### PR TITLE
Check the Linux side of the crates from a Windows machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,11 @@ skills-lock.json
 # untracked noise throughout the documented Windows workflow (C-27).
 /target-pcap/
 
+# Written by scripts/check-linux.sh, from inside the container. Separate from
+# /target for the same reason as above: Linux and Windows objects would evict
+# each other on every alternating build.
+/target-linux/
+
 # Brainstorming companion (superpowers skill)
 .superpowers/
 

--- a/scripts/check-linux.sh
+++ b/scripts/check-linux.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Compile and test the Linux side of the Rust crates, from a Windows checkout.
+#
+#   ./scripts/check-linux.sh              # clippy + tests
+#   ./scripts/check-linux.sh clippy       # clippy only
+#   ./scripts/check-linux.sh test         # tests only
+#   ./scripts/check-linux.sh shell        # a prompt inside the image
+#
+# Why this exists: netscli-core carries 37 platform-conditional blocks, and
+# the ones that matter most are the least forgiving code in the project --
+# ARP table reads and mutations, and raw ICMP:
+#
+#   crates/netscli-core/src/arp/platform/table.rs
+#   crates/netscli-core/src/arp/platform/mutate.rs
+#   crates/netscli-core/src/ping/raw_icmp.rs
+#
+# On a Windows machine `cargo clippy` compiles only the `cfg(windows)` arms.
+# The Linux arms are not type-checked, not linted, and not tested locally at
+# all, so a mistake in them is invisible until CI runs -- which is where you
+# find out, rather than where you would want to.
+#
+# This does NOT replace CI. It skips netscli-gui entirely (see the Dockerfile)
+# and it is not the macOS path, which stays CI-only.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+IMAGE=netscli-linux-check
+MODE="${1:-all}"
+
+# Git Bash rewrites anything that looks like a Unix path in an argument into a
+# Windows one before the process sees it, so `-w /work` reached docker as
+# 'C:/Program Files/Git/work'. Turning that off is only half the fix: the
+# host side of `-v` then needs a real Windows path, which is what `pwd -W`
+# gives and plain $PWD (/h/projects/...) does not. Both are no-ops elsewhere.
+export MSYS_NO_PATHCONV=1
+HOST_ROOT="$(pwd -W 2>/dev/null || pwd)"
+
+# A target directory of its own, for the same reason /target-pcap has one: the
+# container writes Linux objects, and pointing it at ./target would mean the
+# two platforms evict each other's artifacts on every alternating run. Named
+# volume for the registry so crates are downloaded once, not per run.
+TARGET_DIR=/work/target-linux
+REGISTRY_VOLUME=netscli-linux-check-registry
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "check-linux: docker is not on PATH." >&2
+    exit 1
+fi
+
+# Linux containers only. Under Windows-container mode this image cannot even
+# be pulled, and the error that produces is opaque enough to be worth pre-empting.
+os_type=$(docker info --format '{{.OSType}}' 2>/dev/null || echo unknown)
+if [ "$os_type" != "linux" ]; then
+    echo "check-linux: Docker is in '$os_type' container mode; this needs Linux containers." >&2
+    exit 1
+fi
+
+echo "==> Building $IMAGE (cached after the first run)"
+docker build -q -f scripts/linux-check.Dockerfile -t "$IMAGE" scripts/ >/dev/null
+
+docker volume create "$REGISTRY_VOLUME" >/dev/null
+
+run_in_container() {
+    docker run --rm \
+        -v "$HOST_ROOT:/work" \
+        -v "$REGISTRY_VOLUME:/usr/local/cargo/registry" \
+        -e CARGO_TARGET_DIR="$TARGET_DIR" \
+        -w /work \
+        "$IMAGE" \
+        bash -eu -o pipefail -c "$1"
+}
+
+# netscli-gui is excluded, not forgotten: it is a Tauri app whose Linux build
+# needs the whole GTK/WebKit stack, and none of the platform code this script
+# exists for lives there.
+CRATES="-p netscli-core -p netscli-mcp -p netscli"
+
+case "$MODE" in
+clippy)
+    echo "==> clippy (Linux, all features)"
+    run_in_container "cargo clippy $CRATES --all-features --all-targets -- -D warnings"
+    ;;
+test)
+    echo "==> tests (Linux, all features)"
+    run_in_container "cargo test $CRATES --all-features"
+    ;;
+shell)
+    docker run --rm -it \
+        -v "$HOST_ROOT:/work" \
+        -v "$REGISTRY_VOLUME:/usr/local/cargo/registry" \
+        -e CARGO_TARGET_DIR="$TARGET_DIR" \
+        -w /work "$IMAGE" bash
+    ;;
+all)
+    echo "==> clippy (Linux, all features)"
+    run_in_container "cargo clippy $CRATES --all-features --all-targets -- -D warnings"
+    echo "==> tests (Linux, all features)"
+    run_in_container "cargo test $CRATES --all-features"
+    ;;
+*)
+    echo "check-linux: unknown mode '$MODE' (use clippy, test, shell, or nothing)" >&2
+    exit 1
+    ;;
+esac
+
+echo "==> Linux check passed"

--- a/scripts/linux-check.Dockerfile
+++ b/scripts/linux-check.Dockerfile
@@ -1,0 +1,23 @@
+# Compile-and-test image for the Linux side of the Rust crates.
+#
+# Built by scripts/check-linux.sh. It exists so the apt install below happens
+# once rather than on every run.
+#
+# The toolchain is pinned to match rust-toolchain.toml. Keep the two in step:
+# the image ships 1.96.0 as its default, so a mismatch means rustup silently
+# downloads the pinned version on first use and every run pays for it.
+FROM rust:1.96-bookworm
+
+# libpcap-dev + pkg-config: netscli-core's `pcap` feature links against
+# libpcap, so --all-features does not build without it.
+#
+# Deliberately NOT the GTK/WebKit set that ci.yml installs. That workflow runs
+# `cargo test --all`, which pulls in netscli-gui and needs a desktop stack to
+# link. This image never builds the GUI -- see the crate list in
+# check-linux.sh -- so those packages would be several hundred MB bought for
+# nothing.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libpcap-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work


### PR DESCRIPTION
`netscli-core` carries **37 platform-conditional blocks**, and the least forgiving code in the project sits inside them:

- `crates/netscli-core/src/arp/platform/table.rs`
- `crates/netscli-core/src/arp/platform/mutate.rs`
- `crates/netscli-core/src/ping/raw_icmp.rs`

On a Windows machine `cargo clippy` compiles only the `cfg(windows)` arms. The Linux arms are not type-checked, not linted, and not tested locally at all — a mistake in them is invisible until CI.

`scripts/check-linux.sh` runs clippy and the tests for the three non-GUI crates in a `rust:1.96-bookworm` container matching the pinned toolchain.

```bash
./scripts/check-linux.sh          # clippy + tests
./scripts/check-linux.sh clippy   # clippy only
./scripts/check-linux.sh shell    # a prompt inside the image
```

## Measured, not assumed

Replacing the path in the `cfg(target_os = "linux")` arm of `table.rs` with an undefined symbol:

| command | result |
|---|---|
| `./scripts/check-linux.sh clippy` | **exit 101** — `E0425 cannot find value` |
| `cargo clippy -p netscli-core` (Windows) | **exit 0** |

Windows clippy passes on code that does not compile. That is the entire gap, and the container catches it. Restored afterwards; clippy and the full Linux test suite pass on the real tree.

## Two things easy to get wrong

- **netscli-gui is excluded deliberately.** Its Linux build needs the whole GTK/WebKit stack `ci.yml` installs, and none of the platform code this exists for lives there — so the image stays small.
- **`CARGO_TARGET_DIR` points at `/target-linux`**, for the same reason `/target-pcap` exists: Linux and Windows objects would evict each other on alternating builds.

Git Bash needed `MSYS_NO_PATHCONV` and `pwd -W` — without the first, `-w /work` reached docker as `C:/Program Files/Git/work`; without the second, the mount source stayed an MSYS path Docker Desktop cannot resolve.

## Scope

Does **not** replace CI, and does not touch the findings it was mistaken for: the GUI e2e suite (F-3) and `GUI Render` (F-5) are Windows/WebView2 problems a Linux container cannot address. macOS stays CI-only.