### PR TITLE
Give each theme one neutral for hairlines and washes

### DIFF
--- a/site/src/styles/starlight/00-theme-tokens.css
+++ b/site/src/styles/starlight/00-theme-tokens.css
@@ -40,6 +40,12 @@ html[data-theme='dark'] ::backdrop {
   --netscli-table-bg: #20242b;
   --netscli-table-stripe: #242932;
   --netscli-table-head: #252b36;
+
+  /* The neutral this theme draws hairlines, dividers and low-alpha washes
+     from, as channels for the rgba() call sites. Same channels as
+     --sl-color-gray-3 above; declared separately because rgba() needs the
+     numbers, not the colour. */
+  --netscli-hairline-rgb: 140, 149, 166;
 }
 
 html[data-theme='light'],
@@ -92,4 +98,9 @@ html[data-theme='light'] ::backdrop {
    * Matches --sl-color-accent (#146b2e) above, so text, borders and washes
    * are now one colour at different alphas. */
   --netscli-accent-rgb: 20, 107, 46;
+
+  /* The light theme's neutral for hairlines and washes: its own ink, #111827,
+     which is --sl-color-white here because Starlight inverts that name in the
+     light theme. 33 rules already wrote these channels out by hand. */
+  --netscli-hairline-rgb: 17, 24, 39;
 }

--- a/site/src/styles/starlight/01-tokens-and-header.css
+++ b/site/src/styles/starlight/01-tokens-and-header.css
@@ -45,12 +45,12 @@ body {
 
 html {
   scrollbar-width: thin;
-  scrollbar-color: rgba(140, 149, 166, 0.5) rgba(17, 17, 17, 0.9);
+  scrollbar-color: rgba(var(--netscli-hairline-rgb), 0.5) rgba(17, 17, 17, 0.9);
 }
 
 * {
   scrollbar-width: thin;
-  scrollbar-color: rgba(140, 149, 166, 0.42) rgba(255, 255, 255, 0.035);
+  scrollbar-color: rgba(var(--netscli-hairline-rgb), 0.42) rgba(255, 255, 255, 0.035);
 }
 
 ::-webkit-scrollbar {
@@ -63,7 +63,7 @@ html {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(140, 149, 166, 0.45);
+  background: rgba(var(--netscli-hairline-rgb), 0.45);
   border: 3px solid #151515;
   border-radius: 999px;
 }
@@ -81,7 +81,7 @@ html[data-theme='light'] {
 }
 
 html[data-theme='light'] * {
-  scrollbar-color: rgba(68, 81, 106, 0.36) rgba(17, 24, 39, 0.045);
+  scrollbar-color: rgba(68, 81, 106, 0.36) rgba(var(--netscli-hairline-rgb), 0.045);
 }
 
 html[data-theme='light'] ::-webkit-scrollbar-track {
@@ -161,12 +161,12 @@ html[data-docs-scrolled='true'] header.header::after {
 html[data-theme='light'][data-docs-scrolled='true'] header.header {
 
   box-shadow:
-    0 14px 30px rgba(17, 24, 39, 0.11),
+    0 14px 30px rgba(var(--netscli-hairline-rgb), 0.11),
     0 1px 0 rgba(var(--netscli-accent-rgb), 0.12) !important;
 }
 
 html[data-theme='light'][data-docs-scrolled='true'] header.header::after {
-  background: linear-gradient(180deg, rgba(17, 24, 39, 0.12), rgba(17, 24, 39, 0));
+  background: linear-gradient(180deg, rgba(var(--netscli-hairline-rgb), 0.12), rgba(var(--netscli-hairline-rgb), 0));
 }
 
 header.header > .header {
@@ -210,7 +210,7 @@ starlight-menu-button[aria-expanded='true'] button {
 }
 
 site-search button[data-open-modal] {
-  border: 1px solid rgba(140, 149, 166, 0.24);
+  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.24);
   border-radius: 6px;
 
   color: var(--sl-color-gray-2);

--- a/site/src/styles/starlight/02-search-and-sidebar-base.css
+++ b/site/src/styles/starlight/02-search-and-sidebar-base.css
@@ -10,14 +10,14 @@ site-search button[data-open-modal]:focus-visible svg {
 }
 
 site-search button[data-open-modal] > kbd {
-  border: 1px solid rgba(140, 149, 166, 0.24);
+  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.24);
   border-radius: 4px;
   background: rgba(255, 255, 255, 0.04);
   color: var(--sl-color-gray-3);
 }
 
 site-search dialog {
-  border: 1px solid rgba(140, 149, 166, 0.34) !important;
+  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.34) !important;
   border-radius: 8px !important;
 
   box-shadow:
@@ -54,12 +54,12 @@ site-search button[data-close-modal]:focus-visible {
   --pagefind-ui-primary: var(--sl-color-gray-1);
   --pagefind-ui-text: var(--sl-color-gray-2);
   --pagefind-ui-background: #171b22;
-  --pagefind-ui-border: rgba(140, 149, 166, 0.28);
+  --pagefind-ui-border: rgba(var(--netscli-hairline-rgb), 0.28);
   --pagefind-ui-border-width: 1px;
   --pagefind-ui-tag: rgba(var(--netscli-accent-rgb), 0.12);
   --sl-search-corners: 6px;
 }#starlight__search .pagefind-ui__search-input {
-  border-color: rgba(140, 149, 166, 0.32) !important;
+  border-color: rgba(var(--netscli-hairline-rgb), 0.32) !important;
   border-radius: 6px !important;
 
   color: var(--sl-color-gray-1) !important;
@@ -90,8 +90,8 @@ site-search button[data-close-modal]:focus-visible {
 
 html[data-theme='light'] site-search button[data-open-modal] {
 
-  border-color: rgba(17, 24, 39, 0.14);
-  box-shadow: 0 1px 2px rgba(17, 24, 39, 0.04);
+  border-color: rgba(var(--netscli-hairline-rgb), 0.14);
+  box-shadow: 0 1px 2px rgba(var(--netscli-hairline-rgb), 0.04);
 }
 
 html[data-theme='light'] site-search button[data-open-modal]:hover {
@@ -106,16 +106,16 @@ html[data-theme='light'] site-search button[data-open-modal]:hover {
 html[data-theme='light'] site-search dialog {
 
   box-shadow:
-    0 30px 70px rgba(17, 24, 39, 0.18),
+    0 30px 70px rgba(var(--netscli-hairline-rgb), 0.18),
     0 0 0 1px rgba(255, 255, 255, 0.72) inset !important;
 }
 
 html[data-theme='light'] #starlight__search {
   --pagefind-ui-background: #ffffff;
-  --pagefind-ui-border: rgba(17, 24, 39, 0.14);
+  --pagefind-ui-border: rgba(var(--netscli-hairline-rgb), 0.14);
   --pagefind-ui-tag: rgba(var(--netscli-accent-rgb), 0.11);
 }html[data-theme='light'] starlight-menu-button button {
-  background: rgba(17, 24, 39, 0.035);
+  background: rgba(var(--netscli-hairline-rgb), 0.035);
   color: var(--sl-color-gray-2);
 }
 

--- a/site/src/styles/starlight/03-shell-layout-base.css
+++ b/site/src/styles/starlight/03-shell-layout-base.css
@@ -185,18 +185,18 @@ html[data-theme='light'] .main-pane {
 }
 
 .sl-markdown-content .expressive-code {
-  --ec-brdCol: rgba(140, 149, 166, 0.22);
+  --ec-brdCol: rgba(var(--netscli-hairline-rgb), 0.22);
   --ec-codeBg: #10151b;
   --ec-codeFg: #d7dce5;
   --ec-codeLineHt: 1.64;
   --ec-codePadBlk: 1rem;
   --ec-codePadInl: 1.15rem;
   --ec-focusBrd: var(--netscli-accent-high);
-  --ec-sbThumbCol: rgba(140, 149, 166, 0.22);
+  --ec-sbThumbCol: rgba(var(--netscli-hairline-rgb), 0.22);
   --ec-sbThumbHoverCol: rgba(159, 248, 222, 0.32);
   --ec-frm-frameBoxShdCssVal: 0 18px 46px rgba(0, 0, 0, 0.34);
   --ec-frm-trmTtbBg: #202733;
-  --ec-frm-trmTtbBrdBtmCol: rgba(140, 149, 166, 0.2);
+  --ec-frm-trmTtbBrdBtmCol: rgba(var(--netscli-hairline-rgb), 0.2);
   --ec-frm-trmTtbDotsFg: #8c95a6;
   --ec-frm-trmTtbDotsOpa: 0.48;
   --ec-frm-trmBg: #10151b;
@@ -210,7 +210,7 @@ html[data-theme='light'] .main-pane {
 .sl-markdown-content .expressive-code .frame {
 
   border-radius: 8px !important;
-  border: 1px solid rgba(140, 149, 166, 0.18);
+  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.18);
 
 }
 
@@ -240,14 +240,14 @@ html[data-theme='light'] .main-pane {
 html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
   border-color: var(--sl-color-hairline-light);
   box-shadow:
-    0 12px 34px rgba(17, 24, 39, 0.11),
+    0 12px 34px rgba(var(--netscli-hairline-rgb), 0.11),
     inset 0 1px 0 rgba(255, 255, 255, 0.78);
 }html[data-theme='light'] .sl-markdown-content .expressive-code {
-  --ec-brdCol: rgba(17, 24, 39, 0.12);
+  --ec-brdCol: rgba(var(--netscli-hairline-rgb), 0.12);
   --ec-codeBg: #f7faf9;
   --ec-codeFg: #243044;
   --ec-frm-trmTtbBg: #edf2f3;
-  --ec-frm-trmTtbBrdBtmCol: rgba(17, 24, 39, 0.1);
+  --ec-frm-trmTtbBrdBtmCol: rgba(var(--netscli-hairline-rgb), 0.1);
   --ec-frm-trmBg: #f7faf9;
   --ec-frm-inlBtnFg: #146b2e;
   --ec-frm-inlBtnBg: #146b2e;
@@ -276,7 +276,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .ec-line :where(s
   margin: 1.2rem 0 2rem;
   border-collapse: separate;
   border-spacing: 0;
-  border: 1px solid rgba(140, 149, 166, 0.18);
+  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.18);
   border-radius: 8px;
   overflow: hidden;
 

--- a/site/src/styles/starlight/04-markdown-content-base.css
+++ b/site/src/styles/starlight/04-markdown-content-base.css
@@ -18,12 +18,12 @@
   text-align: left;
   vertical-align: middle;
 }.sl-markdown-content tbody td {
-  border-bottom: 1px solid rgba(140, 149, 166, 0.105);
+  border-bottom: 1px solid rgba(var(--netscli-hairline-rgb), 0.105);
 }
 
 .sl-markdown-content td + td,
 .sl-markdown-content th + th {
-  border-inline-start: 1px solid rgba(140, 149, 166, 0.11);
+  border-inline-start: 1px solid rgba(var(--netscli-hairline-rgb), 0.11);
 }
 
 .sl-markdown-content td:first-child,

--- a/site/src/styles/starlight/05-docs-surfaces.css
+++ b/site/src/styles/starlight/05-docs-surfaces.css
@@ -2,12 +2,12 @@
    green act as a state/underline accent instead of a dominant fill color. */
 html[data-theme='dark'],
 html[data-theme='dark'] ::backdrop {
-  --sl-color-bg-inline-code: rgba(140, 149, 166, 0.13);
+  --sl-color-bg-inline-code: rgba(var(--netscli-hairline-rgb), 0.13);
 }
 
 html[data-theme='light'],
 html[data-theme='light'] ::backdrop {
-  --sl-color-bg-inline-code: rgba(17, 24, 39, 0.07);
+  --sl-color-bg-inline-code: rgba(var(--netscli-hairline-rgb), 0.07);
 }html[data-theme='light']:not([data-docs-scrolled='true']) header.header {
   box-shadow: inset 0 -1px 0 rgba(var(--netscli-accent-rgb), 0.18) !important;
 }
@@ -77,15 +77,15 @@ site-search dialog .dialog-frame {
 }
 
 .sl-markdown-content :not(pre) > code {
-  border-color: rgba(140, 149, 166, 0.25);
+  border-color: rgba(var(--netscli-hairline-rgb), 0.25);
   background: var(--sl-color-bg-inline-code);
 
 }.sl-markdown-content .expressive-code {
-  --ec-brdCol: rgba(140, 149, 166, 0.24);
+  --ec-brdCol: rgba(var(--netscli-hairline-rgb), 0.24);
   --ec-codeBg: #171c23;
   --ec-codeFg: #d7dce5;
   --ec-focusBrd: rgba(215, 220, 229, 0.8);
-  --ec-sbThumbCol: rgba(140, 149, 166, 0.24);
+  --ec-sbThumbCol: rgba(var(--netscli-hairline-rgb), 0.24);
   --ec-sbThumbHoverCol: rgba(194, 202, 216, 0.42);
   --ec-frm-frameBoxShdCssVal: 0 16px 36px rgba(0, 0, 0, 0.3);
   --ec-frm-trmBg: #171c23;
@@ -111,7 +111,7 @@ site-search dialog .dialog-frame {
 }
 
 .sl-markdown-content .expressive-code .copy button::before {
-  border-color: rgba(140, 149, 166, 0.38);
+  border-color: rgba(var(--netscli-hairline-rgb), 0.38);
 }
 
 .sl-markdown-content .expressive-code .copy button:hover,
@@ -146,7 +146,7 @@ site-search dialog .dialog-frame {
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code {
-  --ec-brdCol: rgba(17, 24, 39, 0.13);
+  --ec-brdCol: rgba(var(--netscli-hairline-rgb), 0.13);
   --ec-codeBg: #f2f5f7;
   --ec-codeFg: #243044;
   --ec-frm-trmBg: #f2f5f7;
@@ -161,7 +161,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
 }
 
 .sl-markdown-content table {
-  border-color: rgba(140, 149, 166, 0.2);
+  border-color: rgba(var(--netscli-hairline-rgb), 0.2);
   background: var(--netscli-table-bg);
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.025) inset,
@@ -186,11 +186,11 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
   background: var(--netscli-table-stripe);
 }.sl-markdown-content td,
 .sl-markdown-content th {
-  border-color: rgba(140, 149, 166, 0.13);
+  border-color: rgba(var(--netscli-hairline-rgb), 0.13);
 }
 
 .sl-markdown-content tbody td {
-  border-bottom-color: rgba(140, 149, 166, 0.11);
+  border-bottom-color: rgba(var(--netscli-hairline-rgb), 0.11);
 }
 
 .sl-markdown-content table.table-row-headers tbody td:first-child {
@@ -205,7 +205,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
 html[data-theme='light'] .sl-markdown-content table {
 
   border-color: var(--sl-color-hairline-light);
-  box-shadow: 0 10px 24px rgba(17, 24, 39, 0.07);
+  box-shadow: 0 10px 24px rgba(var(--netscli-hairline-rgb), 0.07);
 }
 
 html[data-theme='light'] .sl-markdown-content thead tr {

--- a/site/src/styles/starlight/06-docs-interaction-a.css
+++ b/site/src/styles/starlight/06-docs-interaction-a.css
@@ -85,7 +85,7 @@
   display: grid;
   place-items: center;
   min-height: 10rem;
-  border: 1px dashed rgba(140, 149, 166, 0.22);
+  border: 1px dashed rgba(var(--netscli-hairline-rgb), 0.22);
   border-radius: 8px;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 9rem),
@@ -103,7 +103,7 @@ site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidde
   place-items: center;
   min-height: 10rem;
   margin-top: 1rem;
-  border: 1px dashed rgba(140, 149, 166, 0.22);
+  border: 1px dashed rgba(var(--netscli-hairline-rgb), 0.22);
   border-radius: 8px;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 9rem),
@@ -126,7 +126,7 @@ site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidde
   display: grid;
   align-content: center;
   min-height: 10rem;
-  border: 1px dashed rgba(140, 149, 166, 0.22);
+  border: 1px dashed rgba(var(--netscli-hairline-rgb), 0.22);
   border-radius: 8px;
   background: rgba(32, 36, 43, 0.56);
 }
@@ -141,7 +141,7 @@ site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidde
 
 #starlight__search .pagefind-ui__result-inner {
   overflow: hidden;
-  border: 1px solid rgba(140, 149, 166, 0.16);
+  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.16);
   border-radius: 8px;
   background: #20242b;
   box-shadow:
@@ -159,10 +159,10 @@ site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidde
 
 #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)) {
   background: #252b36 !important;
-  box-shadow: inset 0 -1px 0 rgba(140, 149, 166, 0.13);
+  box-shadow: inset 0 -1px 0 rgba(var(--netscli-hairline-rgb), 0.13);
 }
 
 #starlight__search .pagefind-ui__result-nested,
 #starlight__search .pagefind-ui__result-tags {
-  box-shadow: inset 0 1px 0 rgba(140, 149, 166, 0.1);
+  box-shadow: inset 0 1px 0 rgba(var(--netscli-hairline-rgb), 0.1);
 }

--- a/site/src/styles/starlight/07-docs-interaction-b.css
+++ b/site/src/styles/starlight/07-docs-interaction-b.css
@@ -6,11 +6,11 @@
   background: #2b313d !important;
   box-shadow:
     inset 2px 0 0 rgba(var(--netscli-accent-rgb), 0.74),
-    inset 0 -1px 0 rgba(140, 149, 166, 0.13);
+    inset 0 -1px 0 rgba(var(--netscli-hairline-rgb), 0.13);
 }
 
 .sl-markdown-content .expressive-code {
-  --ec-brdCol: rgba(140, 149, 166, 0.2);
+  --ec-brdCol: rgba(var(--netscli-hairline-rgb), 0.2);
   --ec-codeBg: #20242b;
   --ec-codeFg: #d7dce5;
   --ec-frm-trmBg: #20242b;
@@ -25,7 +25,7 @@
 .sl-markdown-content .expressive-code .frame {
   position: relative;
   overflow: hidden;
-  border-color: rgba(140, 149, 166, 0.2);
+  border-color: rgba(var(--netscli-hairline-rgb), 0.2);
   background: #20242b !important;
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.025) inset,
@@ -62,7 +62,7 @@
 .sl-markdown-content .expressive-code .copy button {
   width: var(--netscli-code-copy-size);
   height: var(--netscli-code-copy-size);
-  border: 1px solid rgba(140, 149, 166, 0.18);
+  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.18);
   border-radius: 5px;
   background: #252b36;
   opacity: 0.9;
@@ -119,13 +119,13 @@ html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
 
 .pagination-links a:hover {
   background: rgba(255, 255, 255, 0.018) !important;
-  border-color: rgba(140, 149, 166, 0.26) !important;
+  border-color: rgba(var(--netscli-hairline-rgb), 0.26) !important;
   color: var(--sl-color-white) !important;
 }
 
 html[data-theme='light'] .pagination-links a:hover {
-  background: rgba(17, 24, 39, 0.022) !important;
-  border-color: rgba(17, 24, 39, 0.16) !important;
+  background: rgba(var(--netscli-hairline-rgb), 0.022) !important;
+  border-color: rgba(var(--netscli-hairline-rgb), 0.16) !important;
   color: var(--sl-color-white) !important;
 }
 
@@ -141,10 +141,10 @@ html[data-theme='light'] .pagination-links a > svg {
 html[data-theme='light'] #starlight__search .pagefind-ui__result-inner,
 html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
   background: #f6f8fa !important;
-  border-color: rgba(17, 24, 39, 0.13);
+  border-color: rgba(var(--netscli-hairline-rgb), 0.13);
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.8) inset,
-    0 10px 24px rgba(17, 24, 39, 0.07);
+    0 10px 24px rgba(var(--netscli-hairline-rgb), 0.07);
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)),
@@ -155,7 +155,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
 }html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
   background: rgba(var(--netscli-accent-rgb), 0.42);
 }html[data-theme='light'] .sl-markdown-content :not(pre) > code {
-  border-color: rgba(17, 24, 39, 0.16);
+  border-color: rgba(var(--netscli-hairline-rgb), 0.16);
   background: #eef2f4;
 
 }

--- a/site/src/styles/starlight/08-search-modal.css
+++ b/site/src/styles/starlight/08-search-modal.css
@@ -111,7 +111,7 @@ site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidde
 
 html[data-theme='light'] site-search dialog {
   background: #f6f8fa !important;
-  border-color: rgba(17, 24, 39, 0.24) !important;
+  border-color: rgba(var(--netscli-hairline-rgb), 0.24) !important;
 }
 
 html[data-theme='light'] site-search dialog .dialog-frame,
@@ -136,7 +136,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__form::before {
 
 html[data-theme='light'] #starlight__search .pagefind-ui__search-input {
 
-  border-color: rgba(17, 24, 39, 0.24) !important;
+  border-color: rgba(var(--netscli-hairline-rgb), 0.24) !important;
   color: var(--sl-color-white) !important;
 }
 
@@ -156,7 +156,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__search-clear::before {
 
 html[data-theme='light'] #starlight__search .pagefind-ui__result-inner {
   background: var(--sl-color-black) !important;
-  border-color: rgba(17, 24, 39, 0.14);
+  border-color: rgba(var(--netscli-hairline-rgb), 0.14);
 }
 
 html[data-theme='light']
@@ -190,7 +190,7 @@ html[data-theme='light']
 html[data-theme='light'] site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidden)::after,
 html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__message):not(:has(.pagefind-ui__result)) {
   background: var(--sl-color-black);
-  border-color: rgba(17, 24, 39, 0.18);
+  border-color: rgba(var(--netscli-hairline-rgb), 0.18);
   color: var(--sl-color-gray-2);
 }
 

