### PR TITLE
Give the landing page and the changelog a light theme

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -173,7 +173,7 @@ const { hero, social } = site;
   padding:.42rem .58rem;
   border:1px solid rgba(106,240,208,.2);
   border-radius:6px;
-  background:#171c23;
+  background:var(--netscli-surface);
   color:var(--netscli-text);
   box-shadow:0 12px 28px rgba(0,0,0,.32);
   font-size:.72rem;
@@ -193,7 +193,7 @@ const { hero, social } = site;
   height:.45rem;
   border-right:1px solid rgba(106,240,208,.2);
   border-bottom:1px solid rgba(106,240,208,.2);
-  background:#171c23;
+  background:var(--netscli-surface);
   pointer-events:none;
   opacity:0;
   transform:translate(-50%,.25rem) rotate(45deg);
@@ -306,7 +306,7 @@ const { hero, social } = site;
   width:min(260px,calc(100vw - 48px));min-width:0;box-sizing:border-box;
   /* See the wrapped-layout rule below, which widens this to the trigger. */
   padding:5px;border-radius:8px;
-  background:#181b20;border:1px solid rgba(var(--netscli-lift-rgb),.12);
+  background:var(--netscli-surface);border:1px solid rgba(var(--netscli-lift-rgb),.12);
   box-shadow:0 18px 40px rgba(0,0,0,.42);
 }
 .hero-desktop-menu a{

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -120,7 +120,7 @@ const groups = [
   position:relative;
 }
 .tryblock{
-  background:#0b0d0e;border:1px solid rgba(var(--netscli-lift-rgb),.08);
+  background:var(--netscli-bg);border:1px solid rgba(var(--netscli-lift-rgb),.08);
   border-radius:10px;padding:16px 20px;height:100%;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:clamp(.6875rem,1.4vw,.8125rem);
@@ -143,7 +143,7 @@ const groups = [
 }
 .os-tabs{
   grid-column:1;grid-row:1;display:flex;gap:0;
-  border-bottom:1px solid #222;margin-bottom:20px;
+  border-bottom:1px solid var(--netscli-surface-raised);margin-bottom:20px;
 }
 .install-content{grid-column:1;grid-row:2}
 .try{grid-column:2;grid-row:2}
@@ -157,20 +157,20 @@ const groups = [
 .os-panel{display:none}
 .os-panel.active{display:block}
 .reco{
-  background:#0d0d0d;border:1px solid #2a2a2a;border-radius:10px;
+  background:var(--netscli-bg);border:1px solid var(--netscli-surface-raised);border-radius:10px;
   padding:14px 18px;margin-bottom:16px;
 }
 .reco-meta{font-size:.85rem;font-weight:500;color:var(--netscli-text);margin-bottom:8px}
 .cmd.big{font-size:1.05rem;padding-right:74px}
 .alts{
   display:flex;flex-direction:column;gap:1px;
-  background:#1a1a1a;border:1px solid #1a1a1a;border-radius:8px;overflow:hidden;
+  background:var(--netscli-surface);border:1px solid var(--netscli-surface);border-radius:8px;overflow:hidden;
 }
 .alt{
   display:grid;grid-template-columns:140px 1fr;gap:16px;align-items:center;
-  padding:11px 16px;background:#0c0c0c;transition:background .15s;position:relative;
+  padding:11px 16px;background:var(--netscli-bg);transition:background .15s;position:relative;
 }
-.alt:hover{background:#0f0f0f}
+.alt:hover{background:var(--netscli-bg)}
 .alt-label{font-size:.85rem;color:var(--netscli-text)}
 .alt-cmd{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.82rem;
@@ -230,7 +230,7 @@ a.install-download:focus-visible{
 /* Try it sidebar — one row per command, each row gets .has-copy so the
    existing copy-button JS auto-attaches a button. */
 .try{
-  background:#0a0a0a;border:1px solid rgba(var(--netscli-lift-rgb),.08);border-radius:10px;
+  background:var(--netscli-bg);border:1px solid rgba(var(--netscli-lift-rgb),.08);border-radius:10px;
   padding:18px;
 }
 .try .try-title{margin:0 0 12px}
@@ -240,7 +240,7 @@ a.install-download:focus-visible{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.83rem;
   color:var(--netscli-text);transition:background .15s;position:relative;
 }
-.try-cmd:hover{background:#101010}
+.try-cmd:hover{background:var(--netscli-bg)}
 .try-comment{
   color:var(--netscli-text-muted);font-size:.74rem;line-height:1.35;
 }
@@ -255,7 +255,7 @@ a.install-download:focus-visible{
   opacity:1;
 }
 .has-copy.always-show .copy-btn:hover{
-  background:#2a2d32;
+  background:var(--netscli-surface-raised);
   border-color:rgba(var(--netscli-lift-rgb),.18);
   color:rgba(255,255,255,.58);
 }

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -35,9 +35,22 @@ const onHome = pathname === '/';
           {link.label}
         </a>
       ))}
+      <label class="theme-select">
+        <span class="sr-only">Theme</span>
+        <select data-theme-select>
+          <option value="auto">Auto</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
     </div>
   </div>
 </nav>
+
+<script>
+  import { initThemeSelect } from '../scripts/theme-select';
+  initThemeSelect();
+</script>
 
 {
   onHome && (
@@ -72,7 +85,7 @@ nav[data-site-nav]{
      plus a border instead left the landing bar 0.2px shorter, because a 1px
      border renders as 0.8 at this device pixel ratio. */
   min-height:var(--netscli-nav-height);
-  background:rgba(17,17,17,.85);backdrop-filter:blur(12px);
+  background:rgba(var(--netscli-bg-rgb), .85);backdrop-filter:blur(12px);
   border-bottom:1px solid rgba(var(--netscli-lift-rgb),.06);
   box-shadow:none;
   transition:box-shadow 160ms ease,border-color 160ms ease;
@@ -173,6 +186,42 @@ body.nav-scrolled nav[data-site-nav]::after{
   height:calc(var(--netscli-nav-height) - 1px);
 }
 .nlinks a:hover{color:var(--netscli-text)}
+
+/* Theme control.
+ *
+ * A native <select> rather than a custom listbox: it is keyboard and screen
+ * reader correct for free, and the docs' control is the same element, so the
+ * two bars behave identically. The option list itself is drawn by the
+ * operating system and cannot be fully styled -- known, and not worth a
+ * bespoke widget for three options. */
+.theme-select{display:inline-flex;align-items:center;height:calc(var(--netscli-nav-height) - 1px)}
+.theme-select select{
+  font:inherit;font-size:.8125rem;
+  color:var(--netscli-text-muted);
+  background:transparent;
+  border:1px solid rgba(var(--netscli-hairline-rgb),.24);
+  border-radius:6px;
+  padding:4px 6px;
+  cursor:pointer;
+}
+.theme-select select:hover{color:var(--netscli-text)}
+.theme-select select:focus-visible{
+  outline:0;
+  color:var(--netscli-text);
+  border-color:rgba(var(--netscli-accent-rgb),.45);
+  box-shadow:0 0 0 2px rgba(var(--netscli-accent-rgb),.22);
+}
+/* The option list is OS-drawn; these two are the only properties that
+   reliably take, and without them a dark theme gets a white popup. */
+.theme-select option{color:var(--netscli-text);background:var(--netscli-surface-raised)}
+
+/* Visually hidden, still announced. The control needs a name and the bar has
+   no room for a visible one. */
+.sr-only{
+  position:absolute;width:1px;height:1px;
+  padding:0;margin:-1px;overflow:hidden;
+  clip-path:inset(50%);white-space:nowrap;border:0;
+}
 /* Both values, because two different things set this attribute here.
    Nav.astro marks a genuine current page with "page"; the scroll spy in
    scripts/site-nav.ts marks the section you are looking at with "location",
@@ -228,7 +277,7 @@ body.nav-scrolled nav[data-site-nav]::after{
     justify-content:flex-start;
     gap:2px;
     padding:8px;
-    background:rgba(22,24,26,.98);
+    background:rgba(var(--netscli-bg-rgb), .98);
     border:1px solid rgba(var(--netscli-lift-rgb),.1);
     border-radius:8px;
     box-shadow:0 14px 34px rgba(0,0,0,.36);

--- a/site/src/components/Surfaces.astro
+++ b/site/src/components/Surfaces.astro
@@ -57,7 +57,7 @@ const { surfaces, copy } = site;
 <style is:global>
 /* ─── SURFACE CARDS ─── */
 .surfaces-section{
-  background:#141718;
+  background:var(--netscli-surface);
   border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
 }
 .surfaces-section::before{
@@ -101,7 +101,7 @@ const { surfaces, copy } = site;
   outline-offset:3px;
 }
 .surface-visual .codeblock{
-  background:#0b0d0e;border:1px solid rgba(var(--netscli-lift-rgb),.08);
+  background:var(--netscli-bg);border:1px solid rgba(var(--netscli-lift-rgb),.08);
   border-radius:10px;padding:16px 58px 16px 20px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:.75rem;line-height:1.7;white-space:pre;overflow-x:auto;color:var(--netscli-text);

--- a/site/src/layouts/Page.astro
+++ b/site/src/layouts/Page.astro
@@ -85,6 +85,35 @@ const shouldNoindex = noindex || isPreviewBuild;
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+{/*
+  Apply the stored theme before anything paints.
+
+  Inline and first in <head> on purpose: a deferred module would run after
+  first paint and the page would flash dark before turning light, on every
+  navigation. This is the one script here that cannot be a module.
+
+  `starlight-theme` is Starlight's own localStorage key, deliberately. The
+  docs already write it, so a reader who picks light in the docs and clicks
+  through to the landing page stays in light -- which is the whole point of
+  the two halves sharing a palette.
+*/}
+<script is:inline>
+  (() => {
+    try {
+      const stored = localStorage.getItem('starlight-theme');
+      const theme =
+        stored === 'light' || stored === 'dark'
+          ? stored
+          : matchMedia('(prefers-color-scheme: light)').matches
+            ? 'light'
+            : 'dark';
+      document.documentElement.dataset.theme = theme;
+    } catch {
+      // Private mode, or storage blocked. Falling through leaves the dark
+      // default, which is what an unthemed page has always rendered.
+    }
+  })();
+</script>
 <meta name="theme-color" content={meta.themeColor} />
 <title>{title}</title>
 <meta name="description" content={description} />

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -286,7 +286,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   content:"";
   position:absolute;left:0;right:0;bottom:0;height:84px;
   pointer-events:none;
-  background:linear-gradient(180deg,rgba(25,25,25,0),rgba(25,25,25,.95) 70%,#191919);
+  background:linear-gradient(180deg,rgba(var(--netscli-bg-rgb), 0),rgba(var(--netscli-bg-rgb), .95) 70%,var(--netscli-surface));
 }
 .release-body>*+*{margin-top:14px}
 .release-summary{
@@ -330,7 +330,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
 }
 .release-body .release-code{
   position:relative;margin:0;max-width:100%;overflow-x:auto;
-  background:#20242b;border:1px solid rgba(140,149,166,.2);
+  background:var(--netscli-surface-raised);border:1px solid rgba(140,149,166,.2);
   border-radius:8px;padding:.82rem 1rem;color:var(--netscli-text);
   box-shadow:none;
 }

--- a/site/src/scripts/theme-select.ts
+++ b/site/src/scripts/theme-select.ts
@@ -1,0 +1,61 @@
+/* The landing page's theme control.
+ *
+ * Reads and writes `starlight-theme`, the same localStorage key the docs use,
+ * so a choice made on either half of the site holds on the other. The
+ * pre-paint script in Page.astro applies whatever this stores.
+ *
+ * Three values, matching the docs' own control: an explicit `light` or `dark`
+ * is stored; `auto` REMOVES the key rather than storing the word, so the page
+ * follows the operating system from then on. Storing "auto" would work too,
+ * but then the stored value and the applied value are different things and
+ * every reader of the key has to know that.
+ */
+
+type Theme = 'light' | 'dark';
+
+const KEY = 'starlight-theme';
+
+function systemTheme(): Theme {
+  return matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+}
+
+function stored(): Theme | null {
+  try {
+    const value = localStorage.getItem(KEY);
+    return value === 'light' || value === 'dark' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function apply(theme: Theme): void {
+  document.documentElement.dataset.theme = theme;
+}
+
+export function initThemeSelect(): void {
+  const select = document.querySelector<HTMLSelectElement>('[data-theme-select]');
+  if (!select) return;
+
+  // Reflect the current state rather than assuming the markup's default. The
+  // control renders with "Auto" selected, but the reader may have chosen
+  // something on a previous visit or in the docs.
+  select.value = stored() ?? 'auto';
+
+  select.addEventListener('change', () => {
+    const choice = select.value;
+    try {
+      if (choice === 'auto') localStorage.removeItem(KEY);
+      else localStorage.setItem(KEY, choice);
+    } catch {
+      // Storage blocked: the choice still applies to this page, it just will
+      // not survive a navigation. Better than doing nothing.
+    }
+    apply(choice === 'auto' ? systemTheme() : (choice as Theme));
+  });
+
+  // Follow the system while the reader is on "auto", so a theme change in the
+  // OS is picked up without a reload.
+  matchMedia('(prefers-color-scheme: light)').addEventListener('change', () => {
+    if (stored() === null) apply(systemTheme());
+  });
+}

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -12,14 +12,14 @@ html{
   scrollbar-color:rgba(140,149,166,.42) rgba(var(--netscli-lift-rgb),.035);
 }
 ::-webkit-scrollbar{width:12px;height:12px}
-::-webkit-scrollbar-track{background:#151515}
+::-webkit-scrollbar-track{background:var(--netscli-bg)}
 ::-webkit-scrollbar-thumb{
   background:rgba(140,149,166,.45);
-  border:3px solid #151515;
+  border:3px solid var(--netscli-bg);
   border-radius:999px;
 }
 ::-webkit-scrollbar-thumb:hover{background:rgba(170,178,192,.62)}
-::-webkit-scrollbar-corner{background:#151515}
+::-webkit-scrollbar-corner{background:var(--netscli-bg)}
 html[data-theme='light']{
   scrollbar-color:rgba(68,81,106,.42) rgba(241,245,249,.92);
 }
@@ -36,7 +36,7 @@ html[data-theme='light'] ::-webkit-scrollbar-corner{background:#f1f5f9}
 body{
   margin:0;
   font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
-  background:#111;color:var(--netscli-text);line-height:1.6;
+  background:var(--netscli-bg);color:var(--netscli-text);line-height:1.6;
   -webkit-font-smoothing:antialiased;
 }
 .skip-link{
@@ -47,7 +47,7 @@ body{
   padding:8px 12px;
   border:1px solid #2dd4bf;
   border-radius:6px;
-  background:#111;
+  background:var(--netscli-bg);
   color:var(--netscli-text-strong);
   transform:translateY(calc(-100% - 16px));
   transition:transform .15s ease;
@@ -89,7 +89,7 @@ code{
   padding:10px 20px;border-radius:8px;font-size:.875rem;font-weight:600;
   text-decoration:none;transition:all 120ms;
 }
-.btn-w{background:#e5e5e5;color:#111;border:1px solid #e5e5e5}
+.btn-w{background:#e5e5e5;color:var(--netscli-bg);border:1px solid #e5e5e5}
 .btn-w:hover{background:#fff;border-color:#fff}
 .btn-o{background:transparent;color:var(--netscli-text-muted);border:1px solid rgba(var(--netscli-lift-rgb),.15)}
 .btn-o:hover{color:var(--netscli-text);border-color:rgba(255,255,255,.3);text-decoration:none}
@@ -127,7 +127,7 @@ section .lead a:hover{color:var(--netscli-accent-bright)}
 .copy-btn{
   position:absolute;top:50%;right:5px;transform:translateY(-50%);
   /* Opaque background so text behind the button isn't visible through it */
-  background:#222;border:1px solid rgba(var(--netscli-lift-rgb),.12);
+  background:var(--netscli-surface-raised);border:1px solid rgba(var(--netscli-lift-rgb),.12);
   border-radius:6px;color:rgba(255,255,255,.34);
   width:27px;height:27px;padding:0;
   display:inline-flex;align-items:center;justify-content:center;
@@ -138,7 +138,7 @@ section .lead a:hover{color:var(--netscli-accent-bright)}
 .has-copy:hover .copy-btn,.has-copy:focus-within .copy-btn{opacity:1}
 .faq-command:hover .copy-btn,.faq-command:focus-within .copy-btn{opacity:1}
 .faq-command .copy-btn{right:10px}
-.copy-btn:hover{background:#2a2d32;border-color:rgba(var(--netscli-lift-rgb),.18);color:rgba(255,255,255,.58)}
+.copy-btn:hover{background:var(--netscli-surface-raised);border-color:rgba(var(--netscli-lift-rgb),.18);color:rgba(255,255,255,.58)}
 .copy-btn.copied{color:#3fb950;border-color:rgba(63,185,80,.4)}
 .surface-visual .codeblock .copy-btn,
 .tryblock .copy-btn{

--- a/site/src/styles/lightbox.css
+++ b/site/src/styles/lightbox.css
@@ -23,7 +23,7 @@
   inset:0;
   z-index:1200; /* above .skip-link's 1000 */
   padding:32px;
-  background:rgba(8,8,8,.86);
+  background:rgba(var(--netscli-bg-rgb), .86);
   backdrop-filter:blur(3px);
 }
 .image-lightbox.open{
@@ -46,7 +46,7 @@ body.lightbox-open{overflow:hidden}
   min-height:0; /* lets the image shrink inside the flex column */
   border:1px solid rgba(var(--netscli-lift-rgb),.14);
   border-radius:10px;
-  background:#0d0d0d;
+  background:var(--netscli-bg);
   overflow:hidden;
 }
 .image-lightbox-frame img{
@@ -86,13 +86,13 @@ body.lightbox-open{overflow:hidden}
   place-items:center;
   border:1px solid rgba(var(--netscli-lift-rgb),.18);
   border-radius:999px;
-  background:#1b1b1b;
+  background:var(--netscli-surface);
   color:var(--netscli-text-strong);
   font-size:1.25rem;
   line-height:1;
   cursor:pointer;
 }
-.image-lightbox-close:hover{background:#2a2d32;border-color:rgba(255,255,255,.32)}
+.image-lightbox-close:hover{background:var(--netscli-surface-raised);border-color:rgba(255,255,255,.32)}
 .image-lightbox-close:focus-visible{outline:2px solid #2dd4bf;outline-offset:2px}
 
 /* No light-theme overrides here on purpose. The lightbox only runs on the

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -45,8 +45,7 @@
    * The -rgb form is the same colour as a bare triple, for the rgba() call
    * sites that need an alpha. There were 108 hard-coded copies of the old
    * value across 20 files before this; changing it should be one edit here.
-   * The docs light theme keeps its own darker pair in
-   * starlight/01-tokens-and-header.css, as it did before. */
+   * The light theme's darker accent is in the light block below. */
   --netscli-accent: #22c55e;
   --netscli-accent-rgb: 34, 197, 94;
   /* Hover and other lifted states.
@@ -61,7 +60,7 @@
   /* ---- Cross-stack role channels -------------------------------------
    *
    * These moved up from starlight/00-theme-tokens.css, which only the docs
-   * load. The landing page and the changelog need the same three roles to be
+   * load. The landing page and the changelog need these roles to be
    * themeable at all, and a second copy of them under different names is how
    * the two halves of this site drifted apart in the first place.
    *
@@ -97,9 +96,30 @@
   --netscli-text-strong: #f4f4f4;
   --netscli-text: #c2cad8;
   --netscli-text-muted: #8c95a6;
+
+  /* ---- Surfaces -------------------------------------------------------
+   *
+   * Three depths, from the same 21 opaque backgrounds the landing stack had
+   * spread across 32 declarations. They fell into three tight luminance
+   * bands with nothing between them -- eight values from #0a0a0a to #151515
+   * doing the page, six from #141718 to #1b1b1b doing panels, three from
+   * #222 to #2a2d32 doing the layer above -- so the bands were real and only
+   * the exact values inside them were arbitrary.
+   *
+   * Values are the docs' --sl-color-bg, gray-6 and the panel surface, so a
+   * card on the landing page and a card in the docs are finally the same
+   * colour. */
+  --netscli-bg: #111111;
+  --netscli-surface: #191d25;
+  --netscli-surface-raised: #20242b;
+  /* The page background as channels, for the translucent bars drawn over
+     content: the sticky nav, the mobile menu, the lightbox scrim. Those were
+     four slightly different near-black rgba() values -- 17/17/17, 22/24/26,
+     25/25/25, 8/8/8 -- none of which could follow a theme. */
+  --netscli-bg-rgb: 17, 17, 17;
 }
 
-/* The light theme's overrides of the three roles above.
+/* The light theme's overrides of everything above.
  *
  * Set here rather than in the docs' own token file so the landing page and
  * changelog resolve them too. Values match the docs light theme exactly, so
@@ -120,4 +140,13 @@ html[data-theme='light'] {
   --netscli-text-strong: #111827;
   --netscli-text: #44516a;
   --netscli-text-muted: #647084;
+
+  /* Light surfaces, again the docs' own: --sl-color-bg, gray-6, and the
+     panel. Depth inverts with the theme -- a raised surface is lighter than
+     the page in the dark theme and darker than it here -- which is why these
+     are named for depth rather than for a colour. */
+  --netscli-bg: #fbfbfb;
+  --netscli-surface: #f4f6f8;
+  --netscli-surface-raised: #f6f8fa;
+  --netscli-bg-rgb: 251, 251, 251;
 }


### PR DESCRIPTION
The docs have had two themes all along; the other half of the site had one. Setting `data-theme='light'` on the landing page changed nothing but the scrollbars, and there was no control to set it with.

## Surfaces

The landing stack drew **21 distinct opaque backgrounds across 32 declarations**, falling into three tight luminance bands with nothing between them:

| band | values | role |
|---|---|---|
| `#0a0a0a`–`#151515` | 8 | the page |
| `#141718`–`#1b1b1b` | 6 | panels |
| `#222`–`#2a2d32` | 3 | the layer above |

The bands were real; only the exact values inside them were arbitrary. Now `--netscli-bg` / `-surface` / `-surface-raised`, taking the docs' own `--sl-color-bg`, `gray-6` and panel values — so a card on the landing page and a card in the docs are finally the same colour.

Five translucent bars needed a channel of their own (sticky nav, mobile menu, lightbox scrim), written as four slightly different near-blacks an opaque mapping couldn't see. `--netscli-bg-rgb` covers them. The pure `rgba(0,0,0,α)` box-shadows are left alone — those are shadows, not surfaces.

## The control is not a separate step

Without it the light theme is **unreachable, and unreachable means untested**: axe renders the landing page with no `data-theme`, and so did the visual harness, so both were checking the dark theme twice. Adding the control is what makes the rest of this verifiable.

- Writes `starlight-theme`, Starlight's own key, so a choice made in the docs holds on the landing page and vice versa. **Measured end to end**: light chosen on the landing page, then `/docs/` and `/changelog/` both load at `#fbfbfb`.
- `Auto` **removes** the key rather than storing the word, so the stored value and the applied value never mean different things — and it follows the OS live.
- The applying script is **inline and first in `<head>`**. A module would run after first paint and flash dark before turning light, on every navigation.
- A native `<select>`, like the docs use: keyboard and screen-reader correct for free. Its option list is OS-drawn and can't be fully styled — a known limit, not worth a bespoke widget for three options.

## Verification

**axe now covers what it could not before** — the light pass renders these pages light for the first time — and reports **0 violations across 14 pages in both themes**.

148 contrast pairs ≥ 4.5:1 · dead CSS 14/14 · `astro check` clean · **12 captures changed, all landing-side; no docs page moved**.