### PR TITLE
Pin the look of the built site before the override-layer audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,11 @@ docs/superpowers/
 IMPLEMENTATION_PLAN.md
 NEXT_GEN_NETWORKING_PLAN.md
 
+# Local visual-regression baselines for the docs refactor
+# (scripts/visual-snapshot.mjs). PNG bytes are exact on one machine and
+# meaningless across two -- font rasterisation differs between Windows and
+# the Ubuntu runners -- so these are a before/after tool for whoever is doing
+# the work, never a committed artifact or a CI gate.
+site/.visual-baseline/
+site/.visual-current/
+site/.visual-diff/

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -13,7 +13,11 @@
         "@astrojs/check": "^0.9.10",
         "@axe-core/cli": "^4.13.0",
         "linkedom": "^0.18.13",
+        "selenium-webdriver": "^4.44.0",
         "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@astrojs/check": {

--- a/site/package.json
+++ b/site/package.json
@@ -13,7 +13,9 @@
     "check": "astro check",
     "check:changelog": "node ./scripts/changelog-dates.mjs",
     "check:css": "node ./scripts/css-shadowing.mjs --max 24",
-    "test:a11y": "npm run build && node ./scripts/a11y.mjs"
+    "test:a11y": "npm run build && node ./scripts/a11y.mjs",
+    "visual:record": "node ./scripts/visual-snapshot.mjs record",
+    "visual:check": "node ./scripts/visual-snapshot.mjs check"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.7",
@@ -23,6 +25,7 @@
     "@astrojs/check": "^0.9.10",
     "@axe-core/cli": "^4.13.0",
     "linkedom": "^0.18.13",
+    "selenium-webdriver": "^4.44.0",
     "typescript": "^5.5.0"
   }
 }

--- a/site/scripts/a11y.mjs
+++ b/site/scripts/a11y.mjs
@@ -1,39 +1,12 @@
-import { spawn, spawnSync } from 'node:child_process';
-import { existsSync, readdirSync } from 'node:fs';
+import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import process from 'node:process';
-import { setTimeout as delay } from 'node:timers/promises';
+
+import { discoverRoutes, startPreview, resolveChromedriverPath } from './lib/preview-server.mjs';
 
 const host = process.env.A11Y_HOST || '127.0.0.1';
 const port = process.env.A11Y_PORT || '4322';
 const baseUrl = process.env.A11Y_BASE_URL || `http://${host}:${port}`;
-// Derive the route list from what was actually built rather than hard-coding
-// it (B-26). The hard-coded list covered 7 of 14 routes, and the seven it
-// missed -- /docs/cli/, /mcp/, /tui/, /operations/, /packet-capture/,
-// /core-library/, /result-model/ -- hold the heaviest table markup, which
-// docs-header.ts then wraps at runtime on every docs page. A list that has to
-// be updated by hand is exactly the list that drifts as pages are added.
-function discoverRoutes() {
-  const dist = join(process.cwd(), 'dist');
-  if (!existsSync(dist)) return null;
-
-  const found = [];
-  const walk = (dir, prefix) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(full, `${prefix}${entry.name}/`);
-      } else if (entry.name === 'index.html') {
-        found.push(prefix || '/');
-      } else if (entry.name.endsWith('.html')) {
-        found.push(`${prefix}${entry.name}`);
-      }
-    }
-  };
-  walk(dist, '/');
-  return found.sort();
-}
-
 // Falls back to the previous list only if dist/ is missing, so a caller who
 // forgot to build still gets a meaningful run instead of scanning nothing --
 // an empty route list would otherwise pass silently.
@@ -57,123 +30,6 @@ const urls = routes.map((route) => new URL(route, baseUrl).href);
 const modulePath = (...segments) => join(process.cwd(), 'node_modules', ...segments);
 const astroCli = modulePath('astro', 'bin', 'astro.mjs');
 const axeCli = modulePath('@axe-core', 'cli', 'dist', 'src', 'bin', 'cli.js');
