### PR TITLE
Delete ten declarations that could never take effect, and tighten the budget

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -12,7 +12,7 @@
     "preview": "astro preview",
     "check": "astro check",
     "check:changelog": "node ./scripts/changelog-dates.mjs",
-    "check:css": "node ./scripts/css-shadowing.mjs --max 24",
+    "check:css": "node ./scripts/css-shadowing.mjs --max 14",
     "test:a11y": "npm run build && node ./scripts/a11y.mjs",
     "visual:record": "node ./scripts/visual-snapshot.mjs record",
     "visual:check": "node ./scripts/visual-snapshot.mjs check"

--- a/site/src/styles/starlight/12-docs-toc-responsive.css
+++ b/site/src/styles/starlight/12-docs-toc-responsive.css
@@ -8,7 +8,7 @@
 
 
 
-    overflow: visible !important;
+
     border: 0 !important;
   }
 
@@ -37,7 +37,7 @@
 
 
 
-    color: var(--sl-color-gray-1) !important;
+
     font-weight: 720 !important;
   }mobile-starlight-toc .caret {
     color: var(--netscli-accent);

--- a/site/src/styles/starlight/14-docs-nav-table.css
+++ b/site/src/styles/starlight/14-docs-nav-table.css
@@ -17,7 +17,7 @@
 
 
 
-    background: var(--sl-color-bg);
+
     border-bottom: 1px solid var(--sl-color-hairline) !important;
   }
 
@@ -33,7 +33,7 @@
 
 
 
-    overflow: visible !important;
+
     border: 0 !important;
   }
 

--- a/site/src/styles/starlight/17-mobile-shell-closeout-a.css
+++ b/site/src/styles/starlight/17-mobile-shell-closeout-a.css
@@ -25,7 +25,7 @@
 
 
 
-    min-width: 2.5rem !important;
+
     margin-left: auto !important;
   }
 

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -57,7 +57,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 
 
 
-  border-inline-start: 1px solid transparent !important;
+
   background-clip: border-box !important;
 }
 

--- a/site/src/styles/starlight/25-mobile-overrides-final.css
+++ b/site/src/styles/starlight/25-mobile-overrides-final.css
@@ -24,20 +24,7 @@
        header. `clip` contains the same horizontal overflow without creating a
        scroll container. */
     overflow-x: clip !important;
-  }
-
-  .main-pane,
-  .content-panel,
-  .content-panel > .sl-container,
-  .sl-markdown-content {
-
-
-
-
-    overflow-wrap: anywhere;
-  }
-
-  .main-pane .content-panel > div.sl-container,
+  }.main-pane .content-panel > div.sl-container,
   .main-pane main .content-panel > div.sl-container {
     width: calc(100vw - 2rem) !important;
     max-width: calc(100vw - 2rem) !important;
@@ -51,18 +38,8 @@
     width: 100% !important;
 
     min-width: 0 !important;
-  }starlight-menu-button {
-
-
-
-
-    z-index: calc(var(--sl-z-index-navbar) + 2) !important;
   }.docs-header-search {
 
-
-
-
-    width: 2.5rem !important;
     max-width: 2.5rem !important;
     min-width: 2.5rem !important;
   }
@@ -70,18 +47,12 @@
   .sl-markdown-content .netscli-table-scroll,
   .content-panel .netscli-table-scroll {
 
-
-
-
-    overflow-y: hidden !important;
     -webkit-overflow-scrolling: touch !important;
   }
 
   .sl-markdown-content .netscli-table-scroll table,
   .content-panel .netscli-table-scroll table {
     display: table !important;
-
-
 
     table-layout: fixed !important;
   }


### PR DESCRIPTION
First step into the layout half of the override audit, and the cheapest one.

`css-prune.mjs` already existed to remove what `css-shadowing.mjs` proves is unreachable — but it hadn't been run since the budget was set, so 24 removable declarations were just sitting there. **Ten come out**, mostly from `25-mobile-overrides-final.css`, which loses 30 lines and two now-empty rules.

**Budget drops 24 → 14** so it can't silently refill.

## The other 14

Reported by the analysis, but the pruner can't locate the rule containing them — it matches on declaration text, and these sit in rules it can't pin down unambiguously. They're left in place and **named in the output** rather than skipped quietly. Removing them means teaching the pruner to find them, not relaxing anything.

## Verified, not assumed

Each removed declaration shares a media context and selector with a later one of equal-or-greater importance, so the later already won on every element the earlier could match — behaviour-preserving *by construction*.

But "by construction" is a claim about the analysis, and the analysis could be wrong, so I checked. **Three visual runs: two reported all 84 captures identical; one reported a single capture differing, which did not reproduce.** That's the harness's known residual noise rather than a regression — a real regression is deterministic, as every earlier change in this audit has been.

## Gates

contrast 124 pairs ≥ 4.5:1 · `astro check` clean · axe 0 violations, 14 pages, both themes