### PR TITLE
Derive the wordmark's indent and start the contents rail below the hero

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -93,6 +93,15 @@ jobs:
         working-directory: site
         run: npm run check:css
 
+      # Reads the wordmark PNG and checks the token that cancels its
+      # transparent left margin still matches it. Needs no build and no
+      # browser: it is here rather than in the build job so a bad re-export
+      # fails in seconds. See the script for the five drifted values that
+      # made it worth checking.
+      - name: Wordmark inset
+        working-directory: site
+        run: npm run check:wordmark
+
   build:
     name: Build + typecheck
     needs: [changes, maintainability]

--- a/scripts/design-tokens.mjs
+++ b/scripts/design-tokens.mjs
@@ -88,6 +88,22 @@ const TARGETS = [
       'netscli-text-strong',
       'netscli-text',
       'netscli-text-muted',
+      // The accent as ink, and the four code-sample colours.
+      //
+      // Added after the light theme shipped with --netscli-accent left at the
+      // dark #22c55e -- 2.0:1 on a white page, across every accent-coloured
+      // link on the landing page and the changelog -- and the code samples
+      // still carrying a palette picked for a near-black background. Neither
+      // was reachable from this list, so the gate reported a pass on both.
+      // --netscli-accent is the one to watch: only its -rgb twin was
+      // overridden per theme, and channels are invisible to a contrast check.
+      'netscli-accent',
+      'netscli-accent-bright',
+      'netscli-accent-high',
+      'netscli-code-comment',
+      'netscli-code-punct',
+      'netscli-code-key',
+      'netscli-code-string',
     ],
     surfaces: ['sl-color-bg', 'sl-color-bg-sidebar', 'sl-color-black', 'sl-color-gray-6'],
     keys: {

--- a/site/design-tokens.json
+++ b/site/design-tokens.json
@@ -9,7 +9,7 @@
   "light": {
     "surface-base": "#f4f6f8",
     "text-main": "#44516a",
-    "text-muted": "#647084",
+    "text-muted": "#596478",
     "text-strong": "#111827",
     "accent": "#146b2e"
   }

--- a/site/package.json
+++ b/site/package.json
@@ -13,6 +13,7 @@
     "check": "astro check",
     "check:changelog": "node ./scripts/changelog-dates.mjs",
     "check:css": "node ./scripts/css-shadowing.mjs --max 14",
+    "check:wordmark": "node ./scripts/wordmark-inset.mjs",
     "test:a11y": "npm run build && node ./scripts/a11y.mjs",
     "visual:record": "node ./scripts/visual-snapshot.mjs record",
     "visual:check": "node ./scripts/visual-snapshot.mjs check"

--- a/site/scripts/a11y.mjs
+++ b/site/scripts/a11y.mjs
@@ -40,18 +40,37 @@ const axeCli = modulePath('@axe-core', 'cli', 'dist', 'src', 'bin', 'cli.js');
  * light-theme contrast bugs could sit unnoticed behind a green local
  * check. Run both explicitly.
  *
- * Chrome has no "force light" switch because light IS the default with
- * no OS preference; `--force-dark-mode` covers the other side.
+ * Both passes name the preference outright. The light pass used to pass no
+ * flag at all, on the reasoning that light IS the default when the runner
+ * has no OS preference -- true on Ubuntu, false on a workstation, where
+ * Chrome inherits the OS setting. On a dark-mode desktop that made BOTH
+ * passes render dark and report a clean run, which is the same
+ * environment-dependence this block was written to remove, just moved one
+ * step along. It cost a false green: two pages were reported as passing in
+ * both themes while CI had been failing them on 23 and 10 contrast
+ * violations.
+ *
+ * `blink-settings=preferredColorScheme` sets what `prefers-color-scheme`
+ * reports (1 = light, 2 = dark), which is the thing the site actually reads.
+ * `--force-dark-mode` is not that: it is Chrome's automatic darkening of
+ * pages that have no dark theme, so it re-tints an already-dark page and
+ * tests colours nobody wrote. The visual harness dropped it for the same
+ * reason.
  */
 // `headless` is not optional here. Without it, axe launches a headed Chrome
-// that takes its colour scheme from the OS and ignores --force-dark-mode, so
+// that takes its colour scheme from the OS and overrides the flag above, so
 // *both* passes render the same theme and one of them is never tested. That
 // blind spot is not theoretical: it hid a 1.53:1 contrast failure in the
 // caution callout on /docs/packet-capture/ from every local run, and only CI
 // -- which is headless -- caught it.
+//
+// Sabotage-checked in both directions on a dark-mode workstation, against a
+// light theme deliberately broken by restoring the dark accent: the old
+// unflagged light pass reported 0 violations and exited 0; this one reports
+// 6 and exits 1.
 const THEMES = [
-  { name: 'light', chromeOptions: ['headless'] },
-  { name: 'dark', chromeOptions: ['headless', 'force-dark-mode'] },
+  { name: 'light', chromeOptions: ['headless', 'blink-settings=preferredColorScheme=1'] },
+  { name: 'dark', chromeOptions: ['headless', 'blink-settings=preferredColorScheme=2'] },
 ];
 
 /**

--- a/site/scripts/wordmark-inset.mjs
+++ b/site/scripts/wordmark-inset.mjs
@@ -1,0 +1,141 @@
+// Does --netscli-mark-inset-ratio still match the wordmark asset?
+//
+// netscli-wordmark.png carries transparent columns down its left edge, so a
+// bar that renders it flush against the gutter shows the logo indented while
+// the links beside it are not. Both bars cancel that with a negative
+// translate sized from the asset's own margin.
+//
+// This is checked rather than eyeballed because eyeballing it produced five
+// different answers. Before tokens.css derived one value, the compensation
+// was written as -10px on the landing bar, -18px on the docs bar, -8px below
+// 72rem, -24px !important below 50rem, and omitted entirely on the landing
+// page's narrow breakpoint -- against a real margin of 12.4px, 12.4px,
+// 10.9px, 10.3px and 10.3px. Nobody chose those; they accumulated, and a
+// wrong one is a few pixels of indent that renders as plausible and stays
+// wrong for months.
+//
+// Re-exporting the wordmark with different padding silently invalidates the
+// ratio and nothing else in the build would notice, which is the failure this
+// guards. Exits non-zero on drift.
+//
+//   node ./scripts/wordmark-inset.mjs
+
+import fs from 'node:fs';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { fileURLToPath } from 'node:url';
+
+const siteRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const asset = path.join(siteRoot, 'public', 'assets', 'netscli-wordmark.png');
+const tokens = path.join(siteRoot, 'src', 'styles', 'tokens.css');
+
+// Half a pixel at the widest rendered width the site uses (160px). Below that
+// the difference cannot reach a device pixel, so it is not worth failing over.
+const TOLERANCE = 0.5 / 160;
+
+/** Alpha channel of a truecolour-with-alpha, 8-bit PNG, as a w*h Uint8Array. */
+function alphaChannel(file) {
+  const buf = fs.readFileSync(file);
+  const width = buf.readUInt32BE(16);
+  const height = buf.readUInt32BE(20);
+  const bitDepth = buf[24];
+  const colourType = buf[25];
+  if (bitDepth !== 8 || colourType !== 6) {
+    throw new Error(
+      `${path.basename(file)} is bit depth ${bitDepth}, colour type ${colourType}; ` +
+        'this reader only handles 8-bit RGBA (type 6). Re-export it as RGBA, or ' +
+        'teach this script the new format.'
+    );
+  }
+
+  const chunks = [];
+  for (let at = 8; at < buf.length; ) {
+    const length = buf.readUInt32BE(at);
+    if (buf.toString('ascii', at + 4, at + 8) === 'IDAT') {
+      chunks.push(buf.subarray(at + 8, at + 8 + length));
+    }
+    at += 12 + length;
+  }
+
+  // Undo the per-scanline filters (PNG spec 9.2). Each row is prefixed with a
+  // filter byte and predicts from the pixel left (a), above (b), and
+  // above-left (c).
+  const raw = zlib.inflateSync(Buffer.concat(chunks));
+  const bpp = 4;
+  const stride = width * bpp;
+  const out = Buffer.alloc(height * stride);
+  let read = 0;
+  for (let y = 0; y < height; y += 1) {
+    const filter = raw[read];
+    read += 1;
+    for (let x = 0; x < stride; x += 1) {
+      const i = y * stride + x;
+      const a = x >= bpp ? out[i - bpp] : 0;
+      const b = y > 0 ? out[i - stride] : 0;
+      const c = x >= bpp && y > 0 ? out[i - stride - bpp] : 0;
+      let value = raw[read];
+      read += 1;
+      if (filter === 1) value += a;
+      else if (filter === 2) value += b;
+      else if (filter === 3) value += (a + b) >> 1;
+      else if (filter === 4) {
+        const pa = Math.abs(b - c);
+        const pb = Math.abs(a - c);
+        const pc = Math.abs(a + b - 2 * c);
+        value += pa <= pb && pa <= pc ? a : pb <= pc ? b : c;
+      }
+      out[i] = value & 0xff;
+    }
+  }
+
+  const alpha = new Uint8Array(width * height);
+  for (let i = 0; i < width * height; i += 1) alpha[i] = out[i * 4 + 3];
+  return { width, height, alpha };
+}
+
+const { width, height, alpha } = alphaChannel(asset);
+
+// 8/255, not 0: a soft antialiased edge fades to a handful of alpha units
+// well before it reaches nothing, and counting those as ink would report a
+// margin a couple of columns short of where the glyph visibly starts.
+const OPAQUE = 8;
+let left = 0;
+while (left < width) {
+  let ink = false;
+  for (let y = 0; y < height && !ink; y += 1) ink = alpha[y * width + left] > OPAQUE;
+  if (ink) break;
+  left += 1;
+}
+
+const measured = left / width;
+
+const css = fs.readFileSync(tokens, 'utf8');
+const declared = css.match(/--netscli-mark-inset-ratio:\s*([\d.]+)\s*;/);
+if (!declared) {
+  console.error(
+    `No --netscli-mark-inset-ratio declaration in ${path.relative(siteRoot, tokens)}.\n` +
+      `The wordmark's own left margin is ${measured.toFixed(4)} of its width ` +
+      `(${left} of ${width} columns); declare that.`
+  );
+  process.exit(1);
+}
+
+const ratio = Number(declared[1]);
+const drift = Math.abs(ratio - measured);
+
+if (drift > TOLERANCE) {
+  console.error(
+    'Wordmark inset has drifted from the asset.\n' +
+      `  declared  --netscli-mark-inset-ratio: ${ratio}\n` +
+      `  measured  ${measured.toFixed(4)} (${left} transparent columns of ${width})\n` +
+      `  drift     ${(drift * 160).toFixed(2)}px at a 160px wordmark, tolerance 0.50px\n` +
+      `Set the token to ${measured.toFixed(4)} in ${path.relative(siteRoot, tokens)}, ` +
+      'or re-export the asset with its original padding.'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Wordmark inset OK: declared ${ratio}, measured ${measured.toFixed(4)} ` +
+    `(${left} of ${width} columns), off by ${(drift * 160).toFixed(2)}px at 160px.`
+);

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -173,7 +173,7 @@ const { hero, social } = site;
   padding:.42rem .58rem;
   border:1px solid rgba(106,240,208,.2);
   border-radius:6px;
-  background:#171c23;
+  background:var(--netscli-surface);
   color:var(--netscli-text);
   box-shadow:0 12px 28px rgba(0,0,0,.32);
   font-size:.72rem;
@@ -193,7 +193,7 @@ const { hero, social } = site;
   height:.45rem;
   border-right:1px solid rgba(106,240,208,.2);
   border-bottom:1px solid rgba(106,240,208,.2);
-  background:#171c23;
+  background:var(--netscli-surface);
   pointer-events:none;
   opacity:0;
   transform:translate(-50%,.25rem) rotate(45deg);
@@ -306,7 +306,7 @@ const { hero, social } = site;
   width:min(260px,calc(100vw - 48px));min-width:0;box-sizing:border-box;
   /* See the wrapped-layout rule below, which widens this to the trigger. */
   padding:5px;border-radius:8px;
-  background:#181b20;border:1px solid rgba(var(--netscli-lift-rgb),.12);
+  background:var(--netscli-surface);border:1px solid rgba(var(--netscli-lift-rgb),.12);
   box-shadow:0 18px 40px rgba(0,0,0,.42);
 }
 .hero-desktop-menu a{

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -120,7 +120,7 @@ const groups = [
   position:relative;
 }
 .tryblock{
-  background:#0b0d0e;border:1px solid rgba(var(--netscli-lift-rgb),.08);
+  background:var(--netscli-bg);border:1px solid rgba(var(--netscli-lift-rgb),.08);
   border-radius:10px;padding:16px 20px;height:100%;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:clamp(.6875rem,1.4vw,.8125rem);
@@ -143,7 +143,7 @@ const groups = [
 }
 .os-tabs{
   grid-column:1;grid-row:1;display:flex;gap:0;
-  border-bottom:1px solid #222;margin-bottom:20px;
+  border-bottom:1px solid var(--netscli-surface-raised);margin-bottom:20px;
 }
 .install-content{grid-column:1;grid-row:2}
 .try{grid-column:2;grid-row:2}
@@ -157,20 +157,20 @@ const groups = [
 .os-panel{display:none}
 .os-panel.active{display:block}
 .reco{
-  background:#0d0d0d;border:1px solid #2a2a2a;border-radius:10px;
+  background:var(--netscli-bg);border:1px solid var(--netscli-surface-raised);border-radius:10px;
   padding:14px 18px;margin-bottom:16px;
 }
 .reco-meta{font-size:.85rem;font-weight:500;color:var(--netscli-text);margin-bottom:8px}
 .cmd.big{font-size:1.05rem;padding-right:74px}
 .alts{
   display:flex;flex-direction:column;gap:1px;
-  background:#1a1a1a;border:1px solid #1a1a1a;border-radius:8px;overflow:hidden;
+  background:var(--netscli-surface);border:1px solid var(--netscli-surface);border-radius:8px;overflow:hidden;
 }
 .alt{
   display:grid;grid-template-columns:140px 1fr;gap:16px;align-items:center;
-  padding:11px 16px;background:#0c0c0c;transition:background .15s;position:relative;
+  padding:11px 16px;background:var(--netscli-bg);transition:background .15s;position:relative;
 }
-.alt:hover{background:#0f0f0f}
+.alt:hover{background:var(--netscli-bg)}
 .alt-label{font-size:.85rem;color:var(--netscli-text)}
 .alt-cmd{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.82rem;
@@ -230,7 +230,7 @@ a.install-download:focus-visible{
 /* Try it sidebar — one row per command, each row gets .has-copy so the
    existing copy-button JS auto-attaches a button. */
 .try{
-  background:#0a0a0a;border:1px solid rgba(var(--netscli-lift-rgb),.08);border-radius:10px;
+  background:var(--netscli-bg);border:1px solid rgba(var(--netscli-lift-rgb),.08);border-radius:10px;
   padding:18px;
 }
 .try .try-title{margin:0 0 12px}
@@ -240,7 +240,7 @@ a.install-download:focus-visible{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.83rem;
   color:var(--netscli-text);transition:background .15s;position:relative;
 }
-.try-cmd:hover{background:#101010}
+.try-cmd:hover{background:var(--netscli-bg)}
 .try-comment{
   color:var(--netscli-text-muted);font-size:.74rem;line-height:1.35;
 }
@@ -255,7 +255,7 @@ a.install-download:focus-visible{
   opacity:1;
 }
 .has-copy.always-show .copy-btn:hover{
-  background:#2a2d32;
+  background:var(--netscli-surface-raised);
   border-color:rgba(var(--netscli-lift-rgb),.18);
   color:rgba(255,255,255,.58);
 }

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -137,14 +137,20 @@ body.nav-scrolled nav[data-site-nav]::after{
 .mark{
   display:inline-block;line-height:0;text-decoration:none;
   filter:brightness(1);transition:filter 200ms;
-  transform:translateX(-10px);
+  /* Cancels the wordmark asset's own transparent left margin, so the glyph
+     starts on the gutter the nav links start on. See tokens.css. */
+  transform:translateX(calc(var(--netscli-mark-width) * var(--netscli-mark-inset-ratio) * -1));
 }
 .mark img{
-  display:block;width:160px;height:auto;image-rendering:auto;
+  display:block;width:var(--netscli-mark-width);height:auto;image-rendering:auto;
 }
 .mark:hover{filter:brightness(1)}
 @media(max-width:600px){
-  .mark img{width:132px}
+  /* Narrows the wordmark AND its inset -- the transparent margin is a
+     fraction of the rendered width, so a fixed pull-back would over-correct
+     here. This breakpoint used to change only the width, leaving the desktop
+     -10px in place against a 10.3px margin. */
+  .mark{--netscli-mark-width:132px}
 }
 .nav-menu-toggle{
   display:none;
@@ -191,9 +197,15 @@ body.nav-scrolled nav[data-site-nav]::after{
  *
  * A native <select> rather than a custom listbox: it is keyboard and screen
  * reader correct for free, and the docs' control is the same element, so the
- * two bars behave identically. The option list itself is drawn by the
- * operating system and cannot be fully styled -- known, and not worth a
- * bespoke widget for three options. */
+ * two bars behave identically.
+ *
+ * The option list is drawn by the operating system, so it cannot be styled
+ * the way the rest of the bar is. What it CAN follow is `color-scheme`, which
+ * tokens.css now sets per theme -- Starlight declares that for the docs in
+ * its own reset, and this page never loads that reset, so the docs popup was
+ * already dark while this one was drawn white over a near-black bar. That is
+ * as far as it is worth going: a bespoke listbox for three options would have
+ * to re-implement the keyboard and screen reader behaviour this gets free. */
 .theme-select{display:inline-flex;align-items:center;height:calc(var(--netscli-nav-height) - 1px)}
 .theme-select select{
   font:inherit;font-size:.8125rem;
@@ -211,8 +223,11 @@ body.nav-scrolled nav[data-site-nav]::after{
   border-color:rgba(var(--netscli-accent-rgb),.45);
   box-shadow:0 0 0 2px rgba(var(--netscli-accent-rgb),.22);
 }
-/* The option list is OS-drawn; these two are the only properties that
-   reliably take, and without them a dark theme gets a white popup. */
+/* Kept alongside `color-scheme` rather than replaced by it. These two are the
+   only option properties that reliably take, and whether a given platform's
+   popup honours color-scheme on its own is not something this repo can
+   verify -- the popup is a separate OS window and does not appear in a page
+   screenshot. One line is cheaper than finding out it does not. */
 .theme-select option{color:var(--netscli-text);background:var(--netscli-surface-raised)}
 
 /* Visually hidden, still announced. The control needs a name and the bar has

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -35,9 +35,22 @@ const onHome = pathname === '/';
           {link.label}
         </a>
       ))}
+      <label class="theme-select">
+        <span class="sr-only">Theme</span>
+        <select data-theme-select>
+          <option value="auto">Auto</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
     </div>
   </div>
 </nav>
+
+<script>
+  import { initThemeSelect } from '../scripts/theme-select';
+  initThemeSelect();
+</script>
 
 {
   onHome && (
@@ -72,7 +85,7 @@ nav[data-site-nav]{
      plus a border instead left the landing bar 0.2px shorter, because a 1px
      border renders as 0.8 at this device pixel ratio. */
   min-height:var(--netscli-nav-height);
-  background:rgba(17,17,17,.85);backdrop-filter:blur(12px);
+  background:rgba(var(--netscli-bg-rgb), .85);backdrop-filter:blur(12px);
   border-bottom:1px solid rgba(var(--netscli-lift-rgb),.06);
   box-shadow:none;
   transition:box-shadow 160ms ease,border-color 160ms ease;
@@ -173,6 +186,42 @@ body.nav-scrolled nav[data-site-nav]::after{
   height:calc(var(--netscli-nav-height) - 1px);
 }
 .nlinks a:hover{color:var(--netscli-text)}
+
+/* Theme control.
+ *
+ * A native <select> rather than a custom listbox: it is keyboard and screen
+ * reader correct for free, and the docs' control is the same element, so the
+ * two bars behave identically. The option list itself is drawn by the
+ * operating system and cannot be fully styled -- known, and not worth a
+ * bespoke widget for three options. */
+.theme-select{display:inline-flex;align-items:center;height:calc(var(--netscli-nav-height) - 1px)}
+.theme-select select{
+  font:inherit;font-size:.8125rem;
+  color:var(--netscli-text-muted);
+  background:transparent;
+  border:1px solid rgba(var(--netscli-hairline-rgb),.24);
+  border-radius:6px;
+  padding:4px 6px;
+  cursor:pointer;
+}
+.theme-select select:hover{color:var(--netscli-text)}
+.theme-select select:focus-visible{
+  outline:0;
+  color:var(--netscli-text);
+  border-color:rgba(var(--netscli-accent-rgb),.45);
+  box-shadow:0 0 0 2px rgba(var(--netscli-accent-rgb),.22);
+}
+/* The option list is OS-drawn; these two are the only properties that
+   reliably take, and without them a dark theme gets a white popup. */
+.theme-select option{color:var(--netscli-text);background:var(--netscli-surface-raised)}
+
+/* Visually hidden, still announced. The control needs a name and the bar has
+   no room for a visible one. */
+.sr-only{
+  position:absolute;width:1px;height:1px;
+  padding:0;margin:-1px;overflow:hidden;
+  clip-path:inset(50%);white-space:nowrap;border:0;
+}
 /* Both values, because two different things set this attribute here.
    Nav.astro marks a genuine current page with "page"; the scroll spy in
    scripts/site-nav.ts marks the section you are looking at with "location",
@@ -228,7 +277,7 @@ body.nav-scrolled nav[data-site-nav]::after{
     justify-content:flex-start;
     gap:2px;
     padding:8px;
-    background:rgba(22,24,26,.98);
+    background:rgba(var(--netscli-bg-rgb), .98);
     border:1px solid rgba(var(--netscli-lift-rgb),.1);
     border-radius:8px;
     box-shadow:0 14px 34px rgba(0,0,0,.36);

--- a/site/src/components/Surfaces.astro
+++ b/site/src/components/Surfaces.astro
@@ -57,7 +57,7 @@ const { surfaces, copy } = site;
 <style is:global>
 /* ─── SURFACE CARDS ─── */
 .surfaces-section{
-  background:#141718;
+  background:var(--netscli-surface);
   border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
 }
 .surfaces-section::before{
@@ -101,7 +101,7 @@ const { surfaces, copy } = site;
   outline-offset:3px;
 }
 .surface-visual .codeblock{
-  background:#0b0d0e;border:1px solid rgba(var(--netscli-lift-rgb),.08);
+  background:var(--netscli-bg);border:1px solid rgba(var(--netscli-lift-rgb),.08);
   border-radius:10px;padding:16px 58px 16px 20px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:.75rem;line-height:1.7;white-space:pre;overflow-x:auto;color:var(--netscli-text);

--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -78,12 +78,16 @@ const pathname = Astro.url.pathname;
       min-width: 0;
       height: var(--sl-nav-height);
       margin: 0 auto 0 0;
-      transform: translateX(-18px);
+      /* Cancels the wordmark asset's own transparent left margin. This was a
+         flat -18px against a 12.4px margin, so the docs logo hung 5.5px
+         further left than the identical logo on the landing bar. See
+         tokens.css. */
+      transform: translateX(calc(var(--netscli-mark-width) * var(--netscli-mark-inset-ratio) * -1));
     }
 
     .docs-mark img {
       display: block;
-      width: 160px;
+      width: var(--netscli-mark-width);
       height: auto;
     }
 
@@ -174,8 +178,8 @@ const pathname = Astro.url.pathname;
         padding-inline: 1rem;
       }
 
-      .docs-mark img {
-        width: 140px;
+      .docs-mark {
+        --netscli-mark-width: 140px;
       }
 
       .docs-nav-links {
@@ -207,17 +211,13 @@ const pathname = Astro.url.pathname;
 
       .docs-mark {
         margin-right: 0;
-        transform: translateX(-8px);
+        --netscli-mark-width: 132px;
       }
 
       .docs-nav-links {
         margin-left: auto;
         gap: 0.7rem;
         font-size: 0.76rem;
-      }
-
-      .docs-mark img {
-        width: 132px;
       }
 
       .docs-header-search {

--- a/site/src/data/site-content/surfaces.ts
+++ b/site/src/data/site-content/surfaces.ts
@@ -38,30 +38,30 @@ export const surfaces: SurfaceCard[] = [
     title: 'Command line',
     body:
       'Use the CLI for repeatable diagnostics and automation. Network operations expose <code>--json</code> and <code>--yaml</code> output, so scripts and other tools can consume the same data the desktop app displays.',
-    codeHtml: `<span style="color:#888">$</span> netscli scan demo.local -p 80,443 --json
-<span style="color:#7b7b7b">[</span>
-  <span style="color:#7b7b7b">{</span> <span style="color:#7c9fc7">"port"</span>: 80,  <span style="color:#7c9fc7">"open"</span>: true, <span style="color:#7c9fc7">"service"</span>: <span style="color:#8fbc7f">"http"</span>  <span style="color:#7b7b7b">}</span>,
-  <span style="color:#7b7b7b">{</span> <span style="color:#7c9fc7">"port"</span>: 443, <span style="color:#7c9fc7">"open"</span>: true, <span style="color:#7c9fc7">"service"</span>: <span style="color:#8fbc7f">"https"</span> <span style="color:#7b7b7b">}</span>
-<span style="color:#7b7b7b">]</span>
+    codeHtml: `<span style="color:var(--netscli-code-comment)">$</span> netscli scan demo.local -p 80,443 --json
+<span style="color:var(--netscli-code-punct)">[</span>
+  <span style="color:var(--netscli-code-punct)">{</span> <span style="color:var(--netscli-code-key)">"port"</span>: 80,  <span style="color:var(--netscli-code-key)">"open"</span>: true, <span style="color:var(--netscli-code-key)">"service"</span>: <span style="color:var(--netscli-code-string)">"http"</span>  <span style="color:var(--netscli-code-punct)">}</span>,
+  <span style="color:var(--netscli-code-punct)">{</span> <span style="color:var(--netscli-code-key)">"port"</span>: 443, <span style="color:var(--netscli-code-key)">"open"</span>: true, <span style="color:var(--netscli-code-key)">"service"</span>: <span style="color:var(--netscli-code-string)">"https"</span> <span style="color:var(--netscli-code-punct)">}</span>
+<span style="color:var(--netscli-code-punct)">]</span>
 
-<span style="color:#888">$</span> netscli discover --json | jq '.[].hostname'
-<span style="color:#8fbc7f">"workstation.local"</span>
-<span style="color:#8fbc7f">"phone.local"</span>
-<span style="color:#8fbc7f">"pi.local"</span>`,
+<span style="color:var(--netscli-code-comment)">$</span> netscli discover --json | jq '.[].hostname'
+<span style="color:var(--netscli-code-string)">"workstation.local"</span>
+<span style="color:var(--netscli-code-string)">"phone.local"</span>
+<span style="color:var(--netscli-code-string)">"pi.local"</span>`,
   },
   {
     title: 'MCP server',
     body:
       'Run <code>netscli serve</code> when an MCP client needs local network tools. Discovery, scanning, ping, DNS, ARP and interfaces are all exposed as structured tools, so an agent gets the same results you would, in a shape it can parse.',
-    codeHtml: `<span style="color:#888">// claude_desktop_config.json</span>
-<span style="color:#7b7b7b">{</span>
-  <span style="color:#7c9fc7">"mcpServers"</span>: <span style="color:#7b7b7b">{</span>
-    <span style="color:#7c9fc7">"netscli"</span>: <span style="color:#7b7b7b">{</span>
-      <span style="color:#7c9fc7">"command"</span>: <span style="color:#8fbc7f">"netscli"</span>,
-      <span style="color:#7c9fc7">"args"</span>: [<span style="color:#8fbc7f">"serve"</span>]
-    <span style="color:#7b7b7b">}</span>
-  <span style="color:#7b7b7b">}</span>
-<span style="color:#7b7b7b">}</span>`,
+    codeHtml: `<span style="color:var(--netscli-code-comment)">// claude_desktop_config.json</span>
+<span style="color:var(--netscli-code-punct)">{</span>
+  <span style="color:var(--netscli-code-key)">"mcpServers"</span>: <span style="color:var(--netscli-code-punct)">{</span>
+    <span style="color:var(--netscli-code-key)">"netscli"</span>: <span style="color:var(--netscli-code-punct)">{</span>
+      <span style="color:var(--netscli-code-key)">"command"</span>: <span style="color:var(--netscli-code-string)">"netscli"</span>,
+      <span style="color:var(--netscli-code-key)">"args"</span>: [<span style="color:var(--netscli-code-string)">"serve"</span>]
+    <span style="color:var(--netscli-code-punct)">}</span>
+  <span style="color:var(--netscli-code-punct)">}</span>
+<span style="color:var(--netscli-code-punct)">}</span>`,
     flip: true,
   },
 ];

--- a/site/src/layouts/Page.astro
+++ b/site/src/layouts/Page.astro
@@ -85,6 +85,35 @@ const shouldNoindex = noindex || isPreviewBuild;
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+{/*
+  Apply the stored theme before anything paints.
+
+  Inline and first in <head> on purpose: a deferred module would run after
+  first paint and the page would flash dark before turning light, on every
+  navigation. This is the one script here that cannot be a module.
+
+  `starlight-theme` is Starlight's own localStorage key, deliberately. The
+  docs already write it, so a reader who picks light in the docs and clicks
+  through to the landing page stays in light -- which is the whole point of
+  the two halves sharing a palette.
+*/}
+<script is:inline>
+  (() => {
+    try {
+      const stored = localStorage.getItem('starlight-theme');
+      const theme =
+        stored === 'light' || stored === 'dark'
+          ? stored
+          : matchMedia('(prefers-color-scheme: light)').matches
+            ? 'light'
+            : 'dark';
+      document.documentElement.dataset.theme = theme;
+    } catch {
+      // Private mode, or storage blocked. Falling through leaves the dark
+      // default, which is what an unthemed page has always rendered.
+    }
+  })();
+</script>
 <meta name="theme-color" content={meta.themeColor} />
 <title>{title}</title>
 <meta name="description" content={description} />

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -100,7 +100,7 @@ import Footer from '../components/Footer.astro';
   font-weight:700;
 }
 .not-found-actions a.primary{
-  color:#06130f;
+  color:var(--netscli-on-accent);
   border-color:var(--netscli-accent);
   background:var(--netscli-accent);
 }
@@ -112,7 +112,7 @@ import Footer from '../components/Footer.astro';
 }
 .not-found-actions a.primary:hover,
 .not-found-actions a.primary:focus-visible{
-  color:#06130f;
+  color:var(--netscli-on-accent);
   background:var(--netscli-accent-bright);
   border-color:var(--netscli-accent-bright);
 }

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -286,7 +286,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   content:"";
   position:absolute;left:0;right:0;bottom:0;height:84px;
   pointer-events:none;
-  background:linear-gradient(180deg,rgba(25,25,25,0),rgba(25,25,25,.95) 70%,#191919);
+  background:linear-gradient(180deg,rgba(var(--netscli-bg-rgb), 0),rgba(var(--netscli-bg-rgb), .95) 70%,var(--netscli-surface));
 }
 .release-body>*+*{margin-top:14px}
 .release-summary{
@@ -330,7 +330,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
 }
 .release-body .release-code{
   position:relative;margin:0;max-width:100%;overflow-x:auto;
-  background:#20242b;border:1px solid rgba(140,149,166,.2);
+  background:var(--netscli-surface-raised);border:1px solid rgba(140,149,166,.2);
   border-radius:8px;padding:.82rem 1rem;color:var(--netscli-text);
   box-shadow:none;
 }

--- a/site/src/scripts/theme-select.ts
+++ b/site/src/scripts/theme-select.ts
@@ -1,0 +1,61 @@
+/* The landing page's theme control.
+ *
+ * Reads and writes `starlight-theme`, the same localStorage key the docs use,
+ * so a choice made on either half of the site holds on the other. The
+ * pre-paint script in Page.astro applies whatever this stores.
+ *
+ * Three values, matching the docs' own control: an explicit `light` or `dark`
+ * is stored; `auto` REMOVES the key rather than storing the word, so the page
+ * follows the operating system from then on. Storing "auto" would work too,
+ * but then the stored value and the applied value are different things and
+ * every reader of the key has to know that.
+ */
+
+type Theme = 'light' | 'dark';
+
+const KEY = 'starlight-theme';
+
+function systemTheme(): Theme {
+  return matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+}
+
+function stored(): Theme | null {
+  try {
+    const value = localStorage.getItem(KEY);
+    return value === 'light' || value === 'dark' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function apply(theme: Theme): void {
+  document.documentElement.dataset.theme = theme;
+}
+
+export function initThemeSelect(): void {
+  const select = document.querySelector<HTMLSelectElement>('[data-theme-select]');
+  if (!select) return;
+
+  // Reflect the current state rather than assuming the markup's default. The
+  // control renders with "Auto" selected, but the reader may have chosen
+  // something on a previous visit or in the docs.
+  select.value = stored() ?? 'auto';
+
+  select.addEventListener('change', () => {
+    const choice = select.value;
+    try {
+      if (choice === 'auto') localStorage.removeItem(KEY);
+      else localStorage.setItem(KEY, choice);
+    } catch {
+      // Storage blocked: the choice still applies to this page, it just will
+      // not survive a navigation. Better than doing nothing.
+    }
+    apply(choice === 'auto' ? systemTheme() : (choice as Theme));
+  });
+
+  // Follow the system while the reader is on "auto", so a theme change in the
+  // OS is picked up without a reload.
+  matchMedia('(prefers-color-scheme: light)').addEventListener('change', () => {
+    if (stored() === null) apply(systemTheme());
+  });
+}

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -12,14 +12,14 @@ html{
   scrollbar-color:rgba(140,149,166,.42) rgba(var(--netscli-lift-rgb),.035);
 }
 ::-webkit-scrollbar{width:12px;height:12px}
-::-webkit-scrollbar-track{background:#151515}
+::-webkit-scrollbar-track{background:var(--netscli-bg)}
 ::-webkit-scrollbar-thumb{
   background:rgba(140,149,166,.45);
-  border:3px solid #151515;
+  border:3px solid var(--netscli-bg);
   border-radius:999px;
 }
 ::-webkit-scrollbar-thumb:hover{background:rgba(170,178,192,.62)}
-::-webkit-scrollbar-corner{background:#151515}
+::-webkit-scrollbar-corner{background:var(--netscli-bg)}
 html[data-theme='light']{
   scrollbar-color:rgba(68,81,106,.42) rgba(241,245,249,.92);
 }
@@ -36,7 +36,7 @@ html[data-theme='light'] ::-webkit-scrollbar-corner{background:#f1f5f9}
 body{
   margin:0;
   font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
-  background:#111;color:var(--netscli-text);line-height:1.6;
+  background:var(--netscli-bg);color:var(--netscli-text);line-height:1.6;
   -webkit-font-smoothing:antialiased;
 }
 .skip-link{
@@ -47,7 +47,7 @@ body{
   padding:8px 12px;
   border:1px solid #2dd4bf;
   border-radius:6px;
-  background:#111;
+  background:var(--netscli-bg);
   color:var(--netscli-text-strong);
   transform:translateY(calc(-100% - 16px));
   transition:transform .15s ease;
@@ -89,7 +89,7 @@ code{
   padding:10px 20px;border-radius:8px;font-size:.875rem;font-weight:600;
   text-decoration:none;transition:all 120ms;
 }
-.btn-w{background:#e5e5e5;color:#111;border:1px solid #e5e5e5}
+.btn-w{background:#e5e5e5;color:var(--netscli-bg);border:1px solid #e5e5e5}
 .btn-w:hover{background:#fff;border-color:#fff}
 .btn-o{background:transparent;color:var(--netscli-text-muted);border:1px solid rgba(var(--netscli-lift-rgb),.15)}
 .btn-o:hover{color:var(--netscli-text);border-color:rgba(255,255,255,.3);text-decoration:none}
@@ -127,7 +127,7 @@ section .lead a:hover{color:var(--netscli-accent-bright)}
 .copy-btn{
   position:absolute;top:50%;right:5px;transform:translateY(-50%);
   /* Opaque background so text behind the button isn't visible through it */
-  background:#222;border:1px solid rgba(var(--netscli-lift-rgb),.12);
+  background:var(--netscli-surface-raised);border:1px solid rgba(var(--netscli-lift-rgb),.12);
   border-radius:6px;color:rgba(255,255,255,.34);
   width:27px;height:27px;padding:0;
   display:inline-flex;align-items:center;justify-content:center;
@@ -138,7 +138,7 @@ section .lead a:hover{color:var(--netscli-accent-bright)}
 .has-copy:hover .copy-btn,.has-copy:focus-within .copy-btn{opacity:1}
 .faq-command:hover .copy-btn,.faq-command:focus-within .copy-btn{opacity:1}
 .faq-command .copy-btn{right:10px}
-.copy-btn:hover{background:#2a2d32;border-color:rgba(var(--netscli-lift-rgb),.18);color:rgba(255,255,255,.58)}
+.copy-btn:hover{background:var(--netscli-surface-raised);border-color:rgba(var(--netscli-lift-rgb),.18);color:rgba(255,255,255,.58)}
 .copy-btn.copied{color:#3fb950;border-color:rgba(63,185,80,.4)}
 .surface-visual .codeblock .copy-btn,
 .tryblock .copy-btn{

--- a/site/src/styles/lightbox.css
+++ b/site/src/styles/lightbox.css
@@ -23,7 +23,7 @@
   inset:0;
   z-index:1200; /* above .skip-link's 1000 */
   padding:32px;
-  background:rgba(8,8,8,.86);
+  background:rgba(var(--netscli-bg-rgb), .86);
   backdrop-filter:blur(3px);
 }
 .image-lightbox.open{
@@ -46,7 +46,7 @@ body.lightbox-open{overflow:hidden}
   min-height:0; /* lets the image shrink inside the flex column */
   border:1px solid rgba(var(--netscli-lift-rgb),.14);
   border-radius:10px;
-  background:#0d0d0d;
+  background:var(--netscli-bg);
   overflow:hidden;
 }
 .image-lightbox-frame img{
@@ -86,13 +86,13 @@ body.lightbox-open{overflow:hidden}
   place-items:center;
   border:1px solid rgba(var(--netscli-lift-rgb),.18);
   border-radius:999px;
-  background:#1b1b1b;
+  background:var(--netscli-surface);
   color:var(--netscli-text-strong);
   font-size:1.25rem;
   line-height:1;
   cursor:pointer;
 }
-.image-lightbox-close:hover{background:#2a2d32;border-color:rgba(255,255,255,.32)}
+.image-lightbox-close:hover{background:var(--netscli-surface-raised);border-color:rgba(255,255,255,.32)}
 .image-lightbox-close:focus-visible{outline:2px solid #2dd4bf;outline-offset:2px}
 
 /* No light-theme overrides here on purpose. The lightbox only runs on the

--- a/site/src/styles/starlight/00-theme-tokens.css
+++ b/site/src/styles/starlight/00-theme-tokens.css
@@ -69,11 +69,21 @@ html[data-theme='light'] ::backdrop {
      now been raised twice: #718096 was 3.88:1 on --sl-color-bg (#fbfbfb),
      and #667387 cleared that at 4.65:1 but was still 4.44:1 on
      --sl-color-gray-6 (#f4f6f8), the card surface, which the earlier check
-     never looked at. #647084 clears every light surface: 4.84 on bg, 5.01
-     on black, 4.62 on gray-6. Do not lighten this; scripts/design-tokens.mjs
-     checks it against every surface now. The dark theme has its own gray-3
-     above and is unaffected. */
-  --sl-color-gray-3: #647084;
+     never looked at. #647084 cleared every DECLARED light surface -- 4.84 on
+     bg, 5.01 on black, 4.62 on gray-6 -- and still failed in practice, at
+     4.42:1 on the changelog's release header. Nothing there is a declared
+     surface: the card lays a 2.8% wash over the page and the header lays
+     another 1.8% over the card, and two washes nobody would call a colour
+     ate the 0.34 of headroom the value had.
+
+     That is the third time this token has been re-picked, twice to a value
+     that merely cleared the bar. #596478 is chosen with margin instead --
+     5.77 on bg, 5.27 through both changelog washes -- because the gate
+     compares declared colours and cannot see a composite, so the margin is
+     the only thing standing in for the surfaces it will never enumerate.
+     Do not lighten this. The dark theme has its own gray-3 above and is
+     unaffected. */
+  --sl-color-gray-3: #596478;
   --sl-color-gray-4: #c6d0dd;
   --sl-color-gray-5: #e3e8ef;
   --sl-color-gray-6: #f4f6f8;

--- a/site/src/styles/starlight/01-tokens-and-header.css
+++ b/site/src/styles/starlight/01-tokens-and-header.css
@@ -20,6 +20,15 @@
      same token with drifted values, which is how the contents rail ended up
      unable to match it at all. */
   --netscli-sidebar-rail-inset: clamp(2.2rem, 3vw, 3.15rem);
+  /* Height of the title band at the top of every docs page.
+     Declared here because two rules need to agree on it: the band's own
+     min-height in 11-docs-chrome-consistency.css, and the offset that starts
+     the contents rail below it in 03-shell-layout-base.css. Measured across
+     all eleven docs pages at five widths, the band is exactly this value plus
+     its 1px bottom border on every one of them -- no page's title wraps -- so
+     the offset can be a shared expression rather than a tracked measurement.
+     Change it here and both move together. */
+  --netscli-docs-hero-height: clamp(6.75rem, 9vw, 8.25rem);
   --netscli-docs-frame-width: calc(
     var(--netscli-shell-width) + var(--netscli-docs-sidebar-width) + var(--netscli-docs-toc-width)
   );

--- a/site/src/styles/starlight/03-shell-layout-base.css
+++ b/site/src/styles/starlight/03-shell-layout-base.css
@@ -55,6 +55,19 @@
      * right one ended 40px from it. Same two values, mirrored: outer inset
      * matches outer inset, inner matches inner. */
     padding-inline: 1.85rem var(--netscli-sidebar-rail-inset, clamp(2.2rem, 3vw, 3.15rem));
+
+    /* Start below the title band, not beside it.
+     *
+     * The contents list began at the top of the content column, so it sat
+     * level with the page title inside the band -- reading as a second
+     * heading on the same row rather than as navigation for the body below.
+     * The band's height plus its 1px bottom border puts the panel's top edge
+     * exactly on the band's bottom edge, so its own left divider starts where
+     * the band's underline ends instead of crossing it.
+     *
+     * A margin rather than padding: the divider is a border on this element,
+     * so padding would leave the line running up beside the band. */
+    margin-block-start: calc(var(--netscli-docs-hero-height) + 1px);
   }
 
   .content-panel {

--- a/site/src/styles/starlight/11-docs-chrome-consistency.css
+++ b/site/src/styles/starlight/11-docs-chrome-consistency.css
@@ -62,7 +62,7 @@ html[data-theme='light'][data-docs-scrolled='true'] header.header {
 .main-pane > .content-panel:first-child > .sl-container,
 .main-pane > main > .content-panel:first-of-type > .sl-container,
 .main-pane > main > .content-panel:first-child > .sl-container {
-  min-height: clamp(6.75rem, 9vw, 8.25rem);
+  min-height: var(--netscli-docs-hero-height);
   padding-block: clamp(1.2rem, 2vw, 1.7rem) !important;
   padding-inline: clamp(1.75rem, 2.2vw, 2.5rem) !important;
   display: flex;

--- a/site/src/styles/starlight/17-mobile-shell-closeout-a.css
+++ b/site/src/styles/starlight/17-mobile-shell-closeout-a.css
@@ -16,8 +16,6 @@
     padding-inline-start: max(0.65rem, env(safe-area-inset-left)) !important;
     padding-inline-end: max(0.5rem, env(safe-area-inset-right)) !important;
 
-  }.docs-mark img {
-    width: 132px !important;
   }
 
   .docs-header-search {

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -196,10 +196,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   }
 }
 
-@media (max-width: 49.99rem) {.docs-mark {
-    transform: translateX(-24px) !important;
-  }
-
+@media (max-width: 49.99rem) {
   .sidebar-pane[aria-hidden='false'],
   .sidebar-pane:not([aria-hidden]) {
     inset-block-start: calc(var(--sl-nav-height) + 0.65rem) !important;

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -33,6 +33,40 @@
   --netscli-nav-height: 3.75rem;
   --netscli-shell-width: 72rem;
 
+  /* ---- Wordmark ------------------------------------------------------
+   *
+   * netscli-wordmark.png is 720px wide and its first 56 columns are fully
+   * transparent, so the glyph starts 7.78% of the rendered width in. Every
+   * bar that shows it has to pull it back by that much, or the logo sits
+   * indented while the nav links beside it start at the gutter.
+   *
+   * Five rules did that with five different hand-tuned pixel values --
+   * -10px on the landing bar, -18px on the docs bar, -8px below 72rem,
+   * -24px !important below 50rem, and nothing at all on the landing page's
+   * narrow breakpoint -- so no two bars agreed. Measured against the asset,
+   * the docs bar overshot by 5.5px at desktop and by 14px below 50rem, which
+   * is the indent that looked wrong.
+   *
+   * A ratio rather than a length because the transparent margin scales with
+   * the rendered width, so the compensation has to as well: a breakpoint
+   * that narrows the wordmark sets --netscli-mark-width and the inset
+   * follows. Do not pre-compose the two into a single length token -- a
+   * var() inside a custom property resolves where it is DECLARED, so the
+   * composed value would freeze at whatever :root said and quietly ignore
+   * every breakpoint.
+   *
+   * scripts/wordmark-inset.mjs re-derives the ratio from the PNG itself and
+   * fails if this value has drifted from it. */
+  --netscli-mark-width: 160px;
+  --netscli-mark-inset-ratio: 0.0778;
+
+  /* Tells the browser which way to draw the controls it renders itself: the
+   * <select> popup in the theme control, native focus rings, and form
+   * widgets. Starlight declares this for the docs in its own reset, which is
+   * why the docs popup was already dark and the landing page's -- which
+   * never loads that reset -- was drawn white over a near-black bar. */
+  color-scheme: dark;
+
   /* Brand accent.
    *
    * Was #0aae7a, which sits at hue 160 -- right on the green/teal boundary.
@@ -125,6 +159,8 @@
  * changelog resolve them too. Values match the docs light theme exactly, so
  * the two stacks cannot disagree about what "light" means. */
 html[data-theme='light'] {
+  color-scheme: light;
+
   --netscli-accent-rgb: 20, 107, 46;
   --netscli-hairline-rgb: 17, 24, 39;
   /* On a light surface, raised is DARKER. See the note in the docs' token

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -90,6 +90,37 @@
   --netscli-accent-bright: #86efac;
   /* Pale tint for active text on dark surfaces. */
   --netscli-accent-high: #a7f3c6;
+  /* Text drawn ON the accent, where the accent is a fill rather than ink.
+     A literal near-black in 404.astro until the light theme existed, at
+     which point it became near-black on a dark green button. */
+  --netscli-on-accent: #06130f;
+
+  /* ---- Code sample colours -------------------------------------------
+   *
+   * The landing page's terminal and JSON samples are pre-highlighted HTML in
+   * src/data/site-content/, and their spans carried inline
+   * `style="color:#..."` literals -- four values, 32 uses, all picked for a
+   * near-black background. An inline style cannot be overridden by a
+   * stylesheet, so when the landing page gained a light theme these stayed
+   * mid-grey and pastel on white and were the bulk of its 23 contrast
+   * failures. They are var() references now, which inline styles DO resolve
+   * per theme.
+   *
+   * The two blue and green values are the original literals exactly. The two
+   * neutrals are not: naming them made them reachable by
+   * scripts/design-tokens.mjs, which measured the punctuation grey at 4.46:1
+   * on the page and 3.99:1 on a card -- below AA and wrong since long before
+   * the light theme. axe had not caught it because its dark pass ran under
+   * `--force-dark-mode`, which re-tints the page and so measured a colour
+   * nobody wrote. They are lifted to 6.71:1 and 5.47:1 here.
+   *
+   * They were also #888888 and #7b7b7b, a 3% difference no reader can see,
+   * which made the comment/punctuation distinction decorative. The new pair
+   * is far enough apart to read as two things. */
+  --netscli-code-comment: #9a9a9a;
+  --netscli-code-punct: #8a8a8a;
+  --netscli-code-key: #7c9fc7;
+  --netscli-code-string: #8fbc7f;
 
   /* ---- Cross-stack role channels -------------------------------------
    *
@@ -161,7 +192,34 @@
 html[data-theme='light'] {
   color-scheme: light;
 
+  /* The accent, as a colour and as channels.
+   *
+   * Only the -rgb form was overridden here until now, so every
+   * `color: var(--netscli-accent)` call site kept rendering the DARK #22c55e
+   * on a white page -- 2.0:1, and the single largest source of the light
+   * theme's contrast failures. It went unnoticed because the a11y check's
+   * light pass was passing no colour-scheme flag and so tested dark twice on
+   * a dark-mode workstation; see scripts/a11y.mjs.
+   *
+   * Depth inverts with the theme here as it does for surfaces: "bright" is a
+   * hover state, which means further from the page, so on white it is DARKER
+   * than the base accent rather than lighter. */
+  --netscli-accent: #146b2e;
   --netscli-accent-rgb: 20, 107, 46;
+  --netscli-accent-bright: #0e5122;
+  --netscli-accent-high: #0a3d19;
+  /* White on the accent fill: 6.62:1 against #146b2e, where the dark theme's
+     near-black would be 1.7:1. */
+  --netscli-on-accent: #ffffff;
+
+  /* The code sample palette, re-picked for a white background. Same four
+     roles, same hue families -- neutral, neutral, blue, green -- at
+     5.22:1, 7.59:1, 6.38:1 and 6.21:1 against the page. */
+  --netscli-code-comment: #5f6b7d;
+  --netscli-code-punct: #4a5262;
+  --netscli-code-key: #2b5f96;
+  --netscli-code-string: #2f6b32;
+
   --netscli-hairline-rgb: 17, 24, 39;
   /* On a light surface, raised is DARKER. See the note in the docs' token
      file for the 27 rules that had this backwards. */
@@ -175,7 +233,7 @@ html[data-theme='light'] {
      against every surface by scripts/design-tokens.mjs. */
   --netscli-text-strong: #111827;
   --netscli-text: #44516a;
-  --netscli-text-muted: #647084;
+  --netscli-text-muted: #596478;
 
   /* Light surfaces, again the docs' own: --sl-color-bg, gray-6, and the
      panel. Depth inverts with the theme -- a raised surface is lighter than

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -45,8 +45,7 @@
    * The -rgb form is the same colour as a bare triple, for the rgba() call
    * sites that need an alpha. There were 108 hard-coded copies of the old
    * value across 20 files before this; changing it should be one edit here.
-   * The docs light theme keeps its own darker pair in
-   * starlight/01-tokens-and-header.css, as it did before. */
+   * The light theme's darker accent is in the light block below. */
   --netscli-accent: #22c55e;
   --netscli-accent-rgb: 34, 197, 94;
   /* Hover and other lifted states.
@@ -61,7 +60,7 @@
   /* ---- Cross-stack role channels -------------------------------------
    *
    * These moved up from starlight/00-theme-tokens.css, which only the docs
-   * load. The landing page and the changelog need the same three roles to be
+   * load. The landing page and the changelog need these roles to be
    * themeable at all, and a second copy of them under different names is how
    * the two halves of this site drifted apart in the first place.
    *
@@ -97,9 +96,30 @@
   --netscli-text-strong: #f4f4f4;
   --netscli-text: #c2cad8;
   --netscli-text-muted: #8c95a6;
+
+  /* ---- Surfaces -------------------------------------------------------
+   *
+   * Three depths, from the same 21 opaque backgrounds the landing stack had
+   * spread across 32 declarations. They fell into three tight luminance
+   * bands with nothing between them -- eight values from #0a0a0a to #151515
+   * doing the page, six from #141718 to #1b1b1b doing panels, three from
+   * #222 to #2a2d32 doing the layer above -- so the bands were real and only
+   * the exact values inside them were arbitrary.
+   *
+   * Values are the docs' --sl-color-bg, gray-6 and the panel surface, so a
+   * card on the landing page and a card in the docs are finally the same
+   * colour. */
+  --netscli-bg: #111111;
+  --netscli-surface: #191d25;
+  --netscli-surface-raised: #20242b;
+  /* The page background as channels, for the translucent bars drawn over
+     content: the sticky nav, the mobile menu, the lightbox scrim. Those were
+     four slightly different near-black rgba() values -- 17/17/17, 22/24/26,
+     25/25/25, 8/8/8 -- none of which could follow a theme. */
+  --netscli-bg-rgb: 17, 17, 17;
 }
 
-/* The light theme's overrides of the three roles above.
+/* The light theme's overrides of everything above.
  *
  * Set here rather than in the docs' own token file so the landing page and
  * changelog resolve them too. Values match the docs light theme exactly, so
@@ -120,4 +140,13 @@ html[data-theme='light'] {
   --netscli-text-strong: #111827;
   --netscli-text: #44516a;
   --netscli-text-muted: #647084;
+
+  /* Light surfaces, again the docs' own: --sl-color-bg, gray-6, and the
+     panel. Depth inverts with the theme -- a raised surface is lighter than
+     the page in the dark theme and darker than it here -- which is why these
+     are named for depth rather than for a colour. */
+  --netscli-bg: #fbfbfb;
+  --netscli-surface: #f4f6f8;
+  --netscli-surface-raised: #f6f8fa;
+  --netscli-bg-rgb: 251, 251, 251;
 }


### PR DESCRIPTION
The three remaining items from the light-theme review — **plus a false green I need to correct.**

## Correction first

I reported PR #310 as passing axe in both themes. **It never did**; CI had been failing it since it was opened. I stated a local result as if it were CI's, and the local run could not have caught the failure.

`scripts/a11y.mjs` ran its light pass with **no colour-scheme flag at all**, on the reasoning that light *is* the default when the runner expresses no preference. True on Ubuntu, false on a workstation, where Chrome inherits the OS setting. On a dark-mode desktop both passes rendered dark and reported a clean run — the same environment-dependence that block was written to remove, moved one step along.

Both passes now set `blink-settings=preferredColorScheme` explicitly. The dark pass loses `--force-dark-mode` with it: that flag is Chrome's *automatic darkening of pages that have no dark theme*, so it re-tinted an already-dark page and measured colours nobody wrote.

Sabotage-checked both directions on a dark-mode machine, against a light theme deliberately broken by restoring the dark accent: the old unflagged pass reports **0 violations, exit 0**; the fixed one reports **6, exit 1**.

### What it was hiding

- **`--netscli-accent`, `-bright` and `-high` had no light override.** Only the `-rgb` twin did, and channels are invisible to a contrast check — so every `color: var(--netscli-accent)` rendered the dark `#22c55e` on a white page at **2.0:1**. Most of the landing page's 23 violations and the changelog's 10.
- **The landing page's code samples** are pre-highlighted HTML with inline `style="color:#..."` literals — four values, 32 uses, all picked for a near-black background, and an inline style cannot be overridden by a stylesheet. They are `var()` references now, which inline styles *do* resolve per theme.
- **`404.astro`** drew near-black text on `background: var(--netscli-accent)`. Fine on the dark accent, **1.7:1** on the light one.

### Two more, found by fixing the check rather than by the report

- Naming the code colours made them reachable by the contrast gate, which measured the punctuation grey at **4.46:1** on the page and **3.99:1** on a card — below AA, and wrong since long before the light theme. axe had missed it because `--force-dark-mode` was re-tinting the page underneath it.
- `--sl-color-gray-3` / `--netscli-text-muted` cleared every *declared* light surface at 4.62–5.01 and still failed at **4.42:1** on the changelog's release header, where a 2.8% card wash and a 1.8% header wash compound under it. **Third time this token has been re-picked, twice to a value that merely cleared the bar.** `#596478` is chosen with margin — 5.77 on the page, 5.27 through both washes — because the gate compares declared colours and cannot see a composite.

The gate now also covers the accent-as-ink and the four code colours: 148 pairs → **204**.

---

## The wordmark's indent

`netscli-wordmark.png` is 720px wide and its first **56 columns are fully transparent** — the glyph starts 7.78% of the rendered width in. Every bar showing it has to pull it back by that much, or the logo sits indented while the links beside it start on the gutter.

Five rules did that, with five different hand-tuned values:

| where | declared | actual margin |
|---|---|---|
| landing bar | `-10px` | 12.4px |
| docs bar | `-18px` | 12.4px |
| docs, ≤72rem | `-8px` | 10.9px |
| docs, ≤50rem | `-24px !important` | 10.3px |
| landing, ≤600px | *(none)* | 10.3px |

The docs bar overshot by **5.56px** at desktop and **13.7px** below 50rem. That is the indent that looked wrong.

They collapse to one ratio plus a `--netscli-mark-width` per breakpoint. A ratio because the margin scales with the rendered width — and deliberately *not* pre-composed into one length token, because a `var()` inside a custom property resolves where it is **declared**, so the composed value would freeze at `:root`'s 160px and silently ignore every breakpoint.

Verified at 11 widths on both bars — 22 measurements, **off by 0.00px in every one**.

`scripts/wordmark-inset.mjs` re-derives the ratio from the PNG's alpha channel and fails on drift. Machinery for a cosmetic value normally would not earn its place; it earns it here because the value was already wrong five times, a few pixels of indent renders as plausible and nobody re-checks it, and re-exporting the asset would invalidate the token with nothing else noticing. Sabotage-checked.

## The contents rail

It started at the top of the content column, level with the page title *inside* the title band — reading as a second heading rather than as navigation for the body below. It now starts on the band's bottom edge.

Fixed-offset vs tracking resolves to neither: the band's height is a `clamp()` we declare ourselves, so both rules share one token. Measured across all 11 docs pages at 5 widths first, because a per-page difference would have ruled that out — the band is the same height on every page at a given width, and the rail's top now lands within 0.2px of the band's bottom everywhere tested.

## color-scheme

Starlight declares it per theme in its own reset, which only the docs load. The landing page and changelog had none, so the browser drew their native `<select>` popup **white over a near-black bar**. Confirmed absent from the previous build's landing HTML and present in its docs HTML.

The explicit `option` colours stay: whether a platform's popup honours `color-scheme` alone is not something this repo can check — the popup is a separate OS window and does not appear in a page screenshot.

## Gates

axe 0 violations across 14 pages in both themes (**with the light pass actually rendering light**), 204 contrast pairs >= 4.5:1, dead CSS 14/14, `astro check`, changelog dates, file-size, app doc links, wordmark inset. Visual baseline re-recorded.

**Supersedes #310** — this branch contains that commit, so #310 should not be merged separately.
