### PR TITLE
Make a raised surface get darker in the light theme, not lighter

### DIFF
--- a/site/src/styles/starlight/00-theme-tokens.css
+++ b/site/src/styles/starlight/00-theme-tokens.css
@@ -46,6 +46,11 @@ html[data-theme='dark'] ::backdrop {
      --sl-color-gray-3 above; declared separately because rgba() needs the
      numbers, not the colour. */
   --netscli-hairline-rgb: 140, 149, 166;
+
+  /* The direction "raised" points in this theme. On a dark surface a lift is
+     a white wash; see the light block for why this needs to be a token rather
+     than a literal. */
+  --netscli-lift-rgb: 255, 255, 255;
 }
 
 html[data-theme='light'],
@@ -103,4 +108,11 @@ html[data-theme='light'] ::backdrop {
      which is --sl-color-white here because Starlight inverts that name in the
      light theme. 33 rules already wrote these channels out by hand. */
   --netscli-hairline-rgb: 17, 24, 39;
+
+  /* On a light surface, raised is DARKER, not lighter. 26 hover and inset
+     highlight rules wrote rgba(255, 255, 255, a) with no theme scope, at
+     alphas between 0.015 and 0.1 -- white on a near-white page, which is
+     nothing at all. Those hover states have been invisible in this theme.
+     Same alphas, opposite direction. */
+  --netscli-lift-rgb: 17, 24, 39;
 }

--- a/site/src/styles/starlight/01-tokens-and-header.css
+++ b/site/src/styles/starlight/01-tokens-and-header.css
@@ -50,7 +50,7 @@ html {
 
 * {
   scrollbar-width: thin;
-  scrollbar-color: rgba(var(--netscli-hairline-rgb), 0.42) rgba(255, 255, 255, 0.035);
+  scrollbar-color: rgba(var(--netscli-hairline-rgb), 0.42) rgba(var(--netscli-lift-rgb), 0.035);
 }
 
 ::-webkit-scrollbar {
@@ -196,7 +196,7 @@ header.header starlight-theme-select label {
 starlight-menu-button button {
   border: 1px solid var(--sl-color-hairline-light);
   border-radius: 6px;
-  background: rgba(255, 255, 255, 0.035);
+  background: rgba(var(--netscli-lift-rgb), 0.035);
   color: var(--sl-color-gray-2);
   box-shadow: none;
 }
@@ -214,13 +214,13 @@ site-search button[data-open-modal] {
   border-radius: 6px;
 
   color: var(--sl-color-gray-2);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+  box-shadow: inset 0 1px 0 rgba(var(--netscli-lift-rgb), 0.035);
 }
 
 site-search button[data-open-modal]:hover {
 
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.018)),
+    linear-gradient(180deg, rgba(var(--netscli-lift-rgb), 0.04), rgba(var(--netscli-lift-rgb), 0.018)),
     rgba(17, 22, 29, 0.96);
   color: var(--sl-color-white);
 
@@ -231,5 +231,5 @@ site-search button[data-open-modal]:focus-visible {
   border-color: rgba(159, 248, 222, 0.62);
   box-shadow:
     0 0 0 2px rgba(var(--netscli-accent-rgb), 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    inset 0 1px 0 rgba(var(--netscli-lift-rgb), 0.04);
 }

--- a/site/src/styles/starlight/02-search-and-sidebar-base.css
+++ b/site/src/styles/starlight/02-search-and-sidebar-base.css
@@ -12,7 +12,7 @@ site-search button[data-open-modal]:focus-visible svg {
 site-search button[data-open-modal] > kbd {
   border: 1px solid rgba(var(--netscli-hairline-rgb), 0.24);
   border-radius: 4px;
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(var(--netscli-lift-rgb), 0.04);
   color: var(--sl-color-gray-3);
 }
 
@@ -22,7 +22,7 @@ site-search dialog {
 
   box-shadow:
     0 34px 90px rgba(0, 0, 0, 0.62),
-    0 0 0 1px rgba(255, 255, 255, 0.02) inset !important;
+    0 0 0 1px rgba(var(--netscli-lift-rgb), 0.02) inset !important;
 }
 
 site-search dialog::backdrop {
@@ -71,7 +71,7 @@ site-search button[data-close-modal]:focus-visible {
   border-color: rgba(159, 248, 222, 0.72) !important;
   box-shadow:
     0 0 0 2px rgba(var(--netscli-accent-rgb), 0.16),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04) !important;
+    inset 0 1px 0 rgba(var(--netscli-lift-rgb), 0.04) !important;
 }#starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):hover,
 #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):focus-within,
 #starlight__search .pagefind-ui__result-nested:hover,
@@ -176,7 +176,7 @@ html[data-theme='light'] starlight-menu-button[aria-expanded='true'] button {
 
 .sidebar-content a:hover {
   color: var(--sl-color-white);
-  background: rgba(255, 255, 255, 0.045);
+  background: rgba(var(--netscli-lift-rgb), 0.045);
 }
 
 @media (max-width: 72rem) {

--- a/site/src/styles/starlight/04-markdown-content-base.css
+++ b/site/src/styles/starlight/04-markdown-content-base.css
@@ -180,7 +180,7 @@
 
 .pagination-links a {
   box-shadow: none;
-  background: rgba(255, 255, 255, 0.025);
+  background: rgba(var(--netscli-lift-rgb), 0.025);
 }
 
 starlight-theme-select label,
@@ -207,7 +207,7 @@ starlight-theme-select label {
   padding-inline: 0.65rem;
   border: 1px solid var(--sl-color-hairline-light);
   border-radius: 6px;
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(var(--netscli-lift-rgb), 0.03);
   color: var(--sl-color-gray-2);
 }
 

--- a/site/src/styles/starlight/05-docs-surfaces.css
+++ b/site/src/styles/starlight/05-docs-surfaces.css
@@ -164,7 +164,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
   border-color: rgba(var(--netscli-hairline-rgb), 0.2);
   background: var(--netscli-table-bg);
   box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.025) inset,
+    0 1px 0 rgba(var(--netscli-lift-rgb), 0.025) inset,
     0 12px 26px rgba(0, 0, 0, 0.16);
 }
 
@@ -194,7 +194,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code pre {
 }
 
 .sl-markdown-content table.table-row-headers tbody td:first-child {
-  background: rgba(255, 255, 255, 0.018);
+  background: rgba(var(--netscli-lift-rgb), 0.018);
 }
 
 .sl-markdown-content table:not(.table-row-headers) tbody td:first-child,

--- a/site/src/styles/starlight/06-docs-interaction-a.css
+++ b/site/src/styles/starlight/06-docs-interaction-a.css
@@ -88,7 +88,7 @@
   border: 1px dashed rgba(var(--netscli-hairline-rgb), 0.22);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 9rem),
+    linear-gradient(180deg, rgba(var(--netscli-lift-rgb), 0.025), transparent 9rem),
     rgba(32, 36, 43, 0.56);
 }
 
@@ -106,7 +106,7 @@ site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidde
   border: 1px dashed rgba(var(--netscli-hairline-rgb), 0.22);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 9rem),
+    linear-gradient(180deg, rgba(var(--netscli-lift-rgb), 0.025), transparent 9rem),
     rgba(32, 36, 43, 0.56);
   color: var(--sl-color-gray-3);
   font-size: 0.95rem;
@@ -145,7 +145,7 @@ site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidde
   border-radius: 8px;
   background: #20242b;
   box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.025) inset,
