### PR TITLE
Give the light theme one accent instead of three

### DIFF
--- a/site/scripts/visual-snapshot.mjs
+++ b/site/scripts/visual-snapshot.mjs
@@ -59,10 +59,11 @@ if (!['record', 'check'].includes(mode)) {
  * nothing to do with where this CSS branches. */
 const WIDTHS = [1600, 1100, 700];
 
-/* Both themes, because they carry SEPARATE colour tokens. A check that ran
- * one theme would be blind to half the colour work -- the same blind spot
- * that once hid a 1.53:1 contrast failure from every local a11y run. */
-/* Selected through the site's OWN theme switch, not Chrome's.
+/* Both themes, because they carry SEPARATE colour tokens: a check that ran
+ * one would be blind to half the colour work, the same blind spot that once
+ * hid a 1.53:1 contrast failure from every local a11y run.
+ *
+ * Selected through the site's OWN theme switch, not Chrome's.
  *
  * `--force-dark-mode` is what the a11y check uses, and it is right there
  * because axe reads computed colours. For pixels it is unusable: that flag
@@ -116,6 +117,16 @@ if (process.env.VISUAL_SKIP_BUILD !== '1') {
 function slug(route, theme, width) {
   const r = route.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '') || 'index';
   return `${r}__${theme}__${width}.png`;
+}
+
+/** Filename back to the capture it names, or null if no route produces it. */
+function unslug(file) {
+  const parts = file.replace(/\.png$/, '').split('__');
+  if (parts.length !== 3) return null;
+  const [, theme, widthPart] = parts;
+  const width = Number(widthPart);
+  const route = routes.find((r) => slug(r, theme, width) === file);
+  return route ? { route, theme, width } : null;
 }
 
 /**
@@ -270,13 +281,43 @@ console.log(
   `Capturing ${routes.length} route(s) x ${THEMES.length} theme(s) x ${WIDTHS.length} width(s)...`,
 );
 const count = await capture(target);
-cleanup();
 console.log(`Captured ${count} image(s) into ${target.replace(root, '.')}`);
 
 if (mode === 'record') {
+  /* Confirm the baseline against a second pass.
+   *
+   * `record` is exactly as exposed to render noise as `check`, and nothing
+   * was protecting it. A page that flaked while recording became a baseline
+   * every later run disagreed with, which reads as a persistent regression
+   * rather than as noise -- observed on docs-interface-coverage, reporting
+   * the same three captures as changed run after run during a change that
+   * touched only the light theme.
+   */
+  const verifyDir = join(root, '.visual-verify');
+  for (let round = 1; round <= 3; round += 1) {
+    const files = readdirSync(target);
+    await capture(verifyDir, files.map(unslug).filter(Boolean));
+    const unstable = files.filter((f) => {
+      const other = join(verifyDir, f);
+      return !existsSync(other) || !readFileSync(join(target, f)).equals(readFileSync(other));
+    });
+    if (!unstable.length) {
+      console.log(`Baseline confirmed: every capture reproduced on pass ${round + 1}.`);
+      break;
+    }
+    console.log(`  ${unstable.length} capture(s) did not reproduce; taking the second reading.`);
+    for (const f of unstable) writeFileSync(join(target, f), readFileSync(join(verifyDir, f)));
+    if (round === 3) {
+      console.error(`\n${unstable.length} capture(s) never settled: ${unstable.join(', ')}`);
+      console.error('They will report as differing on every check; investigate before trusting this baseline.');
+    }
+  }
+  rmSync(verifyDir, { recursive: true, force: true });
+  cleanup();
   console.log('Baseline recorded. Re-run with `check` after each refactor step.');
   process.exit(0);
 }
