### PR TITLE
Drop the "On this page" marker and settle every rail bar at 1px

### DIFF
--- a/site/src/styles/starlight/18-mobile-shell-closeout-b.css
+++ b/site/src/styles/starlight/18-mobile-shell-closeout-b.css
@@ -12,7 +12,7 @@
     align-items: center;
     min-height: 2.25rem;
     padding: 0.35rem 0.75rem;
-    border-inline-start: 2px solid transparent;
+    border-inline-start: 1px solid transparent;
     color: var(--sl-color-gray-2);
     text-decoration: none;
   }
@@ -112,7 +112,7 @@
     padding-block: 0.35rem !important;
     padding-inline: clamp(1rem, 3.4vw, 1.75rem) !important;
     border-top: 0 !important;
-    border-inline-start: 2px solid transparent !important;
+    border-inline-start: 1px solid transparent !important;
     color: var(--sl-color-gray-2) !important;
     background: transparent !important;
   }

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -1,20 +1,19 @@
 /* Docs shell close-out: align desktop/mobile navigation states after the
    Starlight defaults and earlier responsive passes have loaded. */
-/* The "On this page" list gets the same rail-and-marker treatment as the
-   left nav. It had neither: no rail on the list, and the active link's
-   inline-start border was explicitly forced transparent, so the only cue was
-   a colour change on the text. */
+/* The "On this page" list gets the rail, and only the rail.
+   An earlier pass gave it the left nav's full rail-and-marker treatment, on
+   the reasoning that a colour change alone was too weak a cue. On a wide
+   screen that put two accent bars on screen at once, one per rail, at
+   different weights -- 2px here against the nav's 1px -- which read less
+   like a system than like a mistake. The marker belongs to the nav; see the
+   note on the current-link rule below. */
 .right-sidebar-panel :where(nav ul) {
   border-inline-start: 1px solid var(--sl-color-hairline);
 }
 
 .right-sidebar-panel :where(a) {
   display: block !important;
-  /* -1px so the link's own 2px border covers the list's 1px rail, rather
-     than sitting 7.2px inside it as the old -0.45rem did. */
-  margin-inline: -1px 0 !important;
   padding: 0.28rem 0.45rem 0.28rem 0.65rem !important;
-  border-inline-start: 2px solid transparent !important;
   color: var(--sl-color-gray-3) !important;
   text-decoration: none !important;
   border-radius: 0 !important;
@@ -27,12 +26,19 @@
   outline: 0 !important;
 }
 
+/* Colour only, no inline-start marker. The left nav's marker says "this is
+   the page you are on", which is a fact about the whole document; a second
+   marker in the rail beside it says the same thing about a heading, and two
+   bars of the same colour on one screen read as two claims of the same
+   weight. The heading you are level with changes as you scroll, so it is
+   the weaker of the two and a colour change carries it.
+
+   The rail on the <ul> above stays. That is a track, not a marker. */
 .right-sidebar-panel :where(a[aria-current='true']),
 .right-sidebar-panel :where(a[aria-current='page']),
 .right-sidebar-panel :where(a[aria-current='location']) {
   color: var(--netscli-accent-high) !important;
   background: transparent !important;
-  border-inline-start-color: var(--netscli-accent) !important;
 }
 
 html[data-theme='light'] .right-sidebar-panel :where(a):hover,
@@ -167,7 +173,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   }
 
   mobile-starlight-toc .dropdown a {
-    border-inline-start: 2px solid transparent !important;
+    border-inline-start: 1px solid transparent !important;
   }
 
   mobile-starlight-toc .dropdown a:hover,


### PR DESCRIPTION
Two problems, one cause.

The right-hand table of contents drew an accent bar beside the heading you were level with, and the left nav drew one beside the page you were on. On a wide screen **both were visible at once, saying the same thing at different weights** — 2px in the TOC against the nav's 1px.

## The marker belongs to the nav

Which page you are on is a fact about the whole document. Which heading you have scrolled past is not — it changes under you as you scroll — so it is the weaker of the two claims and does not need a bar of the same colour and weight to carry it.

The TOC now marks the current entry by colour alone, measured going from `#8c95a6` to `#a7f3c6`. The 2px track and the `-1px` margin that compensated for it are both gone; neither had anything left to align. The rail on the `<ul>` stays — that is a track, not a marker.

## One weight everywhere

Every remaining accent bar is now **1px**, matching the hairline rails they sit on:

| surface | before | after |
|---|---|---|
| left nav current page | 1px | 1px |
| docs TOC current heading | 2px | *(removed)* |
| mobile section menu | 2px | 1px |
| mobile TOC dropdown | 2px | 1px |

Nothing in the docs chrome draws a vertical line at any other weight.

## Verified in the browser, not from the diff

At an emulated 1600×900: TOC links measure `0px` inline-start border in **both** the resting and current states, and the nav's current link still measures `1px rgb(34, 197, 94)`.

Site gates: **124 contrast pairs ≥ 4.5:1**, dead-CSS budget **24 of 24 unchanged**, `astro check` clean, **axe 0 violations across 14 pages in both themes**.

The a11y check refused to run at first because the dev server was on its port — it declines to scan a dev server rather than pass on the wrong output. Stopped it and ran against the real build.

The file's header comment described the marker it was adding; rewritten to say why it is gone.