### PR TITLE
Collapse forty text colours into a ramp of three

### DIFF
--- a/scripts/design-tokens.mjs
+++ b/scripts/design-tokens.mjs
@@ -74,7 +74,21 @@ const TARGETS = [
     // Starlight inverts its own naming in the light theme -- `--sl-color-white`
     // is #111827 there -- so white/gray-1..3 are the text ramp in both themes
     // and black/bg/gray-6 are the surfaces in both.
-    foregrounds: ['sl-color-white', 'sl-color-gray-1', 'sl-color-gray-2', 'sl-color-gray-3', 'sl-color-accent'],
+    // netscli-text-* are the landing page's ramp and share values with the
+    // sl-color-* entries beside them. Listed anyway: they are what the landing
+    // stack actually names, and a future change to one of them has to be
+    // checked here rather than rely on a reader noticing the values match.
+    // Their absence let a fourth, dimmer step ship to axe at 3.04:1.
+    foregrounds: [
+      'sl-color-white',
+      'sl-color-gray-1',
+      'sl-color-gray-2',
+      'sl-color-gray-3',
+      'sl-color-accent',
+      'netscli-text-strong',
+      'netscli-text',
+      'netscli-text-muted',
+    ],
     surfaces: ['sl-color-bg', 'sl-color-bg-sidebar', 'sl-color-black', 'sl-color-gray-6'],
     keys: {
       dark: { 'surface-base': 'sl-color-bg', 'text-main': 'sl-color-gray-2', 'text-muted': 'sl-color-gray-3', 'text-strong': 'sl-color-white', accent: 'sl-color-accent' },

--- a/site/src/components/Faq.astro
+++ b/site/src/components/Faq.astro
@@ -50,7 +50,7 @@ const faqGroups = grouped.sort(
 .faq-section{display:grid;gap:8px}
 .faq-section-title{
   margin:0 0 2px;
-  color:#8b95a8;
+  color:var(--netscli-text-muted);
   font-size:.72rem;
   font-weight:600;
   letter-spacing:.08em;
@@ -64,7 +64,7 @@ const faqGroups = grouped.sort(
 }
 .faq details[open]{background:rgba(var(--netscli-lift-rgb),.04);border-color:rgba(var(--netscli-lift-rgb),.14)}
 .faq summary{
-  cursor:pointer;font-size:.9375rem;font-weight:600;color:#e5e5e5;
+  cursor:pointer;font-size:.9375rem;font-weight:600;color:var(--netscli-text);
   list-style:none;display:flex;align-items:center;gap:10px;
 }
 .faq summary::-webkit-details-marker{display:none}
@@ -75,7 +75,7 @@ const faqGroups = grouped.sort(
 }
 .faq details[open] summary::before{content:"−"}
 .faq .answer{
-  color:#b0b0b0;font-size:.875rem;line-height:1.65;margin-top:12px;
+  color:var(--netscli-text-muted);font-size:.875rem;line-height:1.65;margin-top:12px;
   padding-left:24px;
   /* Long URLs inside <code> spans don't break by default and force the
      details card wider than the viewport. Allow breaks at any char so
@@ -94,7 +94,7 @@ const faqGroups = grouped.sort(
   position:relative;
 }
 .faq-command span{
-  color:#8b95a8;
+  color:var(--netscli-text-muted);
   font-size:.78rem;
   line-height:1.7;
 }
@@ -106,7 +106,7 @@ const faqGroups = grouped.sort(
   border:1px solid rgba(var(--netscli-lift-rgb),.07);
   border-radius:5px;
   background:rgba(var(--netscli-lift-rgb),.045);
-  color:#d8dee8;
+  color:var(--netscli-text);
   white-space:pre;
   overflow-x:auto;
 }
@@ -118,7 +118,7 @@ const faqGroups = grouped.sort(
   word-break:normal;
 }
 .faq .answer .faq-command code{
-  color:#e8edf4;
+  color:var(--netscli-text);
   white-space:pre;
   overflow-x:auto;
   overflow-wrap:normal;

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -32,9 +32,9 @@ footer{
 .footer-inner{
   max-width:1060px;margin:0 auto;padding:28px 24px;
   display:flex;justify-content:space-between;align-items:center;
-  flex-wrap:wrap;gap:12px;font-size:.75rem;color:#888;
+  flex-wrap:wrap;gap:12px;font-size:.75rem;color:var(--netscli-text-muted);
 }
-footer a{color:#9a9a9a;text-decoration:none}
-footer a:hover{color:#ccc}
+footer a{color:var(--netscli-text-muted);text-decoration:none}
+footer a:hover{color:var(--netscli-text)}
 .flinks{display:flex;gap:16px}
 </style>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -134,19 +134,19 @@ const { hero, social } = site;
 .hero{padding:72px 24px 0;text-align:center}
 .hero .badge{
   display:inline-block;font-size:.6875rem;font-weight:600;
-  letter-spacing:.06em;text-transform:uppercase;color:#9a9a9a;margin-bottom:16px;
+  letter-spacing:.06em;text-transform:uppercase;color:var(--netscli-text-muted);margin-bottom:16px;
 }
 .hero h1{
-  font-size:clamp(1.75rem,4vw,2.75rem);font-weight:700;color:#f5f5f5;
+  font-size:clamp(1.75rem,4vw,2.75rem);font-weight:700;color:var(--netscli-text-strong);
   letter-spacing:-.02em;margin:0 auto;line-height:1.2;
   /* Sized for the current heading, which is 62 characters. At the old 15ch
      -- set when the heading was "A modern network scanner" -- it broke into
      four lines and pushed the install buttons off the first screen. */
   max-width:34ch;
 }
-.hero .sub{font-size:1.0625rem;color:#a3a3a3;max-width:640px;margin:14px auto 0}
+.hero .sub{font-size:1.0625rem;color:var(--netscli-text-muted);max-width:640px;margin:14px auto 0}
 .hero .social-proof{
-  margin:12px auto 0;font-size:.75rem;color:#9a9a9a;
+  margin:12px auto 0;font-size:.75rem;color:var(--netscli-text-muted);
   display:flex;justify-content:center;align-items:center;gap:10px;
   font-variant-numeric:tabular-nums;min-height:1em;
 }
@@ -154,7 +154,7 @@ const { hero, social } = site;
   display:inline-flex;align-items:center;gap:3px;
 }
 .hero .social-proof a{color:inherit;text-decoration:none}
-.hero .social-proof a:hover{color:#e5e5e5}
+.hero .social-proof a:hover{color:var(--netscli-text)}
 .hero .social-proof a[data-total-downloads]{
   position:relative;
   outline-offset:4px;
@@ -174,7 +174,7 @@ const { hero, social } = site;
   border:1px solid rgba(106,240,208,.2);
   border-radius:6px;
   background:#171c23;
-  color:#e5e5e5;
+  color:var(--netscli-text);
   box-shadow:0 12px 28px rgba(0,0,0,.32);
   font-size:.72rem;
   line-height:1.25;
@@ -271,7 +271,7 @@ const { hero, social } = site;
   -webkit-text-fill-color:transparent;
 }
 .hero-primary-menu{
-  border-radius:0;color:#b8c0cd;
+  border-radius:0;color:var(--netscli-text);
   cursor:pointer;font:inherit;padding:0;
 }
 .hero-primary-menu::before{
@@ -300,7 +300,7 @@ const { hero, social } = site;
     linear-gradient(90deg,var(--netscli-accent) 0%,var(--netscli-accent) 62%,#1edcff 100%) border-box;
   box-shadow:0 0 0 1px rgba(var(--netscli-accent-rgb),.16),0 0 12px rgba(var(--netscli-accent-rgb),.08);
 }
-.hero-primary-menu:hover{color:#fff}
+.hero-primary-menu:hover{color:var(--netscli-text-strong)}
 .hero-desktop-menu{
   position:absolute;top:calc(100% + 6px);left:0;z-index:20;
   width:min(260px,calc(100vw - 48px));min-width:0;box-sizing:border-box;
@@ -313,27 +313,27 @@ const { hero, social } = site;
   display:grid;grid-template-columns:16px minmax(0,1fr) auto;
   align-items:center;gap:8px;
   padding:8px 10px;border-radius:6px;text-align:left;
-  color:#d7dce5;text-decoration:none;font-size:.8rem;font-weight:700;
+  color:var(--netscli-text);text-decoration:none;font-size:.8rem;font-weight:700;
 }
 .hero-desktop-menu .platform-mark{
   position:relative;
   width:16px;height:16px;
   display:inline-flex;justify-content:center;align-items:center;
-  flex:none;color:#8793a8;
+  flex:none;color:var(--netscli-text-muted);
 }
 .hero-desktop-menu .installer-copy{
   display:grid;gap:1px;min-width:0;
 }
 .hero-desktop-menu .installer-name{
-  min-width:0;color:#d7dce5;font-weight:720;line-height:1.18;
+  min-width:0;color:var(--netscli-text);font-weight:720;line-height:1.18;
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
 }
 .hero-desktop-menu .installer-meta{
-  min-width:0;color:#8793a8;font-size:.67rem;font-weight:560;line-height:1.15;
+  min-width:0;color:var(--netscli-text-muted);font-size:.67rem;font-weight:560;line-height:1.15;
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
 }
 .hero-desktop-menu .installer-ext{
-  justify-self:end;align-self:center;color:#9da8ba;font-size:.68rem;font-weight:680;
+  justify-self:end;align-self:center;color:var(--netscli-text-muted);font-size:.68rem;font-weight:680;
 }
 .hero-desktop-menu a .platform-mark{font-weight:700}
 .hero-desktop-menu .platform-windows{
@@ -383,24 +383,24 @@ const { hero, social } = site;
 .hero-command.hero-copy .copy-btn{opacity:1}
 .hero-command code{
   min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
-  color:#e8edf4;font-family:ui-monospace,"SF Mono",Menlo,monospace;
+  color:var(--netscli-text);font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:.78rem;background:transparent;border:0;padding:0;
 }
 .hero-install-link{
   justify-self:end;
   display:inline-flex;align-items:center;
-  color:#cfcfcf;text-decoration:none;font-size:.76rem;white-space:nowrap;
+  color:var(--netscli-text);text-decoration:none;font-size:.76rem;white-space:nowrap;
   border-bottom:1px dotted rgba(255,255,255,.22);
   padding-bottom:2px;
 }
-.hero-install-link:hover{color:#fff;border-bottom-color:rgba(255,255,255,.5)}
+.hero-install-link:hover{color:var(--netscli-text-strong);border-bottom-color:rgba(255,255,255,.5)}
 .hero .links{display:flex;gap:16px;justify-content:center;margin-top:14px;flex-wrap:wrap}
 .hero .links a{
-  font-size:.8125rem;color:#a3a3a3;text-decoration:none;
+  font-size:.8125rem;color:var(--netscli-text-muted);text-decoration:none;
   border-bottom:1px dotted rgba(255,255,255,.22);padding-bottom:1px;
   display:inline-flex;align-items:center;gap:4px;
 }
-.hero .links a:hover{color:#e5e5e5;border-bottom-color:rgba(255,255,255,.5)}
+.hero .links a:hover{color:var(--netscli-text);border-bottom-color:rgba(255,255,255,.5)}
 .hero .links a.plain{border-bottom:0}
 .hero .links a.plain:hover{border-bottom:0}
 @media(max-width:900px){

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -108,14 +108,14 @@ const groups = [
 @media(max-width:860px){.install-grid{grid-template-columns:1fr}}
 .install-card{margin-bottom:16px;overflow:hidden}
 .install-card:last-child{margin-bottom:0}
-.install-label{font-size:.8125rem;font-weight:600;color:#e5e5e5;margin:0 0 6px}
-.install-hint{font-size:.6875rem;color:#8a8a8a;margin:4px 0 0}
+.install-label{font-size:.8125rem;font-weight:600;color:var(--netscli-text);margin:0 0 6px}
+.install-hint{font-size:.6875rem;color:var(--netscli-text-muted);margin:4px 0 0}
 .cmd{
   background:rgba(var(--netscli-lift-rgb),.04);border:1px solid rgba(var(--netscli-lift-rgb),.08);
   border-radius:8px;padding:12px 16px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:clamp(.6875rem,1.4vw,.8125rem);
-  overflow-x:auto;white-space:pre;color:#ccc;
+  overflow-x:auto;white-space:pre;color:var(--netscli-text);
   scrollbar-width:thin;scrollbar-color:rgba(var(--netscli-lift-rgb),.15) transparent;
   position:relative;
 }
@@ -124,14 +124,14 @@ const groups = [
   border-radius:10px;padding:16px 20px;height:100%;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:clamp(.6875rem,1.4vw,.8125rem);
-  line-height:1.9;white-space:pre;overflow-x:auto;color:#ccc;
+  line-height:1.9;white-space:pre;overflow-x:auto;color:var(--netscli-text);
   position:relative;
 }
-.tryblock .c{color:#7b7b7b}
+.tryblock .c{color:var(--netscli-text-muted)}
 
 /* ─── TRY BLOCK TITLE ─── */
 .try-title{
-  font-size:.9375rem;font-weight:600;color:#e5e5e5;margin:0 0 8px;
+  font-size:.9375rem;font-weight:600;color:var(--netscli-text);margin:0 0 8px;
 }
 .try-title + .tryblock{margin-top:0}
 
@@ -148,19 +148,19 @@ const groups = [
 .install-content{grid-column:1;grid-row:2}
 .try{grid-column:2;grid-row:2}
 .os-tab{
-  padding:12px 22px;color:#888;font-size:.9rem;cursor:pointer;user-select:none;
+  padding:12px 22px;color:var(--netscli-text-muted);font-size:.9rem;cursor:pointer;user-select:none;
   border:none;background:transparent;font-family:inherit;
   border-bottom:2px solid transparent;margin-bottom:-1px;transition:color .15s;
 }
-.os-tab:hover{color:#ccc}
-.os-tab.active{color:#fafafa;border-bottom-color:var(--netscli-accent);font-weight:500}
+.os-tab:hover{color:var(--netscli-text)}
+.os-tab.active{color:var(--netscli-text-strong);border-bottom-color:var(--netscli-accent);font-weight:500}
 .os-panel{display:none}
 .os-panel.active{display:block}
 .reco{
   background:#0d0d0d;border:1px solid #2a2a2a;border-radius:10px;
   padding:14px 18px;margin-bottom:16px;
 }
-.reco-meta{font-size:.85rem;font-weight:500;color:#e0e0e0;margin-bottom:8px}
+.reco-meta{font-size:.85rem;font-weight:500;color:var(--netscli-text);margin-bottom:8px}
 .cmd.big{font-size:1.05rem;padding-right:74px}
 .alts{
   display:flex;flex-direction:column;gap:1px;
@@ -171,19 +171,19 @@ const groups = [
   padding:11px 16px;background:#0c0c0c;transition:background .15s;position:relative;
 }
 .alt:hover{background:#0f0f0f}
-.alt-label{font-size:.85rem;color:#bcbcbc}
+.alt-label{font-size:.85rem;color:var(--netscli-text)}
 .alt-cmd{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.82rem;
-  color:#ccc;overflow-wrap:anywhere;word-break:normal;padding-right:50px;
+  color:var(--netscli-text);overflow-wrap:anywhere;word-break:normal;padding-right:50px;
 }
 /* Two groups per OS panel: desktop app, then CLI. */
 .install-group + .install-group{margin-top:26px}
 .install-group-title{
-  font-size:.8125rem;font-weight:600;color:#8a8a8a;margin:0 0 10px;
+  font-size:.8125rem;font-weight:600;color:var(--netscli-text-muted);margin:0 0 10px;
   text-transform:uppercase;letter-spacing:.06em;
 }
-.install-hint{font-size:.7rem;color:#808080;margin:8px 0 0}
-.alt-hint{display:block;font-size:.7rem;color:#7b7b7b;margin-top:2px;line-height:1.35}
+.install-hint{font-size:.7rem;color:var(--netscli-text-muted);margin:8px 0 0}
+.alt-hint{display:block;font-size:.7rem;color:var(--netscli-text-muted);margin-top:2px;line-height:1.35}
 /* Direct-download rows sit in the same column as the commands, but this is
    an action, not something to type.
    It used to be a bare monospace link with `display:block`, so it filled the
@@ -209,7 +209,7 @@ a.install-download{
   font-size:.8125rem;
   font-weight:500;
   line-height:1;
-  color:#ccc;
+  color:var(--netscli-text);
   text-decoration:none;
   padding:8px 14px;
   border:1px solid rgba(var(--netscli-lift-rgb),.08);
@@ -223,7 +223,7 @@ a.install-download:focus-visible{
   border-color:rgba(var(--netscli-accent-rgb),.48);
   background:rgba(var(--netscli-accent-rgb),.10);
 }
-.footer-note{margin-top:14px;font-size:.8125rem;color:#808080}
+.footer-note{margin-top:14px;font-size:.8125rem;color:var(--netscli-text-muted)}
 .footer-note a{color:var(--netscli-accent);text-decoration:underline;text-underline-offset:3px}
 .footer-note a:hover{color:var(--netscli-accent-bright)}
 
@@ -238,14 +238,14 @@ a.install-download:focus-visible{
   display:flex;flex-direction:column;align-items:stretch;gap:3px;
   padding:9px 48px 9px 10px;border-radius:5px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.83rem;
-  color:#bcbcbc;transition:background .15s;position:relative;
+  color:var(--netscli-text);transition:background .15s;position:relative;
 }
 .try-cmd:hover{background:#101010}
 .try-comment{
-  color:#727a8a;font-size:.74rem;line-height:1.35;
+  color:var(--netscli-text-muted);font-size:.74rem;line-height:1.35;
 }
 .try-line{display:flex;align-items:center;gap:8px;min-width:0}
-.try-cmd .p{color:#7a7a7a;user-select:none;flex:none}
+.try-cmd .p{color:var(--netscli-text-muted);user-select:none;flex:none}
 .try-cmd .t{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1}
 
 /* Always-visible Copy variant used where controls should be discoverable
@@ -305,9 +305,9 @@ a.install-download:focus-visible{
 }
 .surface-download-btn .dl-label{font-size:.85rem;line-height:1.2}
 .surface-download-btn .dl-hint{
-  font-size:.7rem;color:#808080;font-weight:400;line-height:1.2;
+  font-size:.7rem;color:var(--netscli-text-muted);font-weight:400;line-height:1.2;
 }
-.surface-download-btn:hover .dl-hint{color:#9a9a9a}
+.surface-download-btn:hover .dl-hint{color:var(--netscli-text-muted)}
 
 /* Narrow screens: truncate long commands, do not scroll them sideways.
  *

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -143,7 +143,7 @@ body.nav-scrolled nav[data-site-nav]::after{
   gap:4px;
   border:1px solid rgba(var(--netscli-lift-rgb),.1);
   border-radius:7px;
-  color:#d7d7d7;
+  color:var(--netscli-text);
   background:rgba(var(--netscli-lift-rgb),.035);
   cursor:pointer;
 }
@@ -155,13 +155,13 @@ body.nav-scrolled nav[data-site-nav]::after{
 }
 .nav-menu-toggle:hover,
 .nav-menu-toggle:focus-visible{
-  color:#fff;
+  color:var(--netscli-text-strong);
   border-color:rgba(var(--netscli-accent-rgb),.35);
   outline:none;
 }
 .nlinks{display:flex;gap:20px;font-size:.8125rem;flex-wrap:wrap;justify-content:flex-end}
 .nlinks a{
-  color:#b0b0b0;text-decoration:none;
+  color:var(--netscli-text-muted);text-decoration:none;
   display:inline-flex;align-items:center;
   border-bottom:2px solid transparent;
   /* Full bar height, so the underline lands on the bar's bottom edge the way
@@ -172,7 +172,7 @@ body.nav-scrolled nav[data-site-nav]::after{
      border. Minus 1px for the border on <nav>. */
   height:calc(var(--netscli-nav-height) - 1px);
 }
-.nlinks a:hover{color:#e5e5e5}
+.nlinks a:hover{color:var(--netscli-text)}
 /* Both values, because two different things set this attribute here.
    Nav.astro marks a genuine current page with "page"; the scroll spy in
    scripts/site-nav.ts marks the section you are looking at with "location",
@@ -185,7 +185,7 @@ body.nav-scrolled nav[data-site-nav]::after{
    contains it, `location` the scroll-spy section on the landing page --
    all three should look current. */
 .nlinks a[aria-current]{
-  color:#e5e5e5;
+  color:var(--netscli-text);
   border-bottom-color:var(--netscli-accent);
 }
 .external-link{

--- a/site/src/components/Surfaces.astro
+++ b/site/src/components/Surfaces.astro
@@ -82,8 +82,8 @@ const { surfaces, copy } = site;
 .surface.flip{direction:rtl}
 .surface.flip>*{direction:ltr;min-width:0}
 .surface-text{padding-top:0}
-.surface-text h3{font-size:1.125rem;font-weight:700;color:#f5f5f5;margin:0 0 22px}
-.surface-text p{font-size:.875rem;color:#a8a8a8;margin:0;line-height:1.6}
+.surface-text h3{font-size:1.125rem;font-weight:700;color:var(--netscli-text-strong);margin:0 0 22px}
+.surface-text p{font-size:.875rem;color:var(--netscli-text-muted);margin:0;line-height:1.6}
 .surface-text code{font-size:.75rem}
 .surface-visual picture{
   display:block;
@@ -104,7 +104,7 @@ const { surfaces, copy } = site;
   background:#0b0d0e;border:1px solid rgba(var(--netscli-lift-rgb),.08);
   border-radius:10px;padding:16px 58px 16px 20px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
-  font-size:.75rem;line-height:1.7;white-space:pre;overflow-x:auto;color:#ccc;
+  font-size:.75rem;line-height:1.7;white-space:pre;overflow-x:auto;color:var(--netscli-text);
   box-shadow:0 12px 40px rgba(0,0,0,.4);
   position:relative;
 }

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -69,7 +69,7 @@ import Footer from '../components/Footer.astro';
 }
 .not-found h1{
   margin:0;
-  color:#f5f5f5;
+  color:var(--netscli-text-strong);
   font-size:clamp(2.4rem,6vw,5rem);
   line-height:1.05;
   letter-spacing:-.035em;
@@ -77,7 +77,7 @@ import Footer from '../components/Footer.astro';
 .not-found p{
   margin:20px 0 0;
   max-width:43rem;
-  color:#bfc5cf;
+  color:var(--netscli-text);
   font-size:clamp(1rem,1.6vw,1.18rem);
 }
 .not-found-actions{
@@ -94,7 +94,7 @@ import Footer from '../components/Footer.astro';
   padding:9px 17px;
   border:1px solid rgba(var(--netscli-accent-rgb),.35);
   border-radius:7px;
-  color:#e5e5e5;
+  color:var(--netscli-text);
   text-decoration:none;
   background:rgba(var(--netscli-lift-rgb),.025);
   font-weight:700;
@@ -108,7 +108,7 @@ import Footer from '../components/Footer.astro';
 .not-found-actions a:focus-visible{
   outline:0;
   border-color:rgba(30,220,255,.62);
-  color:#fff;
+  color:var(--netscli-text-strong);
 }
 .not-found-actions a.primary:hover,
 .not-found-actions a.primary:focus-visible{

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -131,11 +131,11 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   text-transform:uppercase;letter-spacing:.08em;
 }
 .changelog-hero h1{
-  margin:0;color:#f5f5f5;font-size:clamp(2rem,4vw,3rem);
+  margin:0;color:var(--netscli-text-strong);font-size:clamp(2rem,4vw,3rem);
   line-height:1.1;letter-spacing:-.02em;
 }
 .changelog-hero p{
-  margin:12px 0 0;color:#a3a3a3;font-size:.95rem;max-width:680px;
+  margin:12px 0 0;color:var(--netscli-text-muted);font-size:.95rem;max-width:680px;
 }
 /* A text link, not a button. Two bordered pills sat under the intro as if
    they were the page's primary actions; the only one worth keeping is a
@@ -180,7 +180,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
 }
 .release-timeline p{
   margin:0 0 11px;
-  color:#a3a3a3;
+  color:var(--netscli-text-muted);
   font-size:.72rem;
   font-weight:700;
   letter-spacing:.08em;
@@ -196,7 +196,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   gap:5px;
 }
 .release-timeline-year{
-  color:#f0f0f0;
+  color:var(--netscli-text-strong);
   font-size:.82rem;
   line-height:1.2;
 }
@@ -208,7 +208,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   gap:10px;
   min-height:24px;
   padding:3px 0 3px 10px;
-  color:#8f98a8;
+  color:var(--netscli-text-muted);
   font-size:.78rem;
   line-height:1.2;
   text-decoration:none;
@@ -225,7 +225,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   transform:translateY(-50%);
 }
 .release-timeline-link small{
-  color:#737f91;
+  color:var(--netscli-text-muted);
   font-size:.68rem;
 }
 .release-timeline-link:hover,
@@ -240,7 +240,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   background:var(--netscli-accent);
 }
 .release-timeline-empty{
-  color:#737f91;
+  color:var(--netscli-text-muted);
   font-size:.78rem;
 }
 .release-item{
@@ -258,16 +258,16 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   background:rgba(var(--netscli-lift-rgb),.018);
 }
 .release-title-group{min-width:0}
-.release-item h2{margin:0;font-size:1.08rem;color:#f0f0f0;line-height:1.35;min-width:0;overflow-wrap:anywhere}
+.release-item h2{margin:0;font-size:1.08rem;color:var(--netscli-text-strong);line-height:1.35;min-width:0;overflow-wrap:anywhere}
 .release-item h2 a{color:inherit;text-decoration:none;min-width:0;overflow-wrap:anywhere}
 .release-item h2 a:hover .external-link-label{text-decoration:underline;text-underline-offset:3px}
 .release-meta{
-  flex:0 0 auto;margin:0;color:#9aa8bd;font-size:.76rem;
+  flex:0 0 auto;margin:0;color:var(--netscli-text-muted);font-size:.76rem;
   line-height:1.4;white-space:nowrap;text-align:right;
 }
 .release-body{
   position:relative;
-  padding:20px 20px 22px;color:#b8c0cd;font-size:.9rem;line-height:1.65;
+  padding:20px 20px 22px;color:var(--netscli-text);font-size:.9rem;line-height:1.65;
   width:100%;min-width:0;max-width:100%;box-sizing:border-box;
   overflow-wrap:anywhere;word-break:normal;
 }
@@ -292,7 +292,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
 .release-summary{
   margin:0;
   max-width:none;
-  color:#dbe2ec;
+  color:var(--netscli-text);
   font-size:.94rem;
   line-height:1.65;
   padding:0;
@@ -306,7 +306,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
  * introduces. More space above than below now, which is the relationship a
  * section heading is supposed to have. */
 .release-body .release-heading{
-  color:#e5e5e5;font-size:.96rem;line-height:1.35;
+  color:var(--netscli-text);font-size:.96rem;line-height:1.35;
   margin:26px 0 9px;
 }
 .release-body .release-heading:first-child{margin-top:0}
@@ -331,7 +331,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
 .release-body .release-code{
   position:relative;margin:0;max-width:100%;overflow-x:auto;
   background:#20242b;border:1px solid rgba(140,149,166,.2);
-  border-radius:8px;padding:.82rem 1rem;color:#d7dce5;
+  border-radius:8px;padding:.82rem 1rem;color:var(--netscli-text);
   box-shadow:none;
 }
 .release-body .release-code::before{
@@ -353,10 +353,10 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
 .release-body a:hover .external-link-label{text-decoration-color:var(--netscli-accent-bright)}
 .release-quote{
   margin:0;max-width:none;border-left:3px solid rgba(var(--netscli-accent-rgb),.55);
-  padding:8px 12px;background:rgba(var(--netscli-accent-rgb),.065);color:#b8c0cd;
+  padding:8px 12px;background:rgba(var(--netscli-accent-rgb),.065);color:var(--netscli-text);
 }
 .release-empty{
-  color:#8f98a8;background:rgba(var(--netscli-lift-rgb),.03);
+  color:var(--netscli-text-muted);background:rgba(var(--netscli-lift-rgb),.03);
   border:1px dashed rgba(var(--netscli-lift-rgb),.12);border-radius:10px;padding:16px;
 }
 .release-disclosure{

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -36,7 +36,7 @@ html[data-theme='light'] ::-webkit-scrollbar-corner{background:#f1f5f9}
 body{
   margin:0;
   font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
-  background:#111;color:#d4d4d4;line-height:1.6;
+  background:#111;color:var(--netscli-text);line-height:1.6;
   -webkit-font-smoothing:antialiased;
 }
 .skip-link{
@@ -48,7 +48,7 @@ body{
   border:1px solid #2dd4bf;
   border-radius:6px;
   background:#111;
-  color:#fff;
+  color:var(--netscli-text-strong);
   transform:translateY(calc(-100% - 16px));
   transition:transform .15s ease;
 }
@@ -91,8 +91,8 @@ code{
 }
 .btn-w{background:#e5e5e5;color:#111;border:1px solid #e5e5e5}
 .btn-w:hover{background:#fff;border-color:#fff}
-.btn-o{background:transparent;color:#999;border:1px solid rgba(var(--netscli-lift-rgb),.15)}
-.btn-o:hover{color:#e5e5e5;border-color:rgba(255,255,255,.3);text-decoration:none}
+.btn-o{background:transparent;color:var(--netscli-text-muted);border:1px solid rgba(var(--netscli-lift-rgb),.15)}
+.btn-o:hover{color:var(--netscli-text);border-color:rgba(255,255,255,.3);text-decoration:none}
 .gh-icon{width:16px;height:16px;fill:currentColor;flex-shrink:0}
 
 
@@ -116,8 +116,8 @@ section:nth-of-type(even)::before{
   background:radial-gradient(circle at 18% 0%,rgba(var(--netscli-accent-rgb),.055),transparent 34rem);
 }
 section>.w{position:relative;z-index:1}
-section h2{font-size:1.5rem;font-weight:700;color:#f5f5f5;margin:0 0 6px}
-section .lead{color:#a3a3a3;font-size:.9375rem;margin:0 0 28px}
+section h2{font-size:1.5rem;font-weight:700;color:var(--netscli-text-strong);margin:0 0 6px}
+section .lead{color:var(--netscli-text-muted);font-size:.9375rem;margin:0 0 28px}
 section .lead a{color:var(--netscli-accent);text-decoration:underline;text-underline-offset:3px}
 section .lead a:hover{color:var(--netscli-accent-bright)}
 

--- a/site/src/styles/lightbox.css
+++ b/site/src/styles/lightbox.css
@@ -65,7 +65,7 @@ body.lightbox-open{overflow:hidden}
   font-size:.85rem;
   /* Deliberately not a dim grey: this sits on the overlay's near-black
      backdrop, where the site's muted greys fall under 4.5:1. */
-  color:#e6e6e6;
+  color:var(--netscli-text);
 }
 .image-lightbox-caption:empty{display:none}
 
@@ -87,7 +87,7 @@ body.lightbox-open{overflow:hidden}
   border:1px solid rgba(var(--netscli-lift-rgb),.18);
   border-radius:999px;
   background:#1b1b1b;
-  color:#fff;
+  color:var(--netscli-text-strong);
   font-size:1.25rem;
   line-height:1;
   cursor:pointer;

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -10,7 +10,7 @@
  * global.css, so both stacks read the same declaration.
  *
  * site/design-tokens.json is GENERATED from this file and from
- * starlight/01-tokens-and-header.css -- do not edit it by hand. Run
+ * starlight/00-theme-tokens.css -- do not edit it by hand. Run
  * `node scripts/design-tokens.mjs --write` after changing a colour, and CI
  * fails if the committed copy has drifted from its source. It was
  * hand-maintained until 2026-08-29, on the reasoning that values reached
@@ -75,6 +75,28 @@
   --netscli-hairline-rgb: 140, 149, 166;
   /* The direction "raised" points: white on a dark surface. */
   --netscli-lift-rgb: 255, 255, 255;
+
+  /* ---- Text ramp ------------------------------------------------------
+   *
+   * Three steps, because the landing stack had FORTY distinct `color:` values
+   * across 91 declarations and no way to theme any of them. Most of that was
+   * drift rather than intent -- #e5e5e5 beside #e6e6e6 and #e0e0e0, #ccc
+   * beside #cfcfcf, #888 beside #8a8a8a -- differences no reader can see and
+   * nobody chose.
+   *
+   * The values are the docs' own ramp (--sl-color-white / gray-2 / gray-3),
+   * so the two halves of the site finally describe text the same
+   * way and a re-theme is one edit rather than two. That does move the
+   * landing page's text slightly: collapsing a 40-value ramp onto three
+   * cannot be pixel-preserving, and it was chosen over keeping forty.
+   *
+   * There is no fourth, dimmer step. One was tried, borrowing Starlight's
+   * gray-4, and axe caught it on both themes at 3.04:1 and 3.50:1 against a
+   * 4.5 floor -- gray-4 is a BORDER colour there, and using it for text was
+   * the mistake. The dimmest text this site draws is --netscli-text-muted. */
+  --netscli-text-strong: #f4f4f4;
+  --netscli-text: #c2cad8;
+  --netscli-text-muted: #8c95a6;
 }
 
 /* The light theme's overrides of the three roles above.
@@ -88,4 +110,14 @@ html[data-theme='light'] {
   /* On a light surface, raised is DARKER. See the note in the docs' token
      file for the 27 rules that had this backwards. */
   --netscli-lift-rgb: 17, 24, 39;
+
+  /* The light ramp, again matching the docs. Starlight inverts its own
+     naming here -- --sl-color-white is #111827 in the light theme -- which is
+     why "strong" is the darkest of these rather than the lightest.
+     --sl-color-gray-3 carries a note about not lightening it; the same
+     applies to --netscli-text-muted, which is the same value and is checked
+     against every surface by scripts/design-tokens.mjs. */
+  --netscli-text-strong: #111827;
+  --netscli-text: #44516a;
+  --netscli-text-muted: #647084;
 }


### PR DESCRIPTION
The landing stack drew text in **40 distinct colours across 91 declarations**. Most of it was drift rather than intent — `#e5e5e5` beside `#e6e6e6` and `#e0e0e0`, `#ccc` beside `#cfcfcf`, `#888` beside `#8a8a8a` — differences no reader can see and nobody chose. None of them could be themed.

They're now `--netscli-text-strong` / `--netscli-text` / `--netscli-text-muted`, declared per theme in `tokens.css` which both stacks read. **The values are the docs' own ramp**, so the two halves of the site finally describe text the same way and a re-theme is one edit rather than two.

## What stayed literal, and why

84 of 91 map onto the three. The other seven stay literal and should: two greens (accents, not a text tier) and five labels drawn **on** a bright surface — a dark-theme text token there would make them invisible the moment the surface stayed bright. Excluded by saturation and luminance rather than a hand-kept list.

## This moves pixels, as agreed

Collapsing 40 values onto 3 cannot be pixel-preserving. **16 captures changed**, and I read the landing page end to end afterwards — hierarchy intact, nothing dropped out.

## The mistake worth recording

A fourth, dimmer step was tried first and was **wrong**. It borrowed Starlight's `gray-4`, which is a *border* colour there, and axe caught it on both themes at **3.04:1 and 3.50:1** against a 4.5 floor.

**The contrast gate did not catch it** — its foreground list named only the `sl-color-*` tokens, so my new ones were invisible to it. axe did, one step later.

The three tokens are now in that list, taking checked pairs **124 → 148**, so the next change to one of them is caught by the cheap gate rather than the slow one. Sabotage-checked both ways: the failing value exits 1 and prints 3.04 on every dark surface; the real value exits 0.

## Gates

contrast **148** pairs ≥ 4.5:1 · dead CSS 14/14 · `astro check` clean · axe 0 violations, 14 pages, both themes

## Still not a light theme

The landing page's backgrounds, surfaces and borders are untouched, and `data-theme='light'` on it still does nothing visible. Next step.