### PR TITLE
Name the three table surfaces instead of repeating them in six files

### DIFF
--- a/scripts/design-tokens.mjs
+++ b/scripts/design-tokens.mjs
@@ -60,7 +60,14 @@ const TARGETS = [
     // tokens.css carries the brand accent under `:root`; the Starlight file
     // reaches it with `--sl-color-accent: var(--netscli-accent)`, which is why
     // values are resolved through one level of var() before use.
-    css: ['site/src/styles/tokens.css', 'site/src/styles/starlight/01-tokens-and-header.css'],
+    // 00-theme-tokens.css holds the per-theme palette; 01 keeps the layout
+    // tokens the shared `:root` block needs. Both are read because a value can
+    // resolve across them.
+    css: [
+      'site/src/styles/tokens.css',
+      'site/src/styles/starlight/00-theme-tokens.css',
+      'site/src/styles/starlight/01-tokens-and-header.css',
+    ],
     json: 'site/design-tokens.json',
     themes: { dark: "html[data-theme='dark']", light: "html[data-theme='light']" },
     sharedSelector: ':root',

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -55,6 +55,10 @@ export default defineConfig({
       // rules' cascade dependency first.
       customCss: [
         './src/styles/tokens.css',
+        // The whole colour palette, both themes. First on purpose: everything
+        // after it reads these tokens, and re-theming for another project
+        // should be a change to this one file.
+        './src/styles/starlight/00-theme-tokens.css',
         './src/styles/starlight/01-tokens-and-header.css',
         './src/styles/starlight/02-search-and-sidebar-base.css',
         './src/styles/starlight/03-shell-layout-base.css',

--- a/site/src/styles/starlight/00-theme-tokens.css
+++ b/site/src/styles/starlight/00-theme-tokens.css
@@ -1,0 +1,81 @@
+/* Theme colour tokens: the whole palette, both themes, in one place.
+
+ * Split out of 01-tokens-and-header.css, which had grown to two subjects and
+ * 302 lines against a 300-line guard. The split is along the seam the
+ * filename already admitted to -- tokens AND header -- and it is the one
+ * this refactor wants anyway: re-theming the docs for another project should
+ * mean editing this file and nothing else.
+ *
+ * Loaded before 01 in astro.config.mjs. Only one token is redefined
+ * downstream (--sl-color-bg-inline-code, in 05-docs-surfaces.css), and that
+ * file still loads after this one, so its override is unaffected.
+ */
+html[data-theme='dark'],
+html[data-theme='dark'] ::backdrop {
+  --sl-color-accent-low: #0a2a13;
+  --sl-color-accent: var(--netscli-accent);
+  --sl-color-accent-high: var(--netscli-accent-high);
+  --sl-color-white: #f4f4f4;
+  --sl-color-gray-1: #e7edf6;
+  --sl-color-gray-2: #c2cad8;
+  --sl-color-gray-3: #8c95a6;
+  --sl-color-gray-4: #586174;
+  --sl-color-gray-5: #2b313d;
+  --sl-color-gray-6: #191d25;
+  --sl-color-black: #111111;
+  --sl-color-bg: #111111;
+  --sl-color-bg-nav: rgba(17, 17, 17, 0.92);
+  --sl-color-bg-sidebar: #111111;
+  --sl-color-bg-inline-code: rgba(var(--netscli-accent-rgb), 0.09);
+  --sl-color-hairline: rgba(255, 255, 255, 0.08);
+  --sl-color-hairline-light: rgba(255, 255, 255, 0.1);
+  --sl-color-hairline-shade: #070707;
+  --sl-content-width: 64rem;
+
+  /* Table surfaces. Three roles, and the striping is a real distinction --
+     odd and even rows differ on purpose, so these must not be collapsed into
+     one value however close they look. The same three colours were written
+     out as literals in six files, including the wrapper block that appears
+     verbatim in 15, 19 and 23. */
+  --netscli-table-bg: #20242b;
+  --netscli-table-stripe: #242932;
+  --netscli-table-head: #252b36;
+}
+
+html[data-theme='light'],
+html[data-theme='light'] ::backdrop {
+  --sl-color-accent-low: #dcf8e4;
+  --sl-color-accent: #146b2e;
+  --sl-color-accent-high: #0b4a1f;
+  --sl-color-white: #111827;
+  --sl-color-gray-1: #243044;
+  --sl-color-gray-2: #44516a;
+  /* gray-3 is the secondary/small-text colour used by the docs footer,
+     built-with row, and mobile section labels — much of it at 12px. It has
+     now been raised twice: #718096 was 3.88:1 on --sl-color-bg (#fbfbfb),
+     and #667387 cleared that at 4.65:1 but was still 4.44:1 on
+     --sl-color-gray-6 (#f4f6f8), the card surface, which the earlier check
+     never looked at. #647084 clears every light surface: 4.84 on bg, 5.01
+     on black, 4.62 on gray-6. Do not lighten this; scripts/design-tokens.mjs
+     checks it against every surface now. The dark theme has its own gray-3
+     above and is unaffected. */
+  --sl-color-gray-3: #647084;
+  --sl-color-gray-4: #c6d0dd;
+  --sl-color-gray-5: #e3e8ef;
+  --sl-color-gray-6: #f4f6f8;
+  --sl-color-gray-7: #fbfbfb;
+  --sl-color-black: #ffffff;
+  --sl-color-bg: #fbfbfb;
+  --sl-color-bg-nav: rgba(251, 251, 251, 0.92);
+  --sl-color-bg-sidebar: #fbfbfb;
+  --sl-color-bg-inline-code: rgba(0, 122, 84, 0.08);
+  --sl-color-hairline: rgba(17, 24, 39, 0.1);
+  --sl-color-hairline-light: rgba(17, 24, 39, 0.12);
+  --sl-color-hairline-shade: rgba(17, 24, 39, 0.04);
+  --sl-content-width: 64rem;
+
+  /* Light counterparts of the table surfaces; see the dark block above. */
+  --netscli-table-bg: #f7faf9;
+  --netscli-table-stripe: #f6f8fa;
+  --netscli-table-head: #eef2f4;
+}

--- a/site/src/styles/starlight/01-tokens-and-header.css
+++ b/site/src/styles/starlight/01-tokens-and-header.css
@@ -21,6 +21,15 @@ html[data-theme='dark'] ::backdrop {
   --sl-color-hairline-light: rgba(255, 255, 255, 0.1);
   --sl-color-hairline-shade: #070707;
   --sl-content-width: 64rem;
+
+  /* Table surfaces. Three roles, and the striping is a real distinction --
+     odd and even rows differ on purpose, so these must not be collapsed into
+     one value however close they look. The same three colours were written
+     out as literals in six files, including the wrapper block that appears
+     verbatim in 15, 19 and 23. */
+  --netscli-table-bg: #20242b;
+  --netscli-table-stripe: #242932;
+  --netscli-table-head: #252b36;
 }
 
 html[data-theme='light'],
@@ -54,6 +63,11 @@ html[data-theme='light'] ::backdrop {
   --sl-color-hairline-light: rgba(17, 24, 39, 0.12);
   --sl-color-hairline-shade: rgba(17, 24, 39, 0.04);
   --sl-content-width: 64rem;
+
+  /* Light counterparts of the table surfaces; see the dark block above. */
+  --netscli-table-bg: #f7faf9;
+  --netscli-table-stripe: #f6f8fa;
+  --netscli-table-head: #eef2f4;
 }
 
 :root {

--- a/site/src/styles/starlight/01-tokens-and-header.css
+++ b/site/src/styles/starlight/01-tokens-and-header.css
@@ -1,74 +1,8 @@
-/* Theme tokens (dark/light custom properties) and header/search-button base overrides. */
-
-html[data-theme='dark'],
-html[data-theme='dark'] ::backdrop {
-  --sl-color-accent-low: #0a2a13;
-  --sl-color-accent: var(--netscli-accent);
-  --sl-color-accent-high: var(--netscli-accent-high);
-  --sl-color-white: #f4f4f4;
-  --sl-color-gray-1: #e7edf6;
-  --sl-color-gray-2: #c2cad8;
-  --sl-color-gray-3: #8c95a6;
-  --sl-color-gray-4: #586174;
-  --sl-color-gray-5: #2b313d;
-  --sl-color-gray-6: #191d25;
-  --sl-color-black: #111111;
-  --sl-color-bg: #111111;
-  --sl-color-bg-nav: rgba(17, 17, 17, 0.92);
-  --sl-color-bg-sidebar: #111111;
-  --sl-color-bg-inline-code: rgba(var(--netscli-accent-rgb), 0.09);
-  --sl-color-hairline: rgba(255, 255, 255, 0.08);
-  --sl-color-hairline-light: rgba(255, 255, 255, 0.1);
-  --sl-color-hairline-shade: #070707;
-  --sl-content-width: 64rem;
-
-  /* Table surfaces. Three roles, and the striping is a real distinction --
-     odd and even rows differ on purpose, so these must not be collapsed into
-     one value however close they look. The same three colours were written
-     out as literals in six files, including the wrapper block that appears
-     verbatim in 15, 19 and 23. */
-  --netscli-table-bg: #20242b;
-  --netscli-table-stripe: #242932;
-  --netscli-table-head: #252b36;
-}
-
-html[data-theme='light'],
-html[data-theme='light'] ::backdrop {
-  --sl-color-accent-low: #dcf8e4;
-  --sl-color-accent: #146b2e;
-  --sl-color-accent-high: #0b4a1f;
-  --sl-color-white: #111827;
-  --sl-color-gray-1: #243044;
-  --sl-color-gray-2: #44516a;
-  /* gray-3 is the secondary/small-text colour used by the docs footer,
-     built-with row, and mobile section labels — much of it at 12px. It has
-     now been raised twice: #718096 was 3.88:1 on --sl-color-bg (#fbfbfb),
-     and #667387 cleared that at 4.65:1 but was still 4.44:1 on
-     --sl-color-gray-6 (#f4f6f8), the card surface, which the earlier check
-     never looked at. #647084 clears every light surface: 4.84 on bg, 5.01
-     on black, 4.62 on gray-6. Do not lighten this; scripts/design-tokens.mjs
-     checks it against every surface now. The dark theme has its own gray-3
-     above and is unaffected. */
-  --sl-color-gray-3: #647084;
-  --sl-color-gray-4: #c6d0dd;
-  --sl-color-gray-5: #e3e8ef;
-  --sl-color-gray-6: #f4f6f8;
-  --sl-color-gray-7: #fbfbfb;
-  --sl-color-black: #ffffff;
-  --sl-color-bg: #fbfbfb;
-  --sl-color-bg-nav: rgba(251, 251, 251, 0.92);
-  --sl-color-bg-sidebar: #fbfbfb;
-  --sl-color-bg-inline-code: rgba(0, 122, 84, 0.08);
-  --sl-color-hairline: rgba(17, 24, 39, 0.1);
-  --sl-color-hairline-light: rgba(17, 24, 39, 0.12);
-  --sl-color-hairline-shade: rgba(17, 24, 39, 0.04);
-  --sl-content-width: 64rem;
-
-  /* Light counterparts of the table surfaces; see the dark block above. */
-  --netscli-table-bg: #f7faf9;
-  --netscli-table-stripe: #f6f8fa;
-  --netscli-table-head: #eef2f4;
-}
+/* Layout tokens and header/search-button base overrides.
+ *
+ * The dark/light COLOUR tokens moved to 00-theme-tokens.css, which loads
+ * before this file. The name is kept because the numbered order is load
+ * order and renaming would move the file in the cascade. */
 
 :root {
   --sl-nav-height: var(--netscli-nav-height);

--- a/site/src/styles/starlight/05-docs-surfaces.css
+++ b/site/src/styles/starlight/05-docs-surfaces.css
@@ -162,14 +162,14 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
 
 .sl-markdown-content table {
   border-color: rgba(140, 149, 166, 0.2);
-  background: #20242b;
+  background: var(--netscli-table-bg);
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.025) inset,
     0 12px 26px rgba(0, 0, 0, 0.16);
 }
 
 .sl-markdown-content thead tr {
-  background: #252b36;
+  background: var(--netscli-table-head);
   box-shadow: inset 0 -2px 0 rgba(var(--netscli-accent-rgb), 0.55);
 }
 
@@ -179,11 +179,11 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
 }
 
 .sl-markdown-content tbody tr {
-  background: #20242b;
+  background: var(--netscli-table-bg);
 }
 
 .sl-markdown-content tbody tr:nth-child(even) {
-  background: #242932;
+  background: var(--netscli-table-stripe);
 }.sl-markdown-content td,
 .sl-markdown-content th {
   border-color: rgba(140, 149, 166, 0.13);
@@ -209,7 +209,7 @@ html[data-theme='light'] .sl-markdown-content table {
 }
 
 html[data-theme='light'] .sl-markdown-content thead tr {
-  background: #eef2f4;
+  background: var(--netscli-table-head);
   box-shadow: inset 0 -2px 0 rgba(0, 122, 84, 0.42);
 }
 
@@ -222,5 +222,5 @@ html[data-theme='light'] .sl-markdown-content tbody tr {
 }
 
 html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even) {
-  background: #f6f8fa;
+  background: var(--netscli-table-stripe);
 }

--- a/site/src/styles/starlight/07-docs-interaction-b.css
+++ b/site/src/styles/starlight/07-docs-interaction-b.css
@@ -76,11 +76,11 @@
 }
 
 .sl-markdown-content tbody tr:hover {
-  background: #20242b;
+  background: var(--netscli-table-bg);
 }
 
 .sl-markdown-content tbody tr:nth-child(even):hover {
-  background: #242932;
+  background: var(--netscli-table-stripe);
 }
 
 html[data-theme='light'] .sl-markdown-content tbody tr:hover {
@@ -88,7 +88,7 @@ html[data-theme='light'] .sl-markdown-content tbody tr:hover {
 }
 
 html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
-  background: #f6f8fa;
+  background: var(--netscli-table-stripe);
 }
 
 .sl-markdown-content a,

--- a/site/src/styles/starlight/09-search-table-fit.css
+++ b/site/src/styles/starlight/09-search-table-fit.css
@@ -50,12 +50,12 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
 }
 .sl-markdown-content tbody tr,
 .sl-markdown-content tbody tr:hover {
-  background: #20242b !important;
+  background: var(--netscli-table-bg) !important;
 }
 
 .sl-markdown-content tbody tr:nth-child(even),
 .sl-markdown-content tbody tr:nth-child(even):hover {
-  background: #242932 !important;
+  background: var(--netscli-table-stripe) !important;
 }
 
 html[data-theme='light'] .sl-markdown-content tbody tr,
@@ -65,7 +65,7 @@ html[data-theme='light'] .sl-markdown-content tbody tr:hover {
 
 html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even),
 html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
-  background: #f6f8fa !important;
+  background: var(--netscli-table-stripe) !important;
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy button {

--- a/site/src/styles/starlight/15-responsive-containment.css
+++ b/site/src/styles/starlight/15-responsive-containment.css
@@ -20,7 +20,7 @@
     overflow-y: hidden !important;
     border: 1px solid rgba(140, 149, 166, 0.2) !important;
     border-radius: 8px !important;
-    background: #20242b !important;
+    background: var(--netscli-table-bg) !important;
     -webkit-overflow-scrolling: touch;
   }
 
@@ -66,5 +66,5 @@
 }
 
 html[data-theme='light'] .sl-markdown-content table {
-  background: #f7faf9 !important;
+  background: var(--netscli-table-bg) !important;
 }

--- a/site/src/styles/starlight/19-markdown-tables.css
+++ b/site/src/styles/starlight/19-markdown-tables.css
@@ -7,7 +7,7 @@
   overflow-y: hidden;
   border: 1px solid rgba(140, 149, 166, 0.2);
   border-radius: 8px;
-  background: #20242b;
+  background: var(--netscli-table-bg);
   -webkit-overflow-scrolling: touch;
 }
 