-
-let preview;
-let previewOutput = '';
-
-// Cleanup kills whatever is listening on our port, not `preview.pid`.
-//
-// `preview.kill()` leaked the server on every run, and the tree-walk fix
-// tried first did not help either: `taskkill /T` exited 128 ("process not
-// found"). The node process we spawn re-execs and exits, so the process
-// actually holding the port is an orphan whose parent is already gone --
-// there is no tree left to walk from `preview.pid`.
-//
-// The leak was not cosmetic. The next run hit this script's own "something
-// is already listening, refusing to scan it" guard and exited 1, so the
-// check reliably blocked itself on its second invocation.
-//
-// Killing by port is safe here precisely because of that guard: we only
-// reach this point having confirmed the port was free and started the
-// server ourselves, so nothing else can own it.
-const listenersOnPort = () => {
-  if (process.platform === 'win32') {
-    const r = spawnSync('netstat', ['-ano'], { encoding: 'utf8' });
-    if (r.status !== 0 || !r.stdout) return [];
-    const lines = r.stdout.split(/\r?\n/);
-    const pids = lines
-      .filter((line) => line.includes('LISTENING') && line.includes(':' + port))
-      .map((line) => line.trim().split(/\s+/).pop())
-      .filter((pid) => pid && pid !== '0');
-    return [...new Set(pids)];
-  }
-  const r = spawnSync('lsof', ['-ti', 'tcp:' + port], { encoding: 'utf8' });
-  if (r.status !== 0 || !r.stdout) return [];
-  return [...new Set(r.stdout.split(/\s+/).filter(Boolean))];
-};
-
-const cleanup = () => {
-  if (!preview) return;
-  for (const pid of listenersOnPort()) {
-    if (process.platform === 'win32') {
-      spawnSync('taskkill', ['/pid', pid, '/T', '/F'], { stdio: 'ignore' });
-    } else {
-      try {
-        process.kill(Number(pid), 'SIGKILL');
-      } catch {
-        // Already gone.
-      }
-    }
-  }
-  if (!preview.killed) preview.kill();
-};
-
-process.on('exit', cleanup);
-process.on('SIGINT', () => {
-  cleanup();
-  process.exit(130);
-});
-process.on('SIGTERM', () => {
-  cleanup();
-  process.exit(143);
-});
-
-async function isServing() {
-  try {
-    const response = await fetch(baseUrl, { signal: AbortSignal.timeout(1500) });
-    return response.status < 500;
-  } catch {
-    return false;
-  }
-}
-
-async function waitForServer() {
-  for (let attempt = 0; attempt < 60; attempt += 1) {
-    if (await isServing()) return;
-    await delay(500);
-  }
-
-  throw new Error(`Timed out waiting for ${baseUrl}\n${previewOutput}`);
-}
-
-async function ensurePreview() {
-  if (await isServing()) {
-    // Reusing whatever answers on this port is how a green local run stops
-    // meaning anything. A long-running `astro dev` server also listens on
-    // 4322 and serves from source with different CSS processing, so the gate
-    // silently scanned something other than `dist/` -- and passed while CI,
-    // which always starts fresh, failed on a 1.53:1 contrast bug.
-    //
-    // Opt in explicitly if the running server really is the built output.
-    if (process.env.A11Y_REUSE_SERVER === '1') {
-      console.log(`Reusing the server already at ${baseUrl} (A11Y_REUSE_SERVER=1).`);
-      console.log('Note: this is only valid if it is serving the current dist/.');
-      return;
-    }
-    console.error(
-      `Something is already listening on ${baseUrl}.\n` +
-        'Refusing to scan it, because a dev server serves different output than\n' +
-        'the production build and would make this check pass on the wrong thing.\n' +
-        'Stop it, or set A11Y_REUSE_SERVER=1 if it is serving the current dist/.',
-    );
-    process.exit(1);
-  }
-
-  console.log(`Starting Astro preview at ${baseUrl}`);
-  preview = spawn(process.execPath, [astroCli, 'preview', '--host', host, '--port', port], {
-    env: { ...process.env, ASTRO_TELEMETRY_DISABLED: '1' },
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-
-  preview.stdout.on('data', (chunk) => {
-    previewOutput += chunk.toString();
-  });
-  preview.stderr.on('data', (chunk) => {
-    previewOutput += chunk.toString();
-  });
-
-  await waitForServer();
-}
 
 /**
  * The site has a light and a dark theme with SEPARATE colour tokens, and
@@ -211,24 +67,7 @@ const THEMES = [
  * the latter. Prefer that when it exists, and fall back to whatever
  * axe resolves on its own (which is the right behaviour locally).
  */
-function resolveChromedriverPath() {
-  const explicit = process.env.A11Y_CHROMEDRIVER_PATH;
-  const candidates = [
-    explicit,
-    process.env.CHROMEWEBDRIVER && join(process.env.CHROMEWEBDRIVER, 'chromedriver'),
-    process.env.CHROMEWEBDRIVER && join(process.env.CHROMEWEBDRIVER, 'chromedriver.exe'),
-  ].filter(Boolean);
-
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate;
-  }
-  if (explicit) {
-    console.warn(`A11Y_CHROMEDRIVER_PATH is set but ${explicit} does not exist; ignoring.`);
-  }
-  return null;
-}
-
-const chromedriverPath = resolveChromedriverPath();
+const chromedriverPath = resolveChromedriverPath(process.env.A11Y_CHROMEDRIVER_PATH);
 if (chromedriverPath) {
   console.log(`Using runner-matched chromedriver: ${chromedriverPath}`);
 }
@@ -270,7 +109,14 @@ function runAxe({ name, chromeOptions }) {
   });
 }
 