--- a/site/src/styles/starlight/09-search-table-fit.css
+++ b/site/src/styles/starlight/09-search-table-fit.css
@@ -69,7 +69,7 @@ html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy button {
-  border-color: rgba(17, 24, 39, 0.14) !important;
+  border-color: rgba(var(--netscli-hairline-rgb), 0.14) !important;
   background: #e9eef2 !important;
   color: var(--sl-color-gray-1) !important;
   opacity: 1;
@@ -83,7 +83,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .copy button:focu
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy button::before {
-  border-color: rgba(17, 24, 39, 0.26) !important;
+  border-color: rgba(var(--netscli-hairline-rgb), 0.26) !important;
 }
 
 .sl-markdown-content .expressive-code .copy button {

--- a/site/src/styles/starlight/12-docs-toc-responsive.css
+++ b/site/src/styles/starlight/12-docs-toc-responsive.css
@@ -112,7 +112,7 @@
 }
 
 html[data-theme='light'] mobile-starlight-toc .toggle {
-  border-color: rgba(17, 24, 39, 0.14) !important;
+  border-color: rgba(var(--netscli-hairline-rgb), 0.14) !important;
   background: rgba(255, 255, 255, 0.72) !important;
   color: var(--sl-color-gray-1) !important;
 }
@@ -156,7 +156,7 @@ html[data-theme='light'] mobile-starlight-toc .display-current {
 }
 
 .sl-markdown-content .expressive-code .copy button[data-copied] {
-  border-color: rgba(140, 149, 166, 0.18) !important;
+  border-color: rgba(var(--netscli-hairline-rgb), 0.18) !important;
   background: #252b36 !important;
   color: rgba(216, 222, 232, 0.46) !important;
 }
@@ -184,7 +184,7 @@ html[data-theme='light'] mobile-starlight-toc .display-current {
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .copy button[data-copied] {
-  border-color: rgba(17, 24, 39, 0.14) !important;
+  border-color: rgba(var(--netscli-hairline-rgb), 0.14) !important;
   background: #e9eef2 !important;
   color: #536176 !important;
 }

--- a/site/src/styles/starlight/14-docs-nav-table.css
+++ b/site/src/styles/starlight/14-docs-nav-table.css
@@ -138,7 +138,7 @@
     width: 100% !important;
     max-width: 100% !important;
     overflow-x: auto !important;
-    border: 1px solid rgba(140, 149, 166, 0.2) !important;
+    border: 1px solid rgba(var(--netscli-hairline-rgb), 0.2) !important;
     border-radius: 8px !important;
     background: #20242b !important;
   }
@@ -165,7 +165,7 @@
     width: auto !important;
     min-width: 9rem;
     padding: 0.68rem 0.85rem !important;
-    border-bottom: 1px solid rgba(140, 149, 166, 0.11) !important;
+    border-bottom: 1px solid rgba(var(--netscli-hairline-rgb), 0.11) !important;
     white-space: normal !important;
     overflow-wrap: normal !important;
   }
