### PR TITLE
Move the shared role tokens where both halves of the site can read them

### DIFF
--- a/site/src/components/Faq.astro
+++ b/site/src/components/Faq.astro
@@ -57,12 +57,12 @@ const faqGroups = grouped.sort(
   text-transform:uppercase;
 }
 .faq details{
-  background:rgba(255,255,255,.025);
-  border:1px solid rgba(255,255,255,.08);
+  background:rgba(var(--netscli-lift-rgb),.025);
+  border:1px solid rgba(var(--netscli-lift-rgb),.08);
   border-radius:10px;padding:14px 18px;
   transition:background 150ms,border-color 150ms;
 }
-.faq details[open]{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.14)}
+.faq details[open]{background:rgba(var(--netscli-lift-rgb),.04);border-color:rgba(var(--netscli-lift-rgb),.14)}
 .faq summary{
   cursor:pointer;font-size:.9375rem;font-weight:600;color:#e5e5e5;
   list-style:none;display:flex;align-items:center;gap:10px;
@@ -103,9 +103,9 @@ const faqGroups = grouped.sort(
   align-items:center;
   min-height:40px;
   padding:8px 48px 8px 12px;
-  border:1px solid rgba(255,255,255,.07);
+  border:1px solid rgba(var(--netscli-lift-rgb),.07);
   border-radius:5px;
-  background:rgba(255,255,255,.045);
+  background:rgba(var(--netscli-lift-rgb),.045);
   color:#d8dee8;
   white-space:pre;
   overflow-x:auto;

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -27,7 +27,7 @@ const { meta, hero, builtWith } = site;
 
 <style is:global>
 footer{
-  border-top:1px solid rgba(255,255,255,.06);padding:0;
+  border-top:1px solid rgba(var(--netscli-lift-rgb),.06);padding:0;
 }
 .footer-inner{
   max-width:1060px;margin:0 auto;padding:28px 24px;

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -306,7 +306,7 @@ const { hero, social } = site;
   width:min(260px,calc(100vw - 48px));min-width:0;box-sizing:border-box;
   /* See the wrapped-layout rule below, which widens this to the trigger. */
   padding:5px;border-radius:8px;
-  background:#181b20;border:1px solid rgba(255,255,255,.12);
+  background:#181b20;border:1px solid rgba(var(--netscli-lift-rgb),.12);
   box-shadow:0 18px 40px rgba(0,0,0,.42);
 }
 .hero-desktop-menu a{
@@ -377,7 +377,7 @@ const { hero, social } = site;
   position:relative;display:grid;grid-template-columns:minmax(0,1fr);
   align-items:center;gap:10px;min-height:36px;
   padding:8px 58px 8px 14px;border-radius:9px;
-  background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.1);
+  background:rgba(var(--netscli-lift-rgb),.04);border:1px solid rgba(var(--netscli-lift-rgb),.1);
   box-shadow:0 0 0 1px rgba(var(--netscli-accent-rgb),.26),0 0 14px rgba(var(--netscli-accent-rgb),.08);
 }
 .hero-command.hero-copy .copy-btn{opacity:1}
@@ -477,7 +477,7 @@ const { hero, social } = site;
 .bigshot{
   margin:48px auto 78px;max-width:980px;
   border-radius:10px;overflow:hidden;
-  border:1px solid rgba(255,255,255,.08);
+  border:1px solid rgba(var(--netscli-lift-rgb),.08);
   box-shadow:0 32px 80px rgba(0,0,0,.6);
 }
 .bigshot img{width:100%;height:auto;display:block}

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -111,16 +111,16 @@ const groups = [
 .install-label{font-size:.8125rem;font-weight:600;color:#e5e5e5;margin:0 0 6px}
 .install-hint{font-size:.6875rem;color:#8a8a8a;margin:4px 0 0}
 .cmd{
-  background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);
+  background:rgba(var(--netscli-lift-rgb),.04);border:1px solid rgba(var(--netscli-lift-rgb),.08);
   border-radius:8px;padding:12px 16px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:clamp(.6875rem,1.4vw,.8125rem);
   overflow-x:auto;white-space:pre;color:#ccc;
-  scrollbar-width:thin;scrollbar-color:rgba(255,255,255,.15) transparent;
+  scrollbar-width:thin;scrollbar-color:rgba(var(--netscli-lift-rgb),.15) transparent;
   position:relative;
 }
 .tryblock{
-  background:#0b0d0e;border:1px solid rgba(255,255,255,.08);
+  background:#0b0d0e;border:1px solid rgba(var(--netscli-lift-rgb),.08);
   border-radius:10px;padding:16px 20px;height:100%;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:clamp(.6875rem,1.4vw,.8125rem);
@@ -212,9 +212,9 @@ a.install-download{
   color:#ccc;
   text-decoration:none;
   padding:8px 14px;
-  border:1px solid rgba(255,255,255,.08);
+  border:1px solid rgba(var(--netscli-lift-rgb),.08);
   border-radius:7px;
-  background:rgba(255,255,255,.04);
+  background:rgba(var(--netscli-lift-rgb),.04);
   transition:background 140ms ease,border-color 140ms ease,color 140ms ease;
 }
 a.install-download:hover,
@@ -230,7 +230,7 @@ a.install-download:focus-visible{
 /* Try it sidebar — one row per command, each row gets .has-copy so the
    existing copy-button JS auto-attaches a button. */
 .try{
-  background:#0a0a0a;border:1px solid rgba(255,255,255,.08);border-radius:10px;
+  background:#0a0a0a;border:1px solid rgba(var(--netscli-lift-rgb),.08);border-radius:10px;
   padding:18px;
 }
 .try .try-title{margin:0 0 12px}
@@ -256,7 +256,7 @@ a.install-download:focus-visible{
 }
 .has-copy.always-show .copy-btn:hover{
   background:#2a2d32;
-  border-color:rgba(255,255,255,.18);
+  border-color:rgba(var(--netscli-lift-rgb),.18);
   color:rgba(255,255,255,.58);
 }
 

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -73,7 +73,7 @@ nav[data-site-nav]{
      border renders as 0.8 at this device pixel ratio. */
   min-height:var(--netscli-nav-height);
   background:rgba(17,17,17,.85);backdrop-filter:blur(12px);
-  border-bottom:1px solid rgba(255,255,255,.06);
+  border-bottom:1px solid rgba(var(--netscli-lift-rgb),.06);
   box-shadow:none;
   transition:box-shadow 160ms ease,border-color 160ms ease;
 }
@@ -141,10 +141,10 @@ body.nav-scrolled nav[data-site-nav]::after{
   justify-content:center;
   flex-direction:column;
   gap:4px;
-  border:1px solid rgba(255,255,255,.1);
+  border:1px solid rgba(var(--netscli-lift-rgb),.1);
   border-radius:7px;
   color:#d7d7d7;
-  background:rgba(255,255,255,.035);
+  background:rgba(var(--netscli-lift-rgb),.035);
   cursor:pointer;
 }
 .nav-menu-toggle span{
@@ -229,7 +229,7 @@ body.nav-scrolled nav[data-site-nav]::after{
     gap:2px;
     padding:8px;
     background:rgba(22,24,26,.98);
-    border:1px solid rgba(255,255,255,.1);
+    border:1px solid rgba(var(--netscli-lift-rgb),.1);
     border-radius:8px;
     box-shadow:0 14px 34px rgba(0,0,0,.36);
     backdrop-filter:blur(12px);

--- a/site/src/components/Surfaces.astro
+++ b/site/src/components/Surfaces.astro
@@ -58,7 +58,7 @@ const { surfaces, copy } = site;
 /* ─── SURFACE CARDS ─── */
 .surfaces-section{
   background:#141718;
-  border-block:1px solid rgba(255,255,255,.045);
+  border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
 }
 .surfaces-section::before{
   content:none;
@@ -92,7 +92,7 @@ const { surfaces, copy } = site;
 .surface-visual img{
   display:block;
   width:100%;height:auto;border-radius:10px;
-  border:1px solid rgba(255,255,255,.08);
+  border:1px solid rgba(var(--netscli-lift-rgb),.08);
   box-shadow:0 12px 40px rgba(0,0,0,.4);
 }
 .surface-visual img:focus-visible,
@@ -101,7 +101,7 @@ const { surfaces, copy } = site;
   outline-offset:3px;
 }
 .surface-visual .codeblock{
-  background:#0b0d0e;border:1px solid rgba(255,255,255,.08);
+  background:#0b0d0e;border:1px solid rgba(var(--netscli-lift-rgb),.08);
   border-radius:10px;padding:16px 58px 16px 20px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:.75rem;line-height:1.7;white-space:pre;overflow-x:auto;color:#ccc;

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -96,7 +96,7 @@ import Footer from '../components/Footer.astro';
   border-radius:7px;
   color:#e5e5e5;
   text-decoration:none;
-  background:rgba(255,255,255,.025);
+  background:rgba(var(--netscli-lift-rgb),.025);
   font-weight:700;
 }
 .not-found-actions a.primary{

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -123,7 +123,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   max-width:var(--netscli-shell-width);margin:0 auto;padding:64px var(--netscli-shell-gutter) 86px;
 }
 .changelog-hero{
-  border-bottom:1px solid rgba(255,255,255,.08);
+  border-bottom:1px solid rgba(var(--netscli-lift-rgb),.08);
   padding-bottom:28px;margin-bottom:28px;
 }
 .changelog-kicker{
@@ -176,7 +176,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   position:sticky;
   top:calc(var(--nav-height, 72px) + 22px);
   padding-left:18px;
-  border-left:1px solid rgba(255,255,255,.08);
+  border-left:1px solid rgba(var(--netscli-lift-rgb),.08);
 }
 .release-timeline p{
   margin:0 0 11px;
@@ -244,8 +244,8 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   font-size:.78rem;
 }
 .release-item{
-  background:rgba(255,255,255,.028);
-  border:1px solid rgba(255,255,255,.085);
+  background:rgba(var(--netscli-lift-rgb),.028);
+  border:1px solid rgba(var(--netscli-lift-rgb),.085);
   border-radius:8px;overflow:hidden;
   max-width:100%;
   min-width:0;
@@ -254,8 +254,8 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
 }
 .release-head{
   display:flex;align-items:center;justify-content:space-between;gap:16px;
-  padding:10px 20px;border-bottom:1px solid rgba(255,255,255,.07);
-  background:rgba(255,255,255,.018);
+  padding:10px 20px;border-bottom:1px solid rgba(var(--netscli-lift-rgb),.07);
+  background:rgba(var(--netscli-lift-rgb),.018);
 }
 .release-title-group{min-width:0}
 .release-item h2{margin:0;font-size:1.08rem;color:#f0f0f0;line-height:1.35;min-width:0;overflow-wrap:anywhere}
@@ -356,8 +356,8 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   padding:8px 12px;background:rgba(var(--netscli-accent-rgb),.065);color:#b8c0cd;
 }
 .release-empty{
-  color:#8f98a8;background:rgba(255,255,255,.03);
-  border:1px dashed rgba(255,255,255,.12);border-radius:10px;padding:16px;
+  color:#8f98a8;background:rgba(var(--netscli-lift-rgb),.03);
+  border:1px dashed rgba(var(--netscli-lift-rgb),.12);border-radius:10px;padding:16px;
 }
 .release-disclosure{
   display:flex;justify-content:center;

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -9,7 +9,7 @@ html{
 }
 *{
   scrollbar-width:thin;
-  scrollbar-color:rgba(140,149,166,.42) rgba(255,255,255,.035);
+  scrollbar-color:rgba(140,149,166,.42) rgba(var(--netscli-lift-rgb),.035);
 }
 ::-webkit-scrollbar{width:12px;height:12px}
 ::-webkit-scrollbar-track{background:#151515}
@@ -77,7 +77,7 @@ body.not-found-page .not-found{
 a{color:inherit}
 code{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.85em;
-  background:rgba(255,255,255,.07);padding:2px 6px;border-radius:4px;color:var(--netscli-accent-bright);
+  background:rgba(var(--netscli-lift-rgb),.07);padding:2px 6px;border-radius:4px;color:var(--netscli-accent-bright);
 }
 
 /* layout */
@@ -91,7 +91,7 @@ code{
 }
 .btn-w{background:#e5e5e5;color:#111;border:1px solid #e5e5e5}
 .btn-w:hover{background:#fff;border-color:#fff}
-.btn-o{background:transparent;color:#999;border:1px solid rgba(255,255,255,.15)}
+.btn-o{background:transparent;color:#999;border:1px solid rgba(var(--netscli-lift-rgb),.15)}
 .btn-o:hover{color:#e5e5e5;border-color:rgba(255,255,255,.3);text-decoration:none}
 .gh-icon{width:16px;height:16px;fill:currentColor;flex-shrink:0}
 
@@ -104,9 +104,9 @@ section{
 }
 section:nth-of-type(even){
   background:
-    linear-gradient(180deg,rgba(255,255,255,.018),rgba(255,255,255,.006)),
+    linear-gradient(180deg,rgba(var(--netscli-lift-rgb),.018),rgba(var(--netscli-lift-rgb),.006)),
     #151515;
-  border-block:1px solid rgba(255,255,255,.045);
+  border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
 }
 section:nth-of-type(even)::before{
   content:"";
@@ -127,7 +127,7 @@ section .lead a:hover{color:var(--netscli-accent-bright)}
 .copy-btn{
   position:absolute;top:50%;right:5px;transform:translateY(-50%);
   /* Opaque background so text behind the button isn't visible through it */
-  background:#222;border:1px solid rgba(255,255,255,.12);
+  background:#222;border:1px solid rgba(var(--netscli-lift-rgb),.12);
   border-radius:6px;color:rgba(255,255,255,.34);
   width:27px;height:27px;padding:0;
   display:inline-flex;align-items:center;justify-content:center;
@@ -138,7 +138,7 @@ section .lead a:hover{color:var(--netscli-accent-bright)}
 .has-copy:hover .copy-btn,.has-copy:focus-within .copy-btn{opacity:1}
 .faq-command:hover .copy-btn,.faq-command:focus-within .copy-btn{opacity:1}
 .faq-command .copy-btn{right:10px}
-.copy-btn:hover{background:#2a2d32;border-color:rgba(255,255,255,.18);color:rgba(255,255,255,.58)}
+.copy-btn:hover{background:#2a2d32;border-color:rgba(var(--netscli-lift-rgb),.18);color:rgba(255,255,255,.58)}
 .copy-btn.copied{color:#3fb950;border-color:rgba(63,185,80,.4)}
 .surface-visual .codeblock .copy-btn,
 .tryblock .copy-btn{

--- a/site/src/styles/lightbox.css
+++ b/site/src/styles/lightbox.css
@@ -44,7 +44,7 @@ body.lightbox-open{overflow:hidden}
 }
 .image-lightbox-frame{
   min-height:0; /* lets the image shrink inside the flex column */
-  border:1px solid rgba(255,255,255,.14);
+  border:1px solid rgba(var(--netscli-lift-rgb),.14);
   border-radius:10px;
   background:#0d0d0d;
   overflow:hidden;
@@ -84,7 +84,7 @@ body.lightbox-open{overflow:hidden}
   height:36px;
   display:grid;
   place-items:center;
-  border:1px solid rgba(255,255,255,.18);
+  border:1px solid rgba(var(--netscli-lift-rgb),.18);
   border-radius:999px;
   background:#1b1b1b;
   color:#fff;

--- a/site/src/styles/starlight/00-theme-tokens.css
+++ b/site/src/styles/starlight/00-theme-tokens.css
@@ -41,16 +41,9 @@ html[data-theme='dark'] ::backdrop {
   --netscli-table-stripe: #242932;
   --netscli-table-head: #252b36;
 
-  /* The neutral this theme draws hairlines, dividers and low-alpha washes
-     from, as channels for the rgba() call sites. Same channels as
-     --sl-color-gray-3 above; declared separately because rgba() needs the
-     numbers, not the colour. */
-  --netscli-hairline-rgb: 140, 149, 166;
-
-  /* The direction "raised" points in this theme. On a dark surface a lift is
-     a white wash; see the light block for why this needs to be a token rather
-     than a literal. */
-  --netscli-lift-rgb: 255, 255, 255;
+  /* --netscli-hairline-rgb and --netscli-lift-rgb are declared in
+     styles/tokens.css, which both this stack and the landing page load. They
+     were here first, and moved when the landing page needed them too. */
 
   /* The raised panel that content sits on: search results and their tag
      rows, and the frame and body of a code block. One surface, written out
@@ -100,31 +93,10 @@ html[data-theme='light'] ::backdrop {
   --netscli-table-stripe: #f6f8fa;
   --netscli-table-head: #eef2f4;
 
-  /* The light theme's own accent, as channels, for the rgba() call sites.
-   *
-   * tokens.css declares --netscli-accent-rgb once under :root, as the DARK
-   * accent, because the landing page is not themed. The docs are, and without
-   * this override every `rgba(var(--netscli-accent-rgb), a)` wash rendered the
-   * dark theme's #22c55e on a light page -- 33 of them. Someone hand-patched
-   * 21 spots with a literal teal at 0/122/84, which matched neither this
-   * theme's accent nor the dark one, leaving the light theme carrying three
-   * greens.
-   *
-   * Matches --sl-color-accent (#146b2e) above, so text, borders and washes
-   * are now one colour at different alphas. */
-  --netscli-accent-rgb: 20, 107, 46;
+  /* --netscli-accent-rgb, --netscli-hairline-rgb and --netscli-lift-rgb
+     for this theme are declared in styles/tokens.css. */
 
-  /* The light theme's neutral for hairlines and washes: its own ink, #111827,
-     which is --sl-color-white here because Starlight inverts that name in the
-     light theme. 33 rules already wrote these channels out by hand. */
-  --netscli-hairline-rgb: 17, 24, 39;
 
-  /* On a light surface, raised is DARKER, not lighter. 26 hover and inset
-     highlight rules wrote rgba(255, 255, 255, a) with no theme scope, at
-     alphas between 0.015 and 0.1 -- white on a near-white page, which is
-     nothing at all. Those hover states have been invisible in this theme.
-     Same alphas, opposite direction. */
-  --netscli-lift-rgb: 17, 24, 39;
 
   /* Light counterpart of the raised panel; see the dark block above. */
   --netscli-panel-bg: #f6f8fa;

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -57,4 +57,35 @@
   --netscli-accent-bright: #86efac;
   /* Pale tint for active text on dark surfaces. */
   --netscli-accent-high: #a7f3c6;
+
+  /* ---- Cross-stack role channels -------------------------------------
+   *
+   * These moved up from starlight/00-theme-tokens.css, which only the docs
+   * load. The landing page and the changelog need the same three roles to be
+   * themeable at all, and a second copy of them under different names is how
+   * the two halves of this site drifted apart in the first place.
+   *
+   * Declared here as the DARK values because that is what an unthemed page
+   * gets; the light block below overrides all three.
+   *
+   * Channels rather than colours because every call site is an rgba() with
+   * its own alpha. */
+
+  /* Hairlines, dividers, and the neutral washes drawn from them. */
+  --netscli-hairline-rgb: 140, 149, 166;
+  /* The direction "raised" points: white on a dark surface. */
+  --netscli-lift-rgb: 255, 255, 255;
+}
+
+/* The light theme's overrides of the three roles above.
+ *
+ * Set here rather than in the docs' own token file so the landing page and
+ * changelog resolve them too. Values match the docs light theme exactly, so
+ * the two stacks cannot disagree about what "light" means. */
+html[data-theme='light'] {
+  --netscli-accent-rgb: 20, 107, 46;
+  --netscli-hairline-rgb: 17, 24, 39;
+  /* On a light surface, raised is DARKER. See the note in the docs' token
+     file for the 27 rules that had this backwards. */
+  --netscli-lift-rgb: 17, 24, 39;
 }


### PR DESCRIPTION
Groundwork for theming the landing page — a prerequisite rather than a choice.

`--netscli-hairline-rgb`, `--netscli-lift-rgb` and the light theme's `--netscli-accent-rgb` were declared in `starlight/00-theme-tokens.css`, **which only the docs load**. The landing page and changelog can't see them, so they can't be themed at all.

They now live in `styles/tokens.css` — the one file both stacks already read (`Page.astro` imports it; `astro.config` registers it). Dark values under `:root`, since that's what an unthemed page gets, and an `html[data-theme='light']` block overriding all three. The docs' own file keeps its Starlight `--sl-color-*` mappings and docs-specific surfaces, with pointers where the three used to be.

Then the first conversion on the landing side: **45 white washes across ten files** become `rgba(var(--netscli-lift-rgb), α)`. Same fix the docs got in #303, and the same reason — a white wash at 4% over a light page is nothing, so every one of these is a hover or an edge that would be invisible the moment a light theme exists.

Both steps **dark-identical**: 84 captures match after each.

## What this does not do

**It does not give the landing page a light theme.** That page has **117 distinct colours**, including nine greys for body text, and none of the structural ones — background, text, surfaces — are tokenised yet. Setting `data-theme='light'` on it today still changes nothing but the scrollbars.

This is the first of several steps, and the light palette isn't usable until the rest land. Flagging that clearly so this PR isn't mistaken for the feature.

## Gates

contrast 124 pairs ≥ 4.5:1 · dead CSS 14/14 · `astro check` clean · axe 0 violations, both themes