### PR TITLE
Collapse both nav bars at the same width

### DIFF
--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -145,13 +145,6 @@ body.nav-scrolled nav[data-site-nav]::after{
   display:block;width:var(--netscli-mark-width);height:auto;image-rendering:auto;
 }
 .mark:hover{filter:brightness(1)}
-@media(max-width:600px){
-  /* Narrows the wordmark AND its inset -- the transparent margin is a
-     fraction of the rendered width, so a fixed pull-back would over-correct
-     here. This breakpoint used to change only the width, leaving the desktop
-     -10px in place against a 10.3px margin. */
-  .mark{--netscli-mark-width:132px}
-}
 .nav-menu-toggle{
   display:none;
   width:2.45rem;
@@ -277,6 +270,9 @@ body.nav-scrolled nav[data-site-nav]::after{
   .nav-inner{padding:10px 18px;gap:10px 16px}
   .nlinks{font-size:.8rem}
 }
+/* The bar collapses here. The docs bar collapses at the same width, in
+   starlight/Header.astro -- see the note there for why the number is written
+   in both files rather than shared. */
 @media(max-width:900px){
   .nav-inner{flex-wrap:nowrap}
   .nav-menu-toggle{display:inline-flex}

--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -178,10 +178,6 @@ const pathname = Astro.url.pathname;
         padding-inline: 1rem;
       }
 
-      .docs-mark {
-        --netscli-mark-width: 140px;
-      }
-
       .docs-nav-links {
         gap: 0.75rem;
         font-size: 0.78rem;
@@ -194,6 +190,13 @@ const pathname = Astro.url.pathname;
         min-width: 7.75rem;
       }
 
+    }
+
+    /* Same width the landing bar collapses at -- see the note on
+       .docs-nav-links below. The theme control moves into the mobile menu's
+       footer at this point (MobileMenuFooter.astro), so it is relocated
+       rather than lost. */
+    @media (max-width: 900px) {
       .docs-header-theme {
         display: none !important;
       }
@@ -211,7 +214,6 @@ const pathname = Astro.url.pathname;
 
       .docs-mark {
         margin-right: 0;
-        --netscli-mark-width: 132px;
       }
 
       .docs-nav-links {
@@ -230,7 +232,19 @@ const pathname = Astro.url.pathname;
 
     }
 
-    @media (max-width: 72rem) {
+    /* 900px, matching the landing bar's own collapse in Nav.astro.
+     *
+     * This was 72rem (1152px), so between 901 and 1152 the docs bar showed a
+     * hamburger while the landing bar showed the same six links -- the two
+     * halves of one site with visibly different navigation, and the shape of
+     * the bar changing under the cursor when you clicked "Docs".
+     *
+     * Nothing forced the early collapse: measured at 901px the bar's contents
+     * come to 476px against 842px of room, with the wordmark at its full size
+     * and search already reduced to its icon. If you change this, change
+     * Nav.astro's `@media(max-width:900px)` with it; a media query cannot read
+     * a custom property, so the number genuinely has to be written twice. */
+    @media (max-width: 900px) {
       .docs-nav-links {
         display: none;
       }

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -66,11 +66,14 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   box-shadow: none !important;
 }
 
+/* The `.docs-nav-links { display: none !important }` that used to head this
+   block is gone. It was a second copy of the collapse rule Header.astro
+   already had, and being unlayered and !important it was the one that
+   actually won -- so moving the breakpoint in the component did nothing, and
+   the docs bar kept collapsing 250px before the landing bar. Header.astro
+   owns it now; nothing else on the page selects .docs-nav-links, so there is
+   no layered-vs-unlayered fight left to have. */
 @media (max-width: 72rem) {
-  .docs-nav-links {
-    display: none !important;
-  }
-
   .docs-topbar {
 
     gap: 0.45rem !important;

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -184,6 +184,27 @@
   --netscli-bg-rgb: 17, 17, 17;
 }
 
+/* The wordmark's one size step, for both bars.
+ *
+ * It was three different ladders: the landing bar went 160 -> 132 at 600px,
+ * the docs bar went 160 -> 140 -> 132 at 72rem, and an override file forced
+ * 132 again below 50rem. So at a 1000px window the same logo was 160px on
+ * the landing page and 132px in the docs, and clicking "Docs" visibly
+ * resized it.
+ *
+ * The docs bar had no need of the early steps: measured at 901px it uses
+ * 476px of the 842px available, 366px spare, even with the search icon and
+ * the full link list. It was shrinking to make room it already had.
+ *
+ * Declared on :root rather than on each bar's own class so the inset
+ * ratio above resolves against it -- see the note there about var() in a
+ * custom property resolving where it is declared. */
+@media (max-width: 600px) {
+  :root {
+    --netscli-mark-width: 132px;
+  }
+}
+
 /* The light theme's overrides of everything above.
  *
  * Set here rather than in the docs' own token file so the landing page and


### PR DESCRIPTION
Moving between the landing page and the docs was meant to look seamless. It didn't, and search wasn't the reason.

## The seam

| | landing | docs |
|---|---|---|
| collapsed to a burger at | **≤900px** | **≤1152px** |
| wordmark size ladder | 160 → 132 at 600px | 160 → **140** → 132 at 72rem, and 132 again below 50rem |

So between 901 and 1152 the docs showed a hamburger while the landing page showed the same six links — and at 1000px the same logo was 160px on one page and 132px on the other. Clicking "Docs" changed the shape of the bar you clicked it in.

**Nothing forced it.** Measured at 901px the docs bar's contents come to **476px against 842px of room** — 366px spare, with the wordmark at full size and search already reduced to its icon. It was shrinking to make room it already had.

## Moving it meant deleting a rule, not editing one

`Header.astro`'s `.docs-nav-links { display: none }` was shadowed by a second copy in `20-docs-shell-closeout.css` that was unlayered and `!important`, so *that* was the one taking effect. Changing the breakpoint in the component did nothing at all until the copy was gone.

Nothing else on the page selects that class, so there's no layered-vs-unlayered fight left to have.

## Search stays docs-only

Deliberate. It's a docs affordance — the landing page is a single scroll with a scroll-spy nav and nothing on it to search, and Pagefind's bundle would land on the page where first paint matters most. With the breakpoint fixed it's the only element that differs, alongside Starlight's sidebar toggle, which the landing page has no sidebar to need.

## Verified

Ten widths on both bars. Bar height, wordmark size, link count and collapse state agree at **every one**, and the wordmark's glyph still lands exactly on each bar's content edge — 0.00px at all ten.

**One difference measured and left in:** below 600px the landing bar is 60.19px against the docs' 60.00px, because its menu button is 39.2px inside 20px of padding. Under a fifth of a pixel; rounds to the same row at every device pixel ratio. Recorded rather than chased.

## Gates

axe 0 violations across 14 pages in both themes, 204 contrast pairs ≥ 4.5:1, dead CSS 14/14, `astro check`, changelog dates, file size, app doc links, wordmark inset.

43 visual captures moved — **all docs pages, all at 1100 and 700**, the two bands this touches. No landing, changelog or 404 capture moved at any width. Baseline re-recorded.