@@ -179,19 +179,19 @@
 
   .sl-markdown-content table td + td,
   .sl-markdown-content table th + th {
-    border-inline-start: 1px solid rgba(140, 149, 166, 0.11) !important;
+    border-inline-start: 1px solid rgba(var(--netscli-hairline-rgb), 0.11) !important;
   }
 }
 
 html[data-theme='light'] mobile-starlight-toc .dropdown {
   background: var(--sl-color-black) !important;
-  box-shadow: 0 14px 32px rgba(17, 24, 39, 0.12) !important;
+  box-shadow: 0 14px 32px rgba(var(--netscli-hairline-rgb), 0.12) !important;
 }
 
 html[data-theme='light'] mobile-starlight-toc .dropdown a:hover,
 html[data-theme='light'] mobile-starlight-toc .dropdown a:focus-visible {
   color: var(--sl-color-white) !important;
-  background: rgba(17, 24, 39, 0.045) !important;
+  background: rgba(var(--netscli-hairline-rgb), 0.045) !important;
 }
 
 html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true'] {

--- a/site/src/styles/starlight/15-responsive-containment.css
+++ b/site/src/styles/starlight/15-responsive-containment.css
@@ -18,7 +18,7 @@
     max-width: 100% !important;
     overflow-x: auto !important;
     overflow-y: hidden !important;
