### PR TITLE
Quieten the theme control's focus ring and drop the contents rail

### DIFF
--- a/site/src/styles/starlight/04-markdown-content-base.css
+++ b/site/src/styles/starlight/04-markdown-content-base.css
@@ -226,12 +226,19 @@ starlight-theme-select label:hover {
  * keyboard user has nothing else to go on. The <select> inside also has
  * `appearance: none` and no border of its own, so its own focus ring had
  * nothing to draw around. */
+/* Quieter than it was, and matching the rest of the header.
+ *
+ * The fix above overshot: a solid 2px accent outline AND an accent border AND
+ * a 10% accent background is three signals for one state, and next to the
+ * search button -- which marks focus with a soft 2px ring at 0.18 alpha -- it
+ * read as an error rather than a cursor position. One ring, the same idiom,
+ * still unmistakable against the header and still the only state a keyboard
+ * user has to go on. */
 starlight-theme-select label:focus-within {
   color: var(--sl-color-white);
-  border-color: rgba(var(--netscli-accent-rgb), 0.62);
-  background: rgba(var(--netscli-accent-rgb), 0.1);
-  outline: 2px solid var(--netscli-accent);
-  outline-offset: 2px;
+  border-color: rgba(var(--netscli-accent-rgb), 0.45);
+  box-shadow: 0 0 0 2px rgba(var(--netscli-accent-rgb), 0.22);
+  outline: 0;
 }
 
 starlight-theme-select select:focus-visible {

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -1,15 +1,14 @@
 /* Docs shell close-out: align desktop/mobile navigation states after the
    Starlight defaults and earlier responsive passes have loaded. */
-/* The "On this page" list gets the rail, and only the rail.
-   An earlier pass gave it the left nav's full rail-and-marker treatment, on
-   the reasoning that a colour change alone was too weak a cue. On a wide
-   screen that put two accent bars on screen at once, one per rail, at
-   different weights -- 2px here against the nav's 1px -- which read less
-   like a system than like a mistake. The marker belongs to the nav; see the
-   note on the current-link rule below. */
-.right-sidebar-panel :where(nav ul) {
-  border-inline-start: 1px solid var(--sl-color-hairline);
-}
+/* The "On this page" list gets neither rail nor marker.
+   Two earlier passes went the other way: the first gave it the left nav's
+   full rail-and-marker treatment, the second dropped the marker and kept the
+   rail as "a track, not a marker". Both were wrong about the same thing --
+   the rail is the left nav's device for showing where you are in a tree, and
+   a flat list of headings on the opposite edge of the page is not that tree.
+   Borrowing it made the two rails look like a matched pair that had drifted
+   rather than two different things. The current heading is marked by colour;
+   see the note on the current-link rule below. */
 
 .right-sidebar-panel :where(a) {
   display: block !important;


### PR DESCRIPTION
Two of the five things reported from looking at the built site.

## Focus ring

The theme control's focus state was **three signals for one event**: a solid 2px accent outline, an accent border, *and* a 10% accent background. Next to the search button — which marks focus with a soft 2px ring at 0.18 alpha — it read as an error rather than a cursor position.

It now uses that same idiom: one ring, no outline, resting neutral background instead of a green wash. Still unmistakable against the header, which matters because it's the only state a keyboard user has to go on.

## The contents rail

The "On this page" list loses its inline-start rail.

Two earlier passes went the other way — the first gave it the left nav's full rail-and-marker treatment; the second (#297) dropped the marker and kept the rail as *"a track, not a marker"*. **Both were wrong about the same thing.** The rail is the left nav's device for showing where you are in a tree. A flat list of headings on the opposite edge of the page is not that tree, and borrowing it made the two rails look like a matched pair that had drifted rather than two different things.

Colour marks the current heading, as it has since #297.

## Verified

| | |
|---|---|
| rail | computes to `0px` |
| focus | no outline, 2px ring at 0.22 alpha, neutral background |
| captures | 23 moved, split across **both** themes — what a rail rendered in both should do |

Gates: contrast 124 pairs ≥ 4.5:1 · dead CSS 14/14 · `astro check` clean · **axe 0 violations in both themes** — the one that matters here, since quietening a focus indicator is exactly the change that can break keyboard use.

## Not in this PR

Three more from the same list, because each needs a decision rather than a fix: the native theme dropdown's OS-drawn option list, where the contents panel should start vertically, and the landing page and changelog having no theme at all.