-await ensurePreview();
+const { cleanup } = await startPreview({
+  baseUrl,
+  host,
+  port,
+  astroCli,
+  allowReuse: process.env.A11Y_REUSE_SERVER === '1',
+  reuseHint: 'A11Y_REUSE_SERVER',
+});
 
 let failed = false;
 for (const theme of THEMES) {

--- a/site/scripts/lib/preview-server.mjs
+++ b/site/scripts/lib/preview-server.mjs
@@ -1,0 +1,201 @@
+/* Shared plumbing for checks that run against the BUILT site.
+ *
+ * Extracted from a11y.mjs when visual-fingerprint.mjs needed the same three
+ * things. Every comment below records a bug that was actually hit; a second
+ * hand-written copy of this logic would have re-hit them one at a time, which
+ * is the whole reason it lives in one place now.
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
+import { setTimeout as delay } from 'node:timers/promises';
+
+/**
+ * Every route the build actually produced.
+ *
+ * Derived from dist/ rather than hard-coded (B-26). The hard-coded list
+ * covered 7 of 14 routes, and the seven it missed -- /docs/cli/, /mcp/,
+ * /tui/, /operations/, /packet-capture/, /core-library/, /result-model/ --
+ * hold the heaviest table markup. A list maintained by hand is exactly the
+ * list that drifts as pages are added.
+ *
+ * Returns null when dist/ is absent so the caller can decide whether that is
+ * fatal; an empty list would let a check pass having scanned nothing.
+ */
+export function discoverRoutes(cwd = process.cwd()) {
+  const dist = join(cwd, 'dist');
+  if (!existsSync(dist)) return null;
+
+  const found = [];
+  const walk = (dir, prefix) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full, `${prefix}${entry.name}/`);
+      } else if (entry.name === 'index.html') {
+        found.push(prefix || '/');
+      } else if (entry.name.endsWith('.html')) {
+        found.push(`${prefix}${entry.name}`);
+      }
+    }
+  };
+  walk(dist, '/');
+  return found.sort();
+}
+
+/** PIDs listening on `port`, on either platform. */
+function listenersOnPort(port) {
+  if (process.platform === 'win32') {
+    const r = spawnSync('netstat', ['-ano'], { encoding: 'utf8' });
+    if (r.status !== 0 || !r.stdout) return [];
+    return [
+      ...new Set(
+        r.stdout
+          .split(/\r?\n/)
+          .filter((line) => line.includes('LISTENING') && line.includes(':' + port))
+          .map((line) => line.trim().split(/\s+/).pop())
+          .filter((pid) => pid && pid !== '0'),
+      ),
+    ];
+  }
+  const r = spawnSync('lsof', ['-ti', 'tcp:' + port], { encoding: 'utf8' });
+  if (r.status !== 0 || !r.stdout) return [];
+  return [...new Set(r.stdout.split(/\s+/).filter(Boolean))];
+}
+
+/**
+ * Start `astro preview`, or refuse if the port is already taken.
+ *
+ * Returns a `{ cleanup }` handle. The caller must invoke it; the process
+ * hooks below also run it, so an interrupted run does not leak the server.
+ *
+ * @param {object} options
+ * @param {string} options.baseUrl   e.g. http://127.0.0.1:4322
+ * @param {string} options.host
+ * @param {string} options.port
+ * @param {string} options.astroCli  path to astro's bin
+ * @param {boolean} options.allowReuse  honour the caller's REUSE env opt-in
+ * @param {string} options.reuseHint    env var name to name in the message
+ */
+export async function startPreview({ baseUrl, host, port, astroCli, allowReuse, reuseHint }) {
+  let preview;
+  let previewOutput = '';
+
+  // Cleanup kills whatever is listening on our port, not `preview.pid`.
+  //
+  // `preview.kill()` leaked the server on every run, and a tree-walk fix
+  // did not help either: `taskkill /T` exited 128 ("process not found").
+  // The node process we spawn re-execs and exits, so the process actually
+  // holding the port is an orphan whose parent is already gone -- there is
+  // no tree left to walk from `preview.pid`.
+  //
+  // The leak was not cosmetic. The next run hit the "already listening"
+  // guard below and exited 1, so the check reliably blocked itself on its
+  // second invocation.
+  //
+  // Killing by port is safe precisely because of that guard: we only reach
+  // here having confirmed the port was free and started the server
+  // ourselves, so nothing else can own it.
+  const cleanup = () => {
+    if (!preview) return;
+    for (const pid of listenersOnPort(port)) {
+      if (process.platform === 'win32') {
+        spawnSync('taskkill', ['/pid', pid, '/T', '/F'], { stdio: 'ignore' });
+      } else {
+        try {
+          process.kill(Number(pid), 'SIGKILL');
+        } catch {
+          // Already gone.
+        }
+      }
+    }
+    if (!preview.killed) preview.kill();
+  };
+
+  process.on('exit', cleanup);
+  process.on('SIGINT', () => {
+    cleanup();
+    process.exit(130);
+  });
+  process.on('SIGTERM', () => {
+    cleanup();
+    process.exit(143);
+  });
+
+  const isServing = async () => {
+    try {
+      const response = await fetch(baseUrl, { signal: AbortSignal.timeout(1500) });
+      return response.status < 500;
+    } catch {
+      return false;
+    }
+  };
+
+  if (await isServing()) {
+    // Reusing whatever answers on this port is how a green local run stops
+    // meaning anything. A long-running `astro dev` server also listens on
+    // 4322 and serves from source with different CSS processing, so the gate
+    // silently checked something other than dist/ -- and passed while CI,
+    // which always starts fresh, failed on a 1.53:1 contrast bug.
+    if (allowReuse) {
+      console.log(`Reusing the server already at ${baseUrl} (${reuseHint}=1).`);
+      console.log('Note: this is only valid if it is serving the current dist/.');
+      return { cleanup };
+    }
+    console.error(
+      `Something is already listening on ${baseUrl}.\n` +
+        'Refusing to use it, because a dev server serves different output than\n' +
+        'the production build and would make this check pass on the wrong thing.\n' +
+        `Stop it, or set ${reuseHint}=1 if it is serving the current dist/.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`Starting Astro preview at ${baseUrl}`);
+  preview = spawn(process.execPath, [astroCli, 'preview', '--host', host, '--port', port], {
+    env: { ...process.env, ASTRO_TELEMETRY_DISABLED: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  preview.stdout.on('data', (chunk) => {
+    previewOutput += chunk.toString();
+  });
+  preview.stderr.on('data', (chunk) => {
+    previewOutput += chunk.toString();
+  });
+
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    if (await isServing()) return { cleanup };
+    await delay(500);
+  }
+  throw new Error(`Timed out waiting for ${baseUrl}\n${previewOutput}`);
+}
+
+/**
+ * ChromeDriver has to match the installed Chrome's major version exactly.
+ * The `chromedriver` npm package fetches whatever is newest at install
+ * time -- so the day ChromeDriver 151 ships and the runner image still has
+ * Chrome 150, every run dies with "session not created". Nothing about the
+ * site changed; the check just stops working.
+ *
+ * GitHub's Ubuntu images ship a matched pair and point `CHROMEWEBDRIVER` at
+ * the directory holding the driver. Prefer that when it exists, and fall
+ * back to whatever resolves locally.
+ */
+export function resolveChromedriverPath(explicitEnv) {
+  const explicit = explicitEnv;
+  const candidates = [
+    explicit,
+    process.env.CHROMEWEBDRIVER && join(process.env.CHROMEWEBDRIVER, 'chromedriver'),
+    process.env.CHROMEWEBDRIVER && join(process.env.CHROMEWEBDRIVER, 'chromedriver.exe'),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  if (explicit) {
+    console.warn(`Chromedriver path ${explicit} does not exist; ignoring.`);
+  }
+  return null;
+}

--- a/site/scripts/visual-snapshot.mjs
+++ b/site/scripts/visual-snapshot.mjs
@@ -1,0 +1,364 @@
+/* Pin the look of the built site so a refactor can prove it changed nothing.
+ *
+ *   node scripts/visual-snapshot.mjs record    # capture the baseline
+ *   node scripts/visual-snapshot.mjs check     # capture again, compare
+ *
+ * Why this exists: the Starlight override layer is being audited declaration
+ * by declaration, and the whole premise of that audit is "the site must look
+ * identical afterwards". Without a mechanical check, every one of those
+ * judgements collapses into "does this still look right to me today", which
+ * is how the layer reached 958 !important declarations in the first place.
+ *
+ * WHAT IT IS NOT: a CI gate, and deliberately so. It compares PNG bytes, so
+ * it is exact on one machine and meaningless across two -- font rasterisation
+ * differs between Windows and the Ubuntu runners, and every capture would
+ * differ for reasons that have nothing to do with the CSS. Committing the
+ * baselines would also add megabytes of binary churn to a repo whose other
+ * guards are all text. So: baselines live in a gitignored directory, and this
+ * is a local before/after tool for whoever is doing the refactor.
+ *
+ * The existing CI gates still cover what they always did -- contrast, dead
+ * CSS, axe, the build. This covers the thing none of them can: "did the page
+ * move".
+ *
+ * Byte comparison rather than a perceptual diff is on purpose. Identical
+ * input renders to identical bytes, so any difference is real; a tolerance
+ * threshold is a knob that eventually gets widened until it passes. When a
+ * capture differs, the two PNGs are written side by side for you to look at
+ * -- a human deciding "that is the change I meant" is the point, not a
+ * number deciding it.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync, existsSync, rmSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
+
+import { Builder } from 'selenium-webdriver';
+import chrome from 'selenium-webdriver/chrome.js';
+
+import { discoverRoutes, startPreview, resolveChromedriverPath } from './lib/preview-server.mjs';
+
+const host = process.env.VISUAL_HOST || '127.0.0.1';
+const port = process.env.VISUAL_PORT || '4323';
+const baseUrl = `http://${host}:${port}`;
+const root = process.cwd();
+const baselineDir = join(root, '.visual-baseline');
+const currentDir = join(root, '.visual-current');
+const diffDir = join(root, '.visual-diff');
+
+const mode = process.argv[2] || 'check';
+if (!['record', 'check'].includes(mode)) {
+  console.error(`Usage: visual-snapshot.mjs [record|check]  (got "${mode}")`);
+  process.exit(1);
+}
+
+/* Widths, not device presets. The docs shell switches layout at 72rem and
+ * again at 50rem -- the values the override layer's media queries actually
+ * use -- so these sit either side of both, plus one comfortably above. A
+ * preset like "iPhone 12" would tie the baseline to a device list that has
+ * nothing to do with where this CSS branches. */
+const WIDTHS = [1600, 1100, 700];
+
+/* Both themes, because they carry SEPARATE colour tokens. A check that ran
+ * one theme would be blind to half the colour work -- the same blind spot
+ * that once hid a 1.53:1 contrast failure from every local a11y run. */
+/* Selected through the site's OWN theme switch, not Chrome's.
+ *
+ * `--force-dark-mode` is what the a11y check uses, and it is right there
+ * because axe reads computed colours. For pixels it is unusable: that flag
+ * turns on Chrome's automatic darkening, which re-tints content the browser
+ * decides is not already dark, progressively and by its own heuristics. Every
+ * unstable capture measured during development was a dark one -- 18 of 18 in
+ * the worst run -- while light was rock solid.
+ *
+ * Starlight persists the choice in localStorage and reflects it as
+ * `data-theme` on <html>, which is also the real user path, so this tests
+ * what a visitor sees rather than what a browser flag improvises. */
+const THEMES = [{ name: 'light' }, { name: 'dark' }];
+
+const discovered = discoverRoutes(root);
+if (!discovered) {
+  console.error('No dist/ found. Run `npm run build` first — this checks the built site.');
+  process.exit(1);
+}
+// A subset for when you are iterating on one page and do not want to wait for
+// all 84 captures. Never set in a real check: a baseline recorded from a
+// subset silently compares nothing on every other route.
+const routes = process.env.VISUAL_ROUTES
+  ? process.env.VISUAL_ROUTES.split(/[\s,]+/).filter(Boolean)
+  : discovered;
+
+/* Build before capturing, from inside this process.
+ *
+ * Two bugs, one fix. This compares the BUILT site, so a CSS edit that has not
+ * been rebuilt is invisible -- and that is not hypothetical: the first
+ * sabotage test of this very script reported "Identical" against a
+ * deliberately broken stylesheet, because the build had not been re-run.
+ * Putting the build in an npm script instead would work, except `npm run`
+ * here executes inside a sandbox that Chrome cannot launch from, so the
+ * capture has to be started as a plain `node` process. Doing the build here
+ * means the one supported invocation does both.
+ */
+if (process.env.VISUAL_SKIP_BUILD !== '1') {
+  const { spawnSync } = await import('node:child_process');
+  console.log('Building the site...');
+  const built = spawnSync(
+    process.execPath,
+    [join(root, 'node_modules', 'astro', 'bin', 'astro.mjs'), 'build'],
+    { stdio: ['ignore', 'ignore', 'inherit'], env: { ...process.env, ASTRO_TELEMETRY_DISABLED: '1' } },
+  );
+  if (built.status !== 0) {
+    console.error('Build failed; refusing to capture a stale dist/.');
+    process.exit(1);
+  }
+}
+
+function slug(route, theme, width) {
+  const r = route.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '') || 'index';
+  return `${r}__${theme}__${width}.png`;
+}
+
+/**
+ * Screenshot repeatedly until two in a row are byte-identical.
+ *
+ * Returns the stable image, or the last one taken if the page never settles
+ * (a page that genuinely never stops moving should show up as a difference
+ * rather than hang the run).
+ */
+async function settle(driver, attempts = 6, gapMs = 200) {
+  let previous = await driver.takeScreenshot();
+  for (let i = 0; i < attempts; i += 1) {
+    await new Promise((r) => setTimeout(r, gapMs));
+    const next = await driver.takeScreenshot();
+    if (next === previous) return next;
+    previous = next;
+  }
+  return previous;
+}
+
+/**
+ * @param {string} outDir
+ * @param {Array<{route:string,theme:string,width:number}>} [only]
+ *   Restrict to these captures. Used by the confirmation pass, which
+ *   re-takes just the handful that differed rather than all 84.
+ */
+async function capture(outDir, only) {
+  rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(outDir, { recursive: true });
+  const wanted = only && new Set(only.map((t) => slug(t.route, t.theme, t.width)));
+
+  const driverPath = resolveChromedriverPath(process.env.VISUAL_CHROMEDRIVER_PATH);
+  let captured = 0;
+
+  for (const theme of THEMES) {
+    const options = new chrome.Options();
+    // Headless is not optional: a headed Chrome takes its colour scheme from
+    // the OS and ignores --force-dark-mode, so both passes would render the
+    // same theme and one would never be captured.
+    options.addArguments(
+      '--headless=new',
+      '--hide-scrollbars',
+      '--force-device-scale-factor=1',
+      // Blackhole every host except the local preview. The landing page and
+      // the changelog both fetch api.github.com at runtime for star counts,
+      // download totals and the latest release, so with the network reachable
+      // the captured pixels depend on what GitHub answered and how fast --
+      // measured as 2, 5 and 3 spurious differences on three consecutive runs
+      // of an unchanged tree. Offline, those elements settle into one state.
+      '--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1',
+      // Pin colour handling so two machines at least start from the same
+      // rendering intent, and nothing re-tints behind our back.
+      '--force-color-profile=srgb',
+      // Text rasterisation is the last source of non-determinism: with these
+      // off, the same page re-rendered differed by 30-220 bytes in a ~300KB
+      // PNG -- antialiasing on glyph edges, no layout change at all. Hinting
+      // and subpixel positioning are the two knobs that vary; disabling them
+      // costs a little text fidelity in a throwaway screenshot and buys an
+      // exact comparison.
+      '--disable-lcd-text',
+      '--font-render-hinting=none',
+      '--disable-font-subpixel-positioning',
+      '--disable-partial-raster',
+      '--disable-gpu',
+    );
+    const service = driverPath ? new chrome.ServiceBuilder(driverPath) : undefined;
+    const builder = new Builder().forBrowser('chrome').setChromeOptions(options);
+    if (service) builder.setChromeService(service);
+    const driver = await builder.build();
+
+    try {
+      // Select the theme the way a visitor does, then let every later page
+      // load pick it up from localStorage. Done before the warm-up so the
+      // cached render and the captured render agree on the theme.
+      await driver.get(new URL('/', baseUrl).href);
+      await driver.executeScript(
+        'localStorage.setItem("starlight-theme", arguments[0]); document.documentElement.dataset.theme = arguments[0];',
+        theme.name,
+      );
+
+      // Warm-up pass: visit every route once, capturing nothing.
+      //
+      // Without this the FIRST visit to each page rendered differently from
+      // every later one -- fonts, the Pagefind search bundle and the theme
+      // script are all fetched and cached per browser session. Measured on an
+      // unchanged tree: 35 differences, then 1, then 0, converging on a stable
+      // state that the freshly-recorded baseline was not part of. A baseline
+      // that is systematically the odd one out is worse than no baseline,
+      // because the first real check looks like a regression.
+      for (const route of routes) {
+        await driver.get(new URL(route, baseUrl).href);
+      }
+
+      for (const width of WIDTHS) {
+        for (const route of routes) {
+          if (wanted && !wanted.has(slug(route, theme.name, width))) continue;
+          await driver.get(new URL(route, baseUrl).href);
+          // Size to the full document so the capture is the whole page, not
+          // the fold. Height is read after the width is applied, because the
+          // page reflows and a tall-at-1600 page is a different height at 700.
+          await driver.manage().window().setRect({ width, height: 900 });
+          const docHeight = await driver.executeScript(
+            'return Math.max(document.body.scrollHeight, document.documentElement.scrollHeight);',
+          );
+          await driver.manage().window().setRect({ width, height: Math.min(Number(docHeight) + 120, 12000) });
+          // Fonts and the theme script both land after first paint; without
+          // this the first capture of each run differs from every later one.
+          await driver.executeScript('return document.fonts ? document.fonts.ready : true;');
+          // Freeze motion. A transition or animation mid-flight is a pixel
+          // difference that says nothing about the CSS being audited.
+          await driver.executeScript(`
+            const id = '__visual_freeze__';
+            if (!document.getElementById(id)) {
+              const s = document.createElement('style');
+              s.id = id;
+              s.textContent = '*,*::before,*::after{transition:none!important;animation:none!important;caret-color:transparent!important;scroll-behavior:auto!important}';
+              document.head.appendChild(s);
+            }
+          `);
+
+          // Settle rather than sleep. A fixed delay is a guess that is either
+          // too short (flaky) or too long (slow), and the right value differs
+          // per page. Capturing until two consecutive frames match makes the
+          // wait self-adjusting and, more importantly, makes "stable" the
+          // condition being tested rather than "0.25s elapsed".
+          const png = await settle(driver);
+          const name = slug(route, theme.name, width);
+          writeFileSync(join(outDir, name), Buffer.from(png, 'base64'));
+          captured += 1;
+          if (process.env.VISUAL_VERBOSE) console.log(`  ${name}`);
+        }
+      }
+    } finally {
+      await driver.quit();
+    }
+  }
+  return captured;
+}
+
+const reuse = process.env.VISUAL_REUSE_SERVER === '1';
+const { cleanup } = await startPreview({
+  baseUrl,
+  host,
+  port,
+  astroCli: join(root, 'node_modules', 'astro', 'bin', 'astro.mjs'),
+  allowReuse: reuse,
+  reuseHint: 'VISUAL_REUSE_SERVER',
+});
+
+const target = mode === 'record' ? baselineDir : currentDir;
+console.log(
+  `Capturing ${routes.length} route(s) x ${THEMES.length} theme(s) x ${WIDTHS.length} width(s)...`,
+);
+const count = await capture(target);
+cleanup();
+console.log(`Captured ${count} image(s) into ${target.replace(root, '.')}`);
+
+if (mode === 'record') {
+  console.log('Baseline recorded. Re-run with `check` after each refactor step.');
+  process.exit(0);
+}
+
+if (!existsSync(baselineDir)) {
+  console.error('No baseline to compare against. Run `record` first.');
+  process.exit(1);
+}
+
+const baseFiles = new Set(readdirSync(baselineDir));
+const curFiles = new Set(readdirSync(currentDir));
+const changed = [];
+const added = [...curFiles].filter((f) => !baseFiles.has(f));
+const removed = [...baseFiles].filter((f) => !curFiles.has(f));
+
+for (const file of [...baseFiles].filter((f) => curFiles.has(f)).sort()) {
+  const a = readFileSync(join(baselineDir, file));
+  const b = readFileSync(join(currentDir, file));
+  if (!a.equals(b)) changed.push(file);
+}
+
+if (!changed.length && !added.length && !removed.length) {
+  console.log(`\n✓ Identical: all ${baseFiles.size} captures match the baseline.`);
+  process.exit(0);
+}
+
+/* Confirm before reporting.
+ *
+ * About one capture in a hundred still differs for reasons that are not the
+ * CSS -- measured as a single flagged page across otherwise clean runs. A
+ * real change is deterministic and survives a second look; that residue does
+ * not. Only the captures that already differ are re-taken, so the cost is a
+ * few seconds rather than a second full pass, and a guard that cries wolf
+ * once a run is a guard that stops being read.
+ */
+if (changed.length) {
+  const parse = (file) => {
+    const [routePart, theme, widthPart] = file.replace(/\.png$/, '').split('__');
+    const route = routes.find((r) => slug(r, theme, Number(widthPart)) === file);
+    return route ? { route, theme, width: Number(widthPart) } : null;
+  };
+  const targets = changed.map(parse).filter(Boolean);
+  if (targets.length) {
+    console.log(`\nRe-checking ${targets.length} differing capture(s) to rule out render noise...`);
+    const confirmDir = join(root, '.visual-confirm');
+    const { cleanup: cleanup2 } = await startPreview({
+      baseUrl,
+      host,
+      port,
+      astroCli: join(root, 'node_modules', 'astro', 'bin', 'astro.mjs'),
+      allowReuse: reuse,
+      reuseHint: 'VISUAL_REUSE_SERVER',
+    });
+    await capture(confirmDir, targets);
+    cleanup2();
+    const stillChanged = changed.filter((file) => {
+      const confirmed = join(confirmDir, file);
+      if (!existsSync(confirmed)) return true;
+      return !readFileSync(join(baselineDir, file)).equals(readFileSync(confirmed));
+    });
+    const dropped = changed.length - stillChanged.length;
+    if (dropped) console.log(`  ${dropped} settled on re-capture and were not real.`);
+    rmSync(confirmDir, { recursive: true, force: true });
+    changed.length = 0;
+    changed.push(...stillChanged);
+  }
+}
+
+if (!changed.length && !added.length && !removed.length) {
+  console.log(`\n✓ Identical: all ${baseFiles.size} captures match the baseline.`);
+  process.exit(0);
+}
+
+// Copy the differing pairs somewhere a human can open them side by side.
+rmSync(diffDir, { recursive: true, force: true });
+mkdirSync(diffDir, { recursive: true });
+for (const file of changed) {
+  writeFileSync(join(diffDir, `BEFORE__${file}`), readFileSync(join(baselineDir, file)));
+  writeFileSync(join(diffDir, `AFTER__${file}`), readFileSync(join(currentDir, file)));
+}
+
+console.error(`\n✗ ${changed.length} capture(s) differ from the baseline:`);
+for (const file of changed) console.error(`   ${file}`);
+if (added.length) console.error(`\n  new captures (route added?): ${added.join(', ')}`);
+if (removed.length) console.error(`\n  missing captures (route removed?): ${removed.join(', ')}`);
+console.error(`\nBefore/after pairs written to ${diffDir.replace(root, '.')} — open them and decide.`);
+console.error('If the change is the one you intended, re-run `record` to move the baseline.');
+process.exit(1);


### PR DESCRIPTION
Step 0 of the Starlight override-layer audit. That audit's whole premise is *"the site must look identical afterwards"* — and without a mechanical check, each of the 528 layout/spacing judgements collapses into "does this still look right to me today", which is how the layer reached 958 `!important` declarations in the first place.

```bash
node scripts/visual-snapshot.mjs record   # capture the baseline
node scripts/visual-snapshot.mjs check    # capture again, compare
```

14 routes × 2 themes × 3 widths = **84 captures** of the built site, compared as PNG bytes.

## Deliberately a local tool, not a CI gate

Byte equality is exact on one machine and meaningless across two — font rasterisation differs between Windows and the Ubuntu runners — and committing 84 PNGs would add megabytes of binary churn to a repo whose other guards are all text. Baselines are gitignored.

## Determinism took four measured rounds

Each is a comment in the file naming what it observed:

| cause | evidence |
|---|---|
| `api.github.com` fetched at runtime by the landing page and changelog | 2, 5, 3 spurious differences on three consecutive **unchanged** runs. Non-local hosts now blackholed. |
| Chrome's `--force-dark-mode` algorithmically re-tints content | every unstable capture in the worst run was dark — **18 of 18**. Theme now chosen via Starlight's own localStorage switch, which is also the real user path. |
| glyph antialiasing | moved 30–220 bytes in a ~300KB PNG with no layout change. Hinting and subpixel positioning off. |
| first visit to a page renders differently from later ones | fonts, Pagefind and the theme script cache per session, so a fresh baseline was systematically the odd one out. Warm-up pass added. |

A residue of ~1 capture in 100 survived all that, so **a differing capture is re-taken before it is reported** — a real change is deterministic and survives; noise settles. Observed doing exactly that during validation.

## Sabotage-checked

Changing one sidebar marker from `1px` to `2px` is reported across **44 captures**, survives the re-check, and **none are at 700px** — where that element isn't rendered. Reverted; three consecutive runs identical.

## Two traps closed

- **The script builds the site itself.** The first sabotage attempt reported "Identical" against a deliberately broken stylesheet, because `dist/` was stale. Putting the build in an npm script doesn't work either — `npm run` here executes in a sandbox Chrome cannot launch from.
- **`a11y.mjs` and this script now share `scripts/lib/preview-server.mjs`.** Both need to start a preview, refuse a busy port, and clean up an orphaned server — each a bug hit and fixed once, and two copies would drift. `a11y.mjs` behaviour is unchanged: re-run after the extraction, **0 violations across 14 pages in both themes**.

## Dependencies

`selenium-webdriver` promoted to a direct devDependency (this script imports it; it was only present transitively via `@axe-core/cli`). **`chromedriver` deliberately not declared** — npm wanted 152.0.2 against an installed Chrome 151, which is the exact version-skew failure `a11y.mjs` already documents, and it runs install scripts. It stays ambient, resolved from PATH or `CHROMEWEBDRIVER`.