-    border: 1px solid rgba(140, 149, 166, 0.2) !important;
+    border: 1px solid rgba(var(--netscli-hairline-rgb), 0.2) !important;
     border-radius: 8px !important;
     background: var(--netscli-table-bg) !important;
     -webkit-overflow-scrolling: touch;
@@ -46,7 +46,7 @@
     width: auto !important;
     min-width: 8.5rem !important;
     padding: 0.68rem 0.85rem !important;
-    border-bottom: 1px solid rgba(140, 149, 166, 0.11) !important;
+    border-bottom: 1px solid rgba(var(--netscli-hairline-rgb), 0.11) !important;
     white-space: normal !important;
     overflow-wrap: normal !important;
   }
@@ -61,7 +61,7 @@
 
   .sl-markdown-content table td + td,
   .sl-markdown-content table th + th {
-    border-inline-start: 1px solid rgba(140, 149, 166, 0.11) !important;
+    border-inline-start: 1px solid rgba(var(--netscli-hairline-rgb), 0.11) !important;
   }
 }
 

--- a/site/src/styles/starlight/16-shell-interaction-closeout.css
+++ b/site/src/styles/starlight/16-shell-interaction-closeout.css
@@ -45,7 +45,7 @@ site-search button[data-open-modal] {
 }
 
 html[data-theme='light'] site-search button[data-open-modal] {
-  background: rgba(17, 24, 39, 0.035) !important;
+  background: rgba(var(--netscli-hairline-rgb), 0.035) !important;
 }#starlight__search .pagefind-ui__drawer:has(.pagefind-ui__result)::before,
 #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__result)::after {
   height: 1.35rem !important;