+    0 1px 0 rgba(var(--netscli-lift-rgb), 0.025) inset,
     0 12px 26px rgba(0, 0, 0, 0.16);
 }
 

--- a/site/src/styles/starlight/07-docs-interaction-b.css
+++ b/site/src/styles/starlight/07-docs-interaction-b.css
@@ -28,7 +28,7 @@
   border-color: rgba(var(--netscli-hairline-rgb), 0.2);
   background: #20242b !important;
   box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.025) inset,
+    0 1px 0 rgba(var(--netscli-lift-rgb), 0.025) inset,
     0 12px 28px rgba(0, 0, 0, 0.2);
 }
 
@@ -118,7 +118,7 @@ html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
 }
 
 .pagination-links a:hover {
-  background: rgba(255, 255, 255, 0.018) !important;
+  background: rgba(var(--netscli-lift-rgb), 0.018) !important;
   border-color: rgba(var(--netscli-hairline-rgb), 0.26) !important;
   color: var(--sl-color-white) !important;
 }

--- a/site/src/styles/starlight/10-docs-feedback.css
+++ b/site/src/styles/starlight/10-docs-feedback.css
@@ -11,7 +11,7 @@
 
 #starlight__search .pagefind-ui__search-input {
   background: #171b22 !important;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.015) !important;
+  box-shadow: inset 0 0 0 1px rgba(var(--netscli-lift-rgb), 0.015) !important;
 }
 
 #starlight__search .pagefind-ui__drawer {

