### PR TITLE
Name the panel and menu surfaces

### DIFF
--- a/site/src/styles/starlight/00-theme-tokens.css
+++ b/site/src/styles/starlight/00-theme-tokens.css
@@ -51,6 +51,16 @@ html[data-theme='dark'] ::backdrop {
      a white wash; see the light block for why this needs to be a token rather
      than a literal. */
   --netscli-lift-rgb: 255, 255, 255;
+
+  /* The raised panel that content sits on: search results and their tag
+     rows, and the frame and body of a code block. One surface, written out
+     six times across three files before this. */
+  --netscli-panel-bg: #20242b;
+
+  /* The floating menu surface: the mobile section menu and the mobile table
+     of contents dropdown, which are the same panel and were written out
+     separately in three files. */
+  --netscli-menu-bg: #1b2028;
 }
 
 html[data-theme='light'],
@@ -115,4 +125,12 @@ html[data-theme='light'] ::backdrop {
      nothing at all. Those hover states have been invisible in this theme.
      Same alphas, opposite direction. */
   --netscli-lift-rgb: 17, 24, 39;
+
+  /* Light counterpart of the raised panel; see the dark block above. */
+  --netscli-panel-bg: #f6f8fa;
+
+  /* Light counterpart of the floating menu; plain white, which this theme
+     also calls --sl-color-black. Named for the role so both themes read the
+     same way at the call site. */
+  --netscli-menu-bg: #ffffff;
 }

--- a/site/src/styles/starlight/06-docs-interaction-a.css
+++ b/site/src/styles/starlight/06-docs-interaction-a.css
@@ -143,7 +143,7 @@ site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidde
   overflow: hidden;
   border: 1px solid rgba(var(--netscli-hairline-rgb), 0.16);
   border-radius: 8px;
-  background: #20242b;
+  background: var(--netscli-panel-bg);
   box-shadow:
     0 1px 0 rgba(var(--netscli-lift-rgb), 0.025) inset,
     0 12px 26px rgba(0, 0, 0, 0.16);
@@ -154,7 +154,7 @@ site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidde
 #starlight__search .pagefind-ui__result-tags {
   border: 0 !important;
   border-radius: 0 !important;
-  background: #20242b !important;
+  background: var(--netscli-panel-bg) !important;
 }
 
 #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)) {

--- a/site/src/styles/starlight/07-docs-interaction-b.css
+++ b/site/src/styles/starlight/07-docs-interaction-b.css
@@ -26,7 +26,7 @@
   position: relative;
   overflow: hidden;
   border-color: rgba(var(--netscli-hairline-rgb), 0.2);
-  background: #20242b !important;
+  background: var(--netscli-panel-bg) !important;
   box-shadow:
     0 1px 0 rgba(var(--netscli-lift-rgb), 0.025) inset,
     0 12px 28px rgba(0, 0, 0, 0.2);
@@ -43,7 +43,7 @@
 }
 
 .sl-markdown-content .expressive-code pre {
-  background: #20242b !important;
+  background: var(--netscli-panel-bg) !important;
 }
 
 .sl-markdown-content .expressive-code code {
@@ -140,7 +140,7 @@ html[data-theme='light'] .pagination-links a > svg {
 
 html[data-theme='light'] #starlight__search .pagefind-ui__result-inner,
 html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
-  background: #f6f8fa !important;
+  background: var(--netscli-panel-bg) !important;
   border-color: rgba(var(--netscli-hairline-rgb), 0.13);
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.8) inset,
@@ -151,7 +151,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__result-title:not(:wher
 html[data-theme='light'] #starlight__search .pagefind-ui__result-nested,
 html[data-theme='light'] #starlight__search .pagefind-ui__result-tags,
 html[data-theme='light'] .sl-markdown-content .expressive-code pre {
-  background: #f6f8fa !important;
+  background: var(--netscli-panel-bg) !important;
 }html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
   background: rgba(var(--netscli-accent-rgb), 0.42);
 }html[data-theme='light'] .sl-markdown-content :not(pre) > code {

--- a/site/src/styles/starlight/14-docs-nav-table.css
+++ b/site/src/styles/starlight/14-docs-nav-table.css
@@ -89,7 +89,7 @@
     overflow-y: auto !important;
     border-block: 1px solid var(--sl-color-hairline) !important;
     border-inline: 0 !important;
-    background: #1b2028 !important;
+    background: var(--netscli-menu-bg) !important;
     box-shadow: 0 14px 34px rgba(0, 0, 0, 0.26) !important;
   }
 
@@ -184,7 +184,7 @@
 }
 
 html[data-theme='light'] mobile-starlight-toc .dropdown {
-  background: var(--sl-color-black) !important;
+  background: var(--netscli-menu-bg) !important;
   box-shadow: 0 14px 32px rgba(var(--netscli-hairline-rgb), 0.12) !important;
 }
 