@@ -45,7 +45,7 @@
 }
 
 html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
-  background: #f7faf9;
+  background: var(--netscli-table-bg);
 }
 
 @media (min-width: 72rem) {

--- a/site/src/styles/starlight/23-regression-guardrails.css
+++ b/site/src/styles/starlight/23-regression-guardrails.css
@@ -83,7 +83,7 @@
     overflow-y: hidden !important;
     border: 1px solid rgba(140, 149, 166, 0.2) !important;
     border-radius: 8px !important;
-    background: #20242b !important;
+    background: var(--netscli-table-bg) !important;
     -webkit-overflow-scrolling: touch !important;
   }
 


### PR DESCRIPTION
Second tranche of the colour audit.

The docs tables use three surfaces — body, alternating row stripe, header row — and each was written as a hex literal wherever it was needed: **17 times across 6 files**, in both themes.

The worst of it is the table wrapper, whose entire declaration block (border, radius, overflow, background) appears **verbatim in three files** — `15-responsive-containment`, `19-markdown-tables`, `23-regression-guardrails`. Three copies of one rule, which is exactly how the background in one could drift without the other two noticing.

Now `--netscli-table-bg` / `-stripe` / `-head`, declared once per theme.

## The striping is not collapsed, and must not be

`#20242b` and `#242932` sit 9 apart in RGB, and my first clustering pass grouped them as drift. Reading the selectors shows they are `tbody tr` and `tbody tr:nth-child(even)` — a **deliberate distinction a distance threshold cannot see**.

That is the argument for reading every cluster before merging any of it, and it is why this change introduces three tokens rather than one.

## Value-preserving

All **84 captures identical**; four flagged and correctly dismissed by the re-check as render noise.

That includes the three theme-agnostic wrapper rules, which previously applied a *dark* literal in both themes and now resolve per theme. Unchanged in every captured state — so the light override was already winning there.

## Gates

contrast 124 pairs ≥ 4.5:1 · dead CSS 24/24 · `astro check` clean · axe 0 violations, 14 pages, both themes

**Literal colour declarations: 128 → 111.**

## One caution for the next tranche

Re-running the exact-match audit now reports 5 new "replaceable" literals. They are `#252b36` in the search results and the TOC — the same *value* as `--netscli-table-head`, but not a table header. Substituting there would be pixel-identical and semantically wrong. **The auto-apply pass is only safe for tokens whose name matches the role**, which is why this tranche was done by hand.