--- a/site/src/styles/starlight/16-shell-interaction-closeout.css
+++ b/site/src/styles/starlight/16-shell-interaction-closeout.css
@@ -31,17 +31,17 @@
  * the same size and radius, and were painted differently: the search button
  * was `rgba(17,22,29,.9)` under a white gradient with a
  * `rgba(140,149,166,.24)` border, the menu toggle a flat
- * `rgba(255,255,255,.035)` with `rgba(255,255,255,.1)`. One looked recessed
+ * `rgba(var(--netscli-lift-rgb), .035)` with `rgba(var(--netscli-lift-rgb), .1)`. One looked recessed
  * and the other flat. The toggle's values win because they are the ones
  * derived from the theme's hairline token. */
 site-search button[data-open-modal] {
-  background: rgba(255, 255, 255, 0.035) !important;
+  background: rgba(var(--netscli-lift-rgb), 0.035) !important;
   border-color: var(--sl-color-hairline-light) !important;
 }site-search button[data-open-modal]:hover {
   border-color: rgba(var(--netscli-accent-rgb), 0.48) !important;
   box-shadow:
     0 0 0 1px rgba(var(--netscli-accent-rgb), 0.16),
-    inset 0 1px 0 rgba(255, 255, 255, 0.035) !important;
+    inset 0 1px 0 rgba(var(--netscli-lift-rgb), 0.035) !important;
 }
 
 html[data-theme='light'] site-search button[data-open-modal] {

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -151,7 +151,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   }.docs-mobile-section-menu a:hover,
   .docs-mobile-section-menu a:focus-visible {
     color: var(--sl-color-white) !important;
-    background: rgba(255, 255, 255, 0.04) !important;
+    background: rgba(var(--netscli-lift-rgb), 0.04) !important;
   }
 
   mobile-starlight-toc nav {
@@ -179,7 +179,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   mobile-starlight-toc .dropdown a:hover,
   mobile-starlight-toc .dropdown a:focus-visible {
     color: var(--sl-color-white) !important;
-    background: rgba(255, 255, 255, 0.04) !important;
+    background: rgba(var(--netscli-lift-rgb), 0.04) !important;
   }
 
   mobile-starlight-toc .dropdown a[aria-current='true'],

--- a/site/src/styles/starlight/21-mobile-docs-shell-verified.css
+++ b/site/src/styles/starlight/21-mobile-docs-shell-verified.css
@@ -4,7 +4,7 @@
 }.sidebar-content :where(details > ul a:hover),
 .sidebar-content :where(details > ul a:focus-visible) {
   color: var(--sl-color-white) !important;
-  background: rgba(255, 255, 255, 0.045) !important;
+  background: rgba(var(--netscli-lift-rgb), 0.045) !important;
 }
 
 .sidebar-content :where(details > ul a[aria-current='page']) {


### PR DESCRIPTION
Hover backgrounds, inset highlights and subtle borders were written as `rgba(255, 255, 255, α)` with **no theme scope** — 27 of them, at alphas between 0.015 and 0.1.

White at 2% over a near-white page is nothing. **Those states have been invisible in the light theme**: a hover that doesn't respond, an inset highlight that never appears.

The mistake is treating "raised" as a colour. It's a *direction*, and it reverses with the background: on a dark surface you lift with white, on a light one you lift by going darker.

Both themes now declare `--netscli-lift-rgb` — `255,255,255` in dark, `17,24,39` in light — and all 27 call sites read it. Alphas untouched.

## Why not reuse the hairline token

The two share a value in light, but reusing `--netscli-hairline-rgb` would have changed the **dark** theme too, from a white wash to a grey one. Dark was already correct.

## Not converted, deliberately

The six remaining `rgba(255,255,255,α)` uses at **0.58–0.94** are light-scoped and are deliberate near-white *surfaces* — dialogs, toggles, code frames — not lifts.

## Verified in the browser, because captures can't see hover

A probe reading `rgba(var(--netscli-lift-rgb), 0.035)`:

| theme | computes to |
|---|---|
| dark | `rgba(255, 255, 255, 0.035)` |
| light | `rgba(17, 24, 39, 0.035)` |

The inversion is the entire claim, and that's it measured.

**Captures: 11 differ, all light, dark byte-identical.** Only resting-state uses show up — the largest moved a 245KB PNG by *7 bytes*. The real benefit is in states a screenshot cannot reach, which is why the browser check above is the evidence rather than the harness.

## Gates

contrast 124 pairs ≥ 4.5:1 · dead CSS 24/24 · `astro check` clean · axe 0 violations, 14 pages, both themes

**Literal colour declarations: 71 → 61.**