--- a/site/src/styles/starlight/17-mobile-shell-closeout-a.css
+++ b/site/src/styles/starlight/17-mobile-shell-closeout-a.css
@@ -136,7 +136,7 @@
     overscroll-behavior: contain;
     padding: 0.8rem clamp(1rem, 3.4vw, 1.75rem) 1rem;
     border-block: 1px solid var(--sl-color-hairline);
-    background: #1b2028;
+    background: var(--netscli-menu-bg);
   }
 
   .docs-mobile-section-menu section + section {

--- a/site/src/styles/starlight/18-mobile-shell-closeout-b.css
+++ b/site/src/styles/starlight/18-mobile-shell-closeout-b.css
@@ -96,7 +96,7 @@
     overscroll-behavior: contain !important;
     border-block: 1px solid var(--sl-color-hairline) !important;
     border-inline: 0 !important;
-    background: #1b2028 !important;
+    background: var(--netscli-menu-bg) !important;
     box-shadow: none !important;
   }
 
@@ -153,7 +153,7 @@
 
 html[data-theme='light'] .docs-mobile-section-menu,
 html[data-theme='light'] mobile-starlight-toc .dropdown {
-  background: #ffffff !important;
+  background: var(--netscli-menu-bg) !important;
 }
 
 html[data-theme='light'] .docs-mobile-section-menu a[aria-current='page'],


### PR DESCRIPTION
Two more surfaces that were written out wherever they were needed rather than named once.

**`--netscli-panel-bg`** — what content sits on: search results and their tag rows, and the frame and body of a code block. Six declarations across three files, `#20242b` dark / `#f6f8fa` light. The two themes already shared selectors, so this is a rename, not a decision.

**`--netscli-menu-bg`** — the floating menu: the mobile section menu and the mobile TOC dropdown, which are the same panel. `#1b2028` dark / white light. Five declarations across three files — one of which already said `var(--sl-color-black)`. Correct, but it reads as "black" at a call site that means "the menu surface", and the two themes then described one surface in different vocabularies.

Both value-preserving: **84 captures identical** after each.

## Not converted, and why an automated pass would get all three wrong

- `#f6f8fa` on the code frame and search dialog is **byte-equal to `--netscli-table-stripe`**, and `#eef2f4` on inline code is byte-equal to `--netscli-table-head`. Same value, different role.
- `starlight-theme-select option` keeps its literals. The comment above that rule says opaque per-theme values are the only ones that take there — a browser limitation on styling `<option>` — and a `var()` is precisely the indirection it warns about.

**The exact-match substitution that cleared 38 literals in #299 is now unsafe for what remains, and I've retired it.** The rest of this tail is per-role and by hand.

## Gates

contrast 124 pairs ≥ 4.5:1 · dead CSS 24/24 · `astro check` clean · axe 0 violations, 14 pages, both themes

**Literal colour uses: 61 → 51.**