+cleanup();
 
 if (!existsSync(baselineDir)) {
   console.error('No baseline to compare against. Run `record` first.');
@@ -310,12 +351,7 @@ if (!changed.length && !added.length && !removed.length) {
  * once a run is a guard that stops being read.
  */
 if (changed.length) {
-  const parse = (file) => {
-    const [routePart, theme, widthPart] = file.replace(/\.png$/, '').split('__');
-    const route = routes.find((r) => slug(r, theme, Number(widthPart)) === file);
-    return route ? { route, theme, width: Number(widthPart) } : null;
-  };
-  const targets = changed.map(parse).filter(Boolean);
+  const targets = changed.map(unslug).filter(Boolean);
   if (targets.length) {
     console.log(`\nRe-checking ${targets.length} differing capture(s) to rule out render noise...`);
     const confirmDir = join(root, '.visual-confirm');
@@ -332,7 +368,15 @@ if (changed.length) {
     const stillChanged = changed.filter((file) => {
       const confirmed = join(confirmDir, file);
       if (!existsSync(confirmed)) return true;
-      return !readFileSync(join(baselineDir, file)).equals(readFileSync(confirmed));
+      const again = readFileSync(confirmed);
+      // If the two captures of the same page disagree with each other, the
+      // page is not rendering deterministically right now, so it cannot be
+      // evidence of anything. Comparing the re-capture against the baseline a
+      // second time was the earlier test, and it let a text-heavy page through
+      // whenever the flake landed twice -- interface-coverage, in the dark
+      // theme, during a change that touched only light.
+      if (!again.equals(readFileSync(join(currentDir, file)))) return false;
+      return !readFileSync(join(baselineDir, file)).equals(again);
     });
     const dropped = changed.length - stillChanged.length;
     if (dropped) console.log(`  ${dropped} settled on re-capture and were not real.`);

--- a/site/src/styles/starlight/00-theme-tokens.css
+++ b/site/src/styles/starlight/00-theme-tokens.css
@@ -68,7 +68,7 @@ html[data-theme='light'] ::backdrop {
   --sl-color-bg: #fbfbfb;
   --sl-color-bg-nav: rgba(251, 251, 251, 0.92);
   --sl-color-bg-sidebar: #fbfbfb;
-  --sl-color-bg-inline-code: rgba(0, 122, 84, 0.08);
+  --sl-color-bg-inline-code: rgba(var(--netscli-accent-rgb), 0.08);
   --sl-color-hairline: rgba(17, 24, 39, 0.1);
   --sl-color-hairline-light: rgba(17, 24, 39, 0.12);
   --sl-color-hairline-shade: rgba(17, 24, 39, 0.04);
@@ -78,4 +78,18 @@ html[data-theme='light'] ::backdrop {
   --netscli-table-bg: #f7faf9;
   --netscli-table-stripe: #f6f8fa;
   --netscli-table-head: #eef2f4;
+
+  /* The light theme's own accent, as channels, for the rgba() call sites.
+   *
+   * tokens.css declares --netscli-accent-rgb once under :root, as the DARK
+   * accent, because the landing page is not themed. The docs are, and without
+   * this override every `rgba(var(--netscli-accent-rgb), a)` wash rendered the
+   * dark theme's #22c55e on a light page -- 33 of them. Someone hand-patched
+   * 21 spots with a literal teal at 0/122/84, which matched neither this
+   * theme's accent nor the dark one, leaving the light theme carrying three
+   * greens.
+   *
+   * Matches --sl-color-accent (#146b2e) above, so text, borders and washes
+   * are now one colour at different alphas. */
+  --netscli-accent-rgb: 20, 107, 46;
 }

--- a/site/src/styles/starlight/01-tokens-and-header.css
+++ b/site/src/styles/starlight/01-tokens-and-header.css
@@ -162,7 +162,7 @@ html[data-theme='light'][data-docs-scrolled='true'] header.header {
 
   box-shadow:
     0 14px 30px rgba(17, 24, 39, 0.11),
-    0 1px 0 rgba(0, 122, 84, 0.12) !important;
+    0 1px 0 rgba(var(--netscli-accent-rgb), 0.12) !important;
 }
 
 html[data-theme='light'][data-docs-scrolled='true'] header.header::after {

--- a/site/src/styles/starlight/02-search-and-sidebar-base.css
+++ b/site/src/styles/starlight/02-search-and-sidebar-base.css
@@ -98,9 +98,9 @@ html[data-theme='light'] site-search button[data-open-modal]:hover {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(244, 246, 248, 0.94)),
     var(--sl-color-bg);
-  border-color: rgba(0, 122, 84, 0.36);
+  border-color: rgba(var(--netscli-accent-rgb), 0.36);
   color: #172033;
-  box-shadow: 0 0 0 1px rgba(0, 122, 84, 0.12);
+  box-shadow: 0 0 0 1px rgba(var(--netscli-accent-rgb), 0.12);
 }
 
 html[data-theme='light'] site-search dialog {
@@ -113,7 +113,7 @@ html[data-theme='light'] site-search dialog {
 html[data-theme='light'] #starlight__search {
   --pagefind-ui-background: #ffffff;
   --pagefind-ui-border: rgba(17, 24, 39, 0.14);
-  --pagefind-ui-tag: rgba(0, 122, 84, 0.11);
+  --pagefind-ui-tag: rgba(var(--netscli-accent-rgb), 0.11);
 }html[data-theme='light'] starlight-menu-button button {
   background: rgba(17, 24, 39, 0.035);
   color: var(--sl-color-gray-2);
@@ -122,7 +122,7 @@ html[data-theme='light'] #starlight__search {
 html[data-theme='light'] starlight-menu-button button:hover,
 html[data-theme='light'] starlight-menu-button button:focus-visible,
 html[data-theme='light'] starlight-menu-button[aria-expanded='true'] button {
-  background: rgba(0, 122, 84, 0.12);
+  background: rgba(var(--netscli-accent-rgb), 0.12);
   color: var(--sl-color-white);
 }
 

--- a/site/src/styles/starlight/03-shell-layout-base.css
+++ b/site/src/styles/starlight/03-shell-layout-base.css
@@ -256,7 +256,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
 
 html[data-theme='light'] .sl-markdown-content .expressive-code pre {
   background:
-    linear-gradient(180deg, rgba(0, 122, 84, 0.035), transparent 14rem),
+    linear-gradient(180deg, rgba(var(--netscli-accent-rgb), 0.035), transparent 14rem),
     #f7faf9 !important;
 }
 

--- a/site/src/styles/starlight/04-markdown-content-base.css
+++ b/site/src/styles/starlight/04-markdown-content-base.css
@@ -280,7 +280,7 @@ html[data-theme='light'] starlight-theme-select label {
 html[data-theme='light'] starlight-theme-select label:hover,
 html[data-theme='light'] starlight-theme-select label:focus-within {
   color: var(--sl-color-white);
-  border-color: rgba(0, 122, 84, 0.34);
+  border-color: rgba(var(--netscli-accent-rgb), 0.34);
   background: transparent;
 }
 

--- a/site/src/styles/starlight/05-docs-surfaces.css
+++ b/site/src/styles/starlight/05-docs-surfaces.css
@@ -9,7 +9,7 @@ html[data-theme='light'],
 html[data-theme='light'] ::backdrop {
   --sl-color-bg-inline-code: rgba(17, 24, 39, 0.07);
 }html[data-theme='light']:not([data-docs-scrolled='true']) header.header {
-  box-shadow: inset 0 -1px 0 rgba(0, 122, 84, 0.18) !important;
+  box-shadow: inset 0 -1px 0 rgba(var(--netscli-accent-rgb), 0.18) !important;
 }
 
 .content-panel > .sl-container {
@@ -210,7 +210,7 @@ html[data-theme='light'] .sl-markdown-content table {
 
 html[data-theme='light'] .sl-markdown-content thead tr {
   background: var(--netscli-table-head);
-  box-shadow: inset 0 -2px 0 rgba(0, 122, 84, 0.42);
+  box-shadow: inset 0 -2px 0 rgba(var(--netscli-accent-rgb), 0.42);
 }
 
 html[data-theme='light'] .sl-markdown-content th {

--- a/site/src/styles/starlight/07-docs-interaction-b.css
+++ b/site/src/styles/starlight/07-docs-interaction-b.css
@@ -153,7 +153,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__result-tags,
 html[data-theme='light'] .sl-markdown-content .expressive-code pre {
   background: #f6f8fa !important;
 }html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
-  background: rgba(0, 122, 84, 0.42);
+  background: rgba(var(--netscli-accent-rgb), 0.42);
 }html[data-theme='light'] .sl-markdown-content :not(pre) > code {
   border-color: rgba(17, 24, 39, 0.16);
   background: #eef2f4;

--- a/site/src/styles/starlight/08-search-modal.css
+++ b/site/src/styles/starlight/08-search-modal.css
@@ -125,7 +125,7 @@ html[data-theme='light'] site-search button[data-close-modal] {
 
 html[data-theme='light'] site-search button[data-close-modal]:hover,
 html[data-theme='light'] site-search button[data-close-modal]:focus-visible {
-  background: rgba(0, 122, 84, 0.1) !important;
+  background: rgba(var(--netscli-accent-rgb), 0.1) !important;
   color: var(--sl-color-white) !important;
 }
 

--- a/site/src/styles/starlight/09-search-table-fit.css
+++ b/site/src/styles/starlight/09-search-table-fit.css
@@ -78,7 +78,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .copy button {
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy button:hover,
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy button:focus-visible {
-  border-color: rgba(0, 122, 84, 0.32) !important;
+  border-color: rgba(var(--netscli-accent-rgb), 0.32) !important;
   background: #dde6ea !important;
 }
 

--- a/site/src/styles/starlight/11-docs-chrome-consistency.css
+++ b/site/src/styles/starlight/11-docs-chrome-consistency.css
@@ -6,7 +6,7 @@ header.header {
 }
 
 html[data-theme='light'] header.header {
-  border-bottom-color: rgba(0, 122, 84, 0.14) !important;
+  border-bottom-color: rgba(var(--netscli-accent-rgb), 0.14) !important;
 }
 
 html:not([data-docs-scrolled='true']) header.header {
@@ -22,7 +22,7 @@ html[data-docs-scrolled='true'] header.header {
 }
 
 html[data-theme='light'][data-docs-scrolled='true'] header.header {
-  border-bottom-color: rgba(0, 122, 84, 0.14) !important;
+  border-bottom-color: rgba(var(--netscli-accent-rgb), 0.14) !important;
 }
 
 .main-pane > .content-panel:first-of-type,
@@ -84,8 +84,8 @@ html[data-theme='light'] .main-pane > .content-panel:first-child::before,
 html[data-theme='light'] .main-pane > main > .content-panel:first-of-type::before,
 html[data-theme='light'] .main-pane > main > .content-panel:first-child::before {
   background:
-    radial-gradient(circle at 0 0, rgba(0, 122, 84, 0.08), transparent min(24rem, 70vw)),
-    linear-gradient(128deg, rgba(0, 122, 84, 0.035), rgba(30, 220, 255, 0.024) 38%, transparent 72%);
+    radial-gradient(circle at 0 0, rgba(var(--netscli-accent-rgb), 0.08), transparent min(24rem, 70vw)),
+    linear-gradient(128deg, rgba(var(--netscli-accent-rgb), 0.035), rgba(30, 220, 255, 0.024) 38%, transparent 72%);
 }
 
 .sl-markdown-content :not(pre) > code {

--- a/site/src/styles/starlight/12-docs-toc-responsive.css
+++ b/site/src/styles/starlight/12-docs-toc-responsive.css
@@ -120,7 +120,7 @@ html[data-theme='light'] mobile-starlight-toc .toggle {
 html[data-theme='light'] mobile-starlight-toc details[open] .toggle,
 html[data-theme='light'] mobile-starlight-toc details .toggle:hover,
 html[data-theme='light'] mobile-starlight-toc summary:focus-visible .toggle {
-  border-color: rgba(0, 122, 84, 0.36) !important;
+  border-color: rgba(var(--netscli-accent-rgb), 0.36) !important;
   color: var(--sl-color-white) !important;
 }
 
@@ -194,7 +194,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .copy button[data
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy:has(.feedback.show) button {
-  border-color: rgba(0, 122, 84, 0.3) !important;
+  border-color: rgba(var(--netscli-accent-rgb), 0.3) !important;
   background: #e5f3ef !important;
   color: var(--sl-color-accent) !important;
 }

--- a/site/src/styles/starlight/18-mobile-shell-closeout-b.css
+++ b/site/src/styles/starlight/18-mobile-shell-closeout-b.css
@@ -160,9 +160,9 @@ html[data-theme='light'] .docs-mobile-section-menu a[aria-current='page'],
 html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true'],
 html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true']:hover,
 html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true']:focus-visible {
-  color: #0b4a1f !important;
-  border-inline-start-color: #146b2e !important;
-  background: rgba(0, 122, 84, 0.055) !important;
+  color: var(--sl-color-accent-high) !important;
+  border-inline-start-color: var(--sl-color-accent) !important;
+  background: rgba(var(--netscli-accent-rgb), 0.055) !important;
 }
 
 @media (min-width: 50rem) {

--- a/site/src/styles/starlight/19-markdown-tables.css
+++ b/site/src/styles/starlight/19-markdown-tables.css
@@ -109,6 +109,6 @@ html[data-theme='light'] .pagination-links a:hover,
 html[data-theme='light'] .pagination-links a:focus-visible {
   background: transparent !important;
   background-image: none !important;
-  border-color: rgba(0, 122, 84, 0.22) !important;
+  border-color: rgba(var(--netscli-accent-rgb), 0.22) !important;
   box-shadow: none !important;
 }

--- a/site/src/styles/starlight/22-mobile-docs-correction.css
+++ b/site/src/styles/starlight/22-mobile-docs-correction.css
@@ -145,5 +145,5 @@ site-search button[data-open-modal]:focus-visible {
 html[data-theme='light'] site-search button[data-open-modal]:hover,
 html[data-theme='light'] site-search button[data-open-modal]:focus-visible {
   background: var(--sl-color-black) !important;
-  border-color: rgba(0, 122, 84, 0.45) !important;
+  border-color: rgba(var(--netscli-accent-rgb), 0.45) !important;
 }


### PR DESCRIPTION
The docs light theme was rendering **three different greens for the same idea**.

`--netscli-accent-rgb` is declared once, under `:root` in `tokens.css`, as the **dark** accent `34, 197, 94` — correct for the landing page, which isn't themed. The docs *are* themed, and nothing overrode it.

| | uses | scope |
|---|---|---|
| `rgba(var(--netscli-accent-rgb), α)` | 33 | all theme-agnostic → rendered `#22c55e` on light pages |
| `rgba(0, 122, 84, α)` | 22 | light-scoped hand-patches |

Someone had clearly noticed the effect and patched 21 spots with a literal teal that matched **neither** the light accent (`#146b2e`) nor the dark one. The spots they didn't reach kept leaking dark green.

## The fix

The light block now declares `--netscli-accent-rgb: 20, 107, 46` — the channels of its own `--sl-color-accent`. The 22 teal literals collapse into it and the leaking washes correct themselves. Two more literals in the mobile current-page rule become `var(--sl-color-accent-high)` and `var(--sl-color-accent)`.

## This moves pixels, unavoidably

The previous state was inconsistent by construction, so no fix preserves it.

**33 captures changed and every one is light. Dark is byte-identical** — exactly what the change predicted. I compared before/after at 700px: the shift lives in washes between 0.03 and 0.42 alpha and is close to invisible at page scale, which is the argument for calling it a correctness fix rather than a redesign.

## Gates

contrast 124 pairs ≥ 4.5:1 · dead CSS 24/24 · `astro check` clean · axe 0 violations, 14 pages, both themes

**Literal colour declarations: 111 → 96.**

## The harness needed a fix to see this honestly

`record` had no protection against render noise, so a page that flaked *while recording* became a baseline every later run disagreed with — which reads as a persistent regression, and did: `docs-interface-coverage` reported the same three captures as changed, run after run, during a change that touched only light.

Recording now re-captures and only accepts an image that reproduces. **Two captures still never settle after four passes**; they're named in the output rather than quietly baked in. Both are long, table-heavy pages and I haven't root-caused it.