### PR TITLE
Point 38 hard-coded colours at the tokens that already held them

### DIFF
--- a/site/src/styles/starlight/03-shell-layout-base.css
+++ b/site/src/styles/starlight/03-shell-layout-base.css
@@ -238,7 +238,7 @@ html[data-theme='light'] .main-pane {
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
-  border-color: rgba(17, 24, 39, 0.12);
+  border-color: var(--sl-color-hairline-light);
   box-shadow:
     0 12px 34px rgba(17, 24, 39, 0.11),
     inset 0 1px 0 rgba(255, 255, 255, 0.78);

--- a/site/src/styles/starlight/04-markdown-content-base.css
+++ b/site/src/styles/starlight/04-markdown-content-base.css
@@ -268,7 +268,7 @@ starlight-theme-select option {
 
 html[data-theme='light'] starlight-theme-select option {
 
-  background-color: #ffffff;
+  background-color: var(--sl-color-black);
 }
 
 html[data-theme='light'] starlight-theme-select label {

--- a/site/src/styles/starlight/05-docs-surfaces.css
+++ b/site/src/styles/starlight/05-docs-surfaces.css
@@ -204,7 +204,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
 
 html[data-theme='light'] .sl-markdown-content table {
 
-  border-color: rgba(17, 24, 39, 0.12);
+  border-color: var(--sl-color-hairline-light);
   box-shadow: 0 10px 24px rgba(17, 24, 39, 0.07);
 }
 
@@ -214,11 +214,11 @@ html[data-theme='light'] .sl-markdown-content thead tr {
 }
 
 html[data-theme='light'] .sl-markdown-content th {
-  color: #243044;
+  color: var(--sl-color-gray-1);
 }
 
 html[data-theme='light'] .sl-markdown-content tbody tr {
-  background: #ffffff;
+  background: var(--sl-color-black);
 }
 
 html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even) {

--- a/site/src/styles/starlight/07-docs-interaction-b.css
+++ b/site/src/styles/starlight/07-docs-interaction-b.css
@@ -84,7 +84,7 @@
 }
 
 html[data-theme='light'] .sl-markdown-content tbody tr:hover {
-  background: #ffffff;
+  background: var(--sl-color-black);
 }
 
 html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
@@ -126,7 +126,7 @@ html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
 html[data-theme='light'] .pagination-links a:hover {
   background: rgba(17, 24, 39, 0.022) !important;
   border-color: rgba(17, 24, 39, 0.16) !important;
-  color: #111827 !important;
+  color: var(--sl-color-white) !important;
 }
 
 .pagination-links a > svg {
@@ -135,7 +135,7 @@ html[data-theme='light'] .pagination-links a:hover {
 }
 
 html[data-theme='light'] .pagination-links a > svg {
-  color: #146b2e;
+  color: var(--sl-color-accent);
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__result-inner,

--- a/site/src/styles/starlight/08-search-modal.css
+++ b/site/src/styles/starlight/08-search-modal.css
@@ -126,7 +126,7 @@ html[data-theme='light'] site-search button[data-close-modal] {
 html[data-theme='light'] site-search button[data-close-modal]:hover,
 html[data-theme='light'] site-search button[data-close-modal]:focus-visible {
   background: rgba(0, 122, 84, 0.1) !important;
-  color: #111827 !important;
+  color: var(--sl-color-white) !important;
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__form::before {
@@ -137,25 +137,25 @@ html[data-theme='light'] #starlight__search .pagefind-ui__form::before {
 html[data-theme='light'] #starlight__search .pagefind-ui__search-input {
 
   border-color: rgba(17, 24, 39, 0.24) !important;
-  color: #111827 !important;
+  color: var(--sl-color-white) !important;
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__search-input::placeholder {
   color: #5b667a;
   opacity: 1;
 }html[data-theme='light'] #starlight__search .pagefind-ui__message {
-  color: #44516a;
+  color: var(--sl-color-gray-2);
 }
 html[data-theme='light'] #starlight__search .pagefind-ui__message .search-data {
-  color: #111827;
+  color: var(--sl-color-white);
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__search-clear::before {
-  background-color: #146b2e;
+  background-color: var(--sl-color-accent);
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__result-inner {
-  background: #ffffff !important;
+  background: var(--sl-color-black) !important;
   border-color: rgba(17, 24, 39, 0.14);
 }
 
@@ -167,12 +167,12 @@ html[data-theme='light']
 
 html[data-theme='light'] #starlight__search .pagefind-ui__result-nested,
 html[data-theme='light'] #starlight__search .pagefind-ui__result-tags {
-  background: #ffffff !important;
+  background: var(--sl-color-black) !important;
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__result-link {
   --pagefind-ui-text: #111827;
-  color: #111827 !important;
+  color: var(--sl-color-white) !important;
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__result-excerpt {
@@ -180,8 +180,8 @@ html[data-theme='light'] #starlight__search .pagefind-ui__result-excerpt {
 }
 
 html[data-theme='light'] #starlight__search mark {
-  color: #0b4a1f !important;
-  background: #dcf8e4 !important;
+  color: var(--sl-color-accent-high) !important;
+  background: var(--sl-color-accent-low) !important;
 }
 
 html[data-theme='light']
@@ -189,9 +189,9 @@ html[data-theme='light']
   .pagefind-ui__drawer:not(:has(.pagefind-ui__result)):not(:has(.pagefind-ui__message)),
 html[data-theme='light'] site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidden)::after,
 html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__message):not(:has(.pagefind-ui__result)) {
-  background: #ffffff;
+  background: var(--sl-color-black);
   border-color: rgba(17, 24, 39, 0.18);
-  color: #44516a;
+  color: var(--sl-color-gray-2);
 }
 
 /* ─── Narrow-screen search dialog ───────────────────────────────────────

--- a/site/src/styles/starlight/09-search-table-fit.css
+++ b/site/src/styles/starlight/09-search-table-fit.css
@@ -60,7 +60,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
 
 html[data-theme='light'] .sl-markdown-content tbody tr,
 html[data-theme='light'] .sl-markdown-content tbody tr:hover {
-  background: #ffffff !important;
+  background: var(--sl-color-black) !important;
 }
 
 html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even),
@@ -71,7 +71,7 @@ html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy button {
   border-color: rgba(17, 24, 39, 0.14) !important;
   background: #e9eef2 !important;
-  color: #243044 !important;
+  color: var(--sl-color-gray-1) !important;
   opacity: 1;
   box-shadow: none !important;
 }

--- a/site/src/styles/starlight/11-docs-chrome-consistency.css
+++ b/site/src/styles/starlight/11-docs-chrome-consistency.css
@@ -93,7 +93,7 @@ html[data-theme='light'] .main-pane > main > .content-panel:first-child::before 
 }
 
 html[data-theme='light'] .sl-markdown-content :not(pre) > code {
-  color: #146b2e !important;
+  color: var(--sl-color-accent) !important;
 }
 
 .sl-markdown-content a,
@@ -111,7 +111,7 @@ html[data-theme='light'] .sl-markdown-content a,
 html[data-theme='light'] .sl-markdown-content .sl-anchor-link,
 html[data-theme='light'] .sl-markdown-content .sl-anchor-link:focus,
 html[data-theme='light'] .sl-markdown-content .sl-heading-wrapper:hover .sl-anchor-link {
-  color: #146b2e !important;
+  color: var(--sl-color-accent) !important;
 }
 
 html[data-theme='light'] .sl-markdown-content a:hover {
@@ -138,7 +138,7 @@ html[data-theme='light'] .sl-markdown-content a:hover {
 
 html[data-theme='light'] .external-link::after,
 html[data-theme='light'] .sl-markdown-content a[href^='http']::after {
-  color: #146b2e !important;
+  color: var(--sl-color-accent) !important;
 }
 
 html[data-theme='light'] .external-link:hover::after,

--- a/site/src/styles/starlight/12-docs-toc-responsive.css
+++ b/site/src/styles/starlight/12-docs-toc-responsive.css
@@ -114,22 +114,22 @@
 html[data-theme='light'] mobile-starlight-toc .toggle {
   border-color: rgba(17, 24, 39, 0.14) !important;
   background: rgba(255, 255, 255, 0.72) !important;
-  color: #243044 !important;
+  color: var(--sl-color-gray-1) !important;
 }
 
 html[data-theme='light'] mobile-starlight-toc details[open] .toggle,
 html[data-theme='light'] mobile-starlight-toc details .toggle:hover,
 html[data-theme='light'] mobile-starlight-toc summary:focus-visible .toggle {
   border-color: rgba(0, 122, 84, 0.36) !important;
-  color: #111827 !important;
+  color: var(--sl-color-white) !important;
 }
 
 html[data-theme='light'] mobile-starlight-toc .caret {
-  color: #146b2e;
+  color: var(--sl-color-accent);
 }
 
 html[data-theme='light'] mobile-starlight-toc .display-current {
-  color: #44516a !important;
+  color: var(--sl-color-gray-2) !important;
 }.sl-markdown-content .expressive-code .copy .feedback {
   position: absolute !important;
   width: 1px !important;
@@ -196,9 +196,9 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .copy button[data
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy:has(.feedback.show) button {
   border-color: rgba(0, 122, 84, 0.3) !important;
   background: #e5f3ef !important;
-  color: #146b2e !important;
+  color: var(--sl-color-accent) !important;
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy:has(.feedback.show) button::after {
-  background: #146b2e !important;
+  background: var(--sl-color-accent) !important;
 }

--- a/site/src/styles/starlight/14-docs-nav-table.css
+++ b/site/src/styles/starlight/14-docs-nav-table.css
@@ -184,18 +184,18 @@
 }
 
 html[data-theme='light'] mobile-starlight-toc .dropdown {
-  background: #ffffff !important;
+  background: var(--sl-color-black) !important;
   box-shadow: 0 14px 32px rgba(17, 24, 39, 0.12) !important;
 }
 
 html[data-theme='light'] mobile-starlight-toc .dropdown a:hover,
 html[data-theme='light'] mobile-starlight-toc .dropdown a:focus-visible {
-  color: #111827 !important;
+  color: var(--sl-color-white) !important;
   background: rgba(17, 24, 39, 0.045) !important;
 }
 
 html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true'] {
-  color: #0b4a1f !important;
-  border-inline-start-color: #146b2e !important;
-  background: rgba(0, 122, 84, 0.08) !important;
+  color: var(--sl-color-accent-high) !important;
+  border-inline-start-color: var(--sl-color-accent) !important;
+  background: var(--sl-color-bg-inline-code) !important;
 }

--- a/site/src/styles/starlight/16-shell-interaction-closeout.css
+++ b/site/src/styles/starlight/16-shell-interaction-closeout.css
@@ -83,7 +83,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-u
 html[data-theme='light'] .pagination-links a:hover,
 html[data-theme='light'] .pagination-links a:focus-visible {
 
-  color: #111827 !important;
+  color: var(--sl-color-white) !important;
 }
 
 #starlight__search .pagefind-ui__button {

--- a/site/src/styles/starlight/22-mobile-docs-correction.css
+++ b/site/src/styles/starlight/22-mobile-docs-correction.css
@@ -144,6 +144,6 @@ site-search button[data-open-modal]:focus-visible {
 
 html[data-theme='light'] site-search button[data-open-modal]:hover,
 html[data-theme='light'] site-search button[data-open-modal]:focus-visible {
-  background: #ffffff !important;
+  background: var(--sl-color-black) !important;
   border-color: rgba(0, 122, 84, 0.45) !important;
 }


### PR DESCRIPTION
First tranche of the colour half of the override-layer audit.

The docs already set **32 `--sl-color-*` tokens** across two themes — the theming API Starlight is designed around — and then hard-code **166 colour values** on top of them. That is what makes "re-theme the docs per project" a 22-file edit rather than a config change.

**38 of those literals were byte-for-byte equal to a token already defined in the theme block they sit inside.** They say nothing the token didn't already say. Replaced with `var()` references.

## Value-preserving by construction

The substitution is only made when the literal and the token's declared value are the same string, so the rendered colour *cannot* move. The visual harness agrees: **all 84 captures identical** — three were flagged and correctly dismissed by the re-check as render noise, which is the confirm pass doing its job on its first real outing.

## Nothing is collapsed here

Near-duplicate greys — `#20242b`, `#252b36`, `#242932`, `#1b2028` — are four values doing one job, and they stay four. Merging them **would** move pixels, and that is a judgement call that belongs in its own change with its own review.

## Gates

| | |
|---|---|
| contrast | 124 pairs ≥ 4.5:1 |
| dead CSS | 24 of 24, unchanged |
| `astro check` | clean |
| axe | 0 violations, 14 pages, both themes |

**166 literals before, 128 after**, and no exact matches remain — what's left needs tokens that don't exist yet.

## One correction

My first audit reported **0** replaceable, which was a broken regex in the audit script, not a finding about the CSS. Caught by noticing that `#f4f4f4` in `04-markdown-content-base.css` is plainly `--sl-color-white`. The number in the plan was wrong; this one is measured twice.