--- a/site/src/styles/starlight/19-markdown-tables.css
+++ b/site/src/styles/starlight/19-markdown-tables.css
@@ -5,7 +5,7 @@
   margin-block: 1.2rem;
   overflow-x: auto;
   overflow-y: hidden;
-  border: 1px solid rgba(140, 149, 166, 0.2);
+  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.2);
   border-radius: 8px;
   background: var(--netscli-table-bg);
   -webkit-overflow-scrolling: touch;

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -209,7 +209,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
     height: auto !important;
     max-height: calc(100dvh - var(--sl-nav-height) - 1.3rem) !important;
     padding: 0 !important;
-    border: 1px solid rgba(140, 149, 166, 0.22) !important;
+    border: 1px solid rgba(var(--netscli-hairline-rgb), 0.22) !important;
     border-radius: 8px !important;
     /* Opaque, and theme-aware.
      *

--- a/site/src/styles/starlight/23-regression-guardrails.css
+++ b/site/src/styles/starlight/23-regression-guardrails.css
@@ -81,7 +81,7 @@
     margin-block: 1rem 1.35rem !important;
     overflow-x: auto !important;
     overflow-y: hidden !important;
-    border: 1px solid rgba(140, 149, 166, 0.2) !important;
+    border: 1px solid rgba(var(--netscli-hairline-rgb), 0.2) !important;
     border-radius: 8px !important;
     background: var(--netscli-table-bg) !important;
     -webkit-overflow-scrolling: touch !important;
@@ -119,7 +119,7 @@
     width: auto !important;
     min-width: 0 !important;
     padding: 0.85rem 1rem !important;
-    border-bottom: 1px solid rgba(140, 149, 166, 0.11) !important;
+    border-bottom: 1px solid rgba(var(--netscli-hairline-rgb), 0.11) !important;
     line-height: 1.42 !important;
     white-space: normal !important;
     overflow-wrap: normal !important;

--- a/site/src/styles/starlight/28-final-interaction-guardrails.css
+++ b/site/src/styles/starlight/28-final-interaction-guardrails.css
@@ -115,7 +115,7 @@ a.download-count:focus-visible,
   .sl-markdown-content table,
   .content-panel table {
     display: table !important;
-    border: 1px solid rgba(140, 149, 166, 0.18) !important;
+    border: 1px solid rgba(var(--netscli-hairline-rgb), 0.18) !important;
     background: var(--sl-color-bg-inline-code) !important;
     overflow: visible !important;
   }
@@ -146,7 +146,7 @@ a.download-count:focus-visible,
     display: table-cell !important;
     min-width: 10rem !important;
     padding: 0.65rem 0.85rem !important;
-    border-bottom: 1px solid rgba(140, 149, 166, 0.14) !important;
+    border-bottom: 1px solid rgba(var(--netscli-hairline-rgb), 0.14) !important;
     white-space: normal !important;
   }
 }


### PR DESCRIPTION
Same shape of bug as the accent, and bigger.

Borders, dividers and low-alpha washes were written as raw channels:

| | uses | scope |
|---|---|---|
| `rgba(140, 149, 166, α)` — dark's `--sl-color-gray-3` | **47** | no theme scope at all |
| `rgba(17, 24, 39, α)` — light's own ink | **33** | light-scoped hand-patches |

So 47 rules applied the *dark* theme's grey on light pages, and someone had patched around it in 33 places. Neither set was named.

Both themes now declare `--netscli-hairline-rgb`, and all **78 call sites** read it.

## Two steps, verified separately

**The 33 light-scoped ink uses** became the token, whose light value already equals what they spelled out — **84 captures identical**. Provably a rename.

**The 47 theme-agnostic grey uses do move pixels**, because they *were* the bug: **29 captures changed, every one light, dark byte-identical**. I compared before/after on `/docs/mcp/` at 700px — borders read slightly darker and better defined against a light page, no layout movement, nothing broken. Alphas are untouched; only the hue each resolves to changed.

## Gates

contrast 124 pairs ≥ 4.5:1 · dead CSS 24/24 · `astro check` clean · axe 0 violations, 14 pages, both themes

**Literal colour declarations: 96 → 71.**

## Left alone deliberately

25 theme-agnostic `rgba(255, 255, 255, α)` washes. A white wash at 0.02–0.05 over a light page is close to invisible, so those hover states probably do nothing in the light theme. Fixing it would make hovers *appear* where today there are none — a behaviour change rather than a colour one, and it wants its own look.