### PR TITLE
Collapse the changelog's release cards before the first frame

### DIFF
--- a/site/src/layouts/Page.astro
+++ b/site/src/layouts/Page.astro
@@ -100,7 +100,18 @@ const shouldNoindex = noindex || isPreviewBuild;
   through to the landing page stays in light -- which is the whole point of
   the two halves sharing a palette.
 */}
+{/*
+  `data-js` marks "scripts run here", set before the first frame.
+
+  It gates CSS that would be wrong for a reader without JavaScript -- today,
+  the changelog's collapsed release cards, which need a "Show more" button to
+  be usable and so must not be clamped when nothing can wire that button up.
+  Set here rather than in a module for the same reason as the theme above: a
+  module runs after first paint, and a clamp applied then is a layout jump
+  instead of a layout.
+*/}
 <script is:inline>
+  document.documentElement.dataset.js = '';
   (() => {
     try {
       const stored = localStorage.getItem('starlight-theme');

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -274,15 +274,28 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
 .release-body :where(p, li, blockquote, h3, h4, h5, a, span, strong, em){
   min-width:0;max-width:100%;overflow-wrap:anywhere;word-break:normal;
 }
-.release-collapsible .release-body{
+/* The clamp, and the button that undoes it, are gated on scripts running.
+ *
+ * `data-js` is set by the pre-paint inline script in Page.astro, so the clamp
+ * is in effect before the first frame. Without it the release notes render at
+ * full height, which is what a reader with no JavaScript should get -- and
+ * they get no "Show more" button that could not do anything either.
+ *
+ * The markup is identical in both cases: every card ships collapsible. That is
+ * the point. Deciding per-card needs a measurement that does not exist before
+ * layout, and making the page wait for it is what had the changelog painting
+ * at ~10,700px and snapping to ~3,750px on every visit. */
+html[data-js] .release-collapsible .release-body{
   max-height:var(--release-collapsed-height, 300px);
   overflow:hidden;
   transition:max-height 220ms ease;
 }
-.release-collapsible.release-expanded .release-body{
+html[data-js] .release-collapsible.release-expanded .release-body{
   max-height:var(--release-expanded-height, 1200px);
 }
-.release-collapsible:not(.release-expanded) .release-body::after{
+.release-disclosure{display:none}
+html[data-js] .release-collapsible .release-disclosure{display:flex}
+html[data-js] .release-collapsible:not(.release-expanded) .release-body::after{
   content:"";
   position:absolute;left:0;right:0;bottom:0;height:84px;
   pointer-events:none;
@@ -360,7 +373,8 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   border:1px dashed rgba(var(--netscli-lift-rgb),.12);border-radius:10px;padding:16px;
 }
 .release-disclosure{
-  display:flex;justify-content:center;
+  /* `display` is set above, gated on data-js. */
+  justify-content:center;
   padding:4px 20px 22px;
   margin-top:-4px;
 }

--- a/site/src/scripts/changelog/release-list.ts
+++ b/site/src/scripts/changelog/release-list.ts
@@ -37,39 +37,75 @@ function mergeRelease(
   };
 }
 
-export function setupReleaseDisclosure(item: HTMLElement, body: HTMLElement, index: number): void {
-  const collapsedHeight = window.matchMedia('(max-width: 42rem)').matches ? 260 : 300;
-  const minimumOverflow = 80;
+/**
+ * Emit the collapsed structure. Runs at BUILD time as well as in the browser,
+ * and measures nothing.
+ *
+ * It used to measure: `scrollHeight` after a `requestAnimationFrame`, to decide
+ * whether a card was long enough to be worth collapsing. That decision cannot
+ * exist before layout, so the page shipped every release fully expanded and
+ * collapsed them once a module had run -- painting at about 10,700px and
+ * snapping to about 3,750px a moment later. A ~7,000px jump on every visit.
+ *
+ * So the decision moved off the critical path rather than being made faster.
+ * Every card is collapsible in the markup; the CSS only applies the clamp
+ * under `html[data-js]`, which the pre-paint script in Page.astro sets, so the
+ * clamp is in effect before the first frame and a reader without JavaScript
+ * still gets the full notes and no dead button.
+ *
+ * `hydrateReleaseDisclosures` then corrects the rare card that turns out to be
+ * short enough not to need it. Measured across all eight releases at 1600,
+ * 1100, 700 and 420: every one exceeds the threshold at every width, the
+ * narrowest margin being 405px against 380. So the correction is a no-op
+ * today, and the shift it can cause is bounded by the threshold rather than by
+ * the length of the release notes.
+ */
+export function renderReleaseDisclosure(item: HTMLElement, body: HTMLElement, index: number): void {
   const bodyId = `release-body-${index}`;
   body.id = bodyId;
+  item.classList.add('release-collapsible');
 
-  requestAnimationFrame(() => {
-    if (body.scrollHeight <= collapsedHeight + minimumOverflow) return;
+  const disclosure = el('div', 'release-disclosure');
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'release-toggle';
+  button.setAttribute('aria-controls', bodyId);
+  button.setAttribute('aria-expanded', 'false');
+  button.setAttribute('aria-label', 'Show full release notes');
+  button.textContent = 'Show more';
+  disclosure.append(button);
+  item.append(disclosure);
+}
 
-    item.classList.add('release-collapsible');
-    body.style.setProperty('--release-collapsed-height', `${collapsedHeight}px`);
+/**
+ * Wire the toggle rendered above, and drop the collapse from any card that
+ * does not need one.
+ *
+ * `scrollHeight` reports the full content height even while `max-height` is
+ * clipping it, so the check still works against an already-collapsed card.
+ */
+export function setupReleaseDisclosure(item: HTMLElement, body: HTMLElement): void {
+  const collapsedHeight = window.matchMedia('(max-width: 42rem)').matches ? 260 : 300;
+  const minimumOverflow = 80;
+  const button = item.querySelector<HTMLButtonElement>('.release-toggle');
+  if (!button) return;
+
+  if (body.scrollHeight <= collapsedHeight + minimumOverflow) {
+    item.classList.remove('release-collapsible');
+    item.querySelector('.release-disclosure')?.remove();
+    return;
+  }
+
+  body.style.setProperty('--release-collapsed-height', `${collapsedHeight}px`);
+
+  button.addEventListener('click', () => {
+    const expanded = !item.classList.contains('release-expanded');
     body.style.setProperty('--release-expanded-height', `${body.scrollHeight}px`);
-
-    const disclosure = el('div', 'release-disclosure');
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'release-toggle';
-    button.setAttribute('aria-controls', bodyId);
-    button.setAttribute('aria-expanded', 'false');
-    button.setAttribute('aria-label', 'Show full release notes');
-    button.textContent = 'Show more';
-    disclosure.append(button);
-    item.append(disclosure);
-
-    button.addEventListener('click', () => {
-      const expanded = !item.classList.contains('release-expanded');
-      body.style.setProperty('--release-expanded-height', `${body.scrollHeight}px`);
-      item.classList.toggle('release-expanded', expanded);
-      button.setAttribute('aria-expanded', String(expanded));
-      button.setAttribute('aria-label', expanded ? 'Collapse release notes' : 'Show full release notes');
-      button.textContent = expanded ? 'Show less' : 'Show more';
-      if (!expanded) item.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-    });
+    item.classList.toggle('release-expanded', expanded);
+    button.setAttribute('aria-expanded', String(expanded));
+    button.setAttribute('aria-label', expanded ? 'Collapse release notes' : 'Show full release notes');
+    button.textContent = expanded ? 'Show less' : 'Show more';
+    if (!expanded) item.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
   });
 }
 
@@ -139,24 +175,27 @@ export function renderReleaseList(
     const body = renderMarkdown(release.body || '', release, repo, releaseSummaries);
     item.append(header, body);
     list.appendChild(item);
-    if (interactive) setupReleaseDisclosure(item, body, index);
+    // Always rendered, at build time as well as in the browser -- the markup
+    // no longer depends on a measurement. Only the wiring does.
+    renderReleaseDisclosure(item, body, index);
+    if (interactive) setupReleaseDisclosure(item, body);
   }
   updateReleaseTimeline(releases.map((release) => mergeRelease(release, fallbackByTag, releaseSummaries)));
   return true;
 }
 
 /**
- * Attach the collapse affordance to cards that were rendered at build time.
+ * Make the build-rendered toggles work.
  *
- * The server render skips it because it measures `scrollHeight`, which is 0
- * without layout. This runs once on load, against the markup already on the
- * page, so the notes are readable before any script runs and gain the
- * collapse once one does.
+ * The cards arrive already collapsed -- see renderReleaseDisclosure -- so this
+ * attaches click handlers and nothing about the page moves. It used to be the
+ * step that introduced the collapse, which is what made the changelog jump on
+ * every load.
  */
 export function hydrateReleaseDisclosures(): void {
   const items = document.querySelectorAll<HTMLElement>('#release-list .release-item');
-  items.forEach((item, index) => {
+  items.forEach((item) => {
     const body = item.querySelector<HTMLElement>('.release-body');
-    if (body) setupReleaseDisclosure(item, body, index);
+    if (body) setupReleaseDisclosure(item, body);
   });
 }


### PR DESCRIPTION
The changelog painted at ~10,700px and snapped to ~3,750px a moment later, on every visit. A **~7,000px jump**.

## Where the problem actually was

Not in how fast the collapse ran — in *where the decision lived*. Each card was collapsed only if it was long enough to be worth collapsing, and that needs `scrollHeight`, which needs layout. So the page shipped every release fully expanded and a module collapsed them afterwards.

The decision moved off the critical path instead of being made faster. Every card now ships **collapsible in the markup**, built at render time and measuring nothing. The CSS applies the clamp only under `html[data-js]`, set by the pre-paint inline script in `Page.astro` — so the clamp is in effect before the first frame.

## The no-JS behaviour is unchanged

That's the constraint the old design was paying for, and it still holds. Without `data-js` there's no clamp and no "Show more" button, so a reader with no JavaScript gets the full notes and no dead control.

Verified with scripting disabled: **10746px, `max-height: none`, disclosure `display: none`.**

## What the runtime still does

`hydrateReleaseDisclosures` now only wires click handlers, plus one correction: a card whose content genuinely fits loses its collapse and its toggle. (`scrollHeight` reports full content height even while `max-height` is clipping, so the check works against an already-collapsed card.)

Measured across all eight releases at 1600, 1100, 700 and 420: **every one exceeds the threshold at every width**, the narrowest margin being 405px against 380. So the correction is a no-op today, and any shift it *can* cause is bounded by the threshold rather than by the length of the release notes.

## Measured

Height polled every 60ms after load, three runs each:

```
before:  10746  3752  3752  3752 ...   (the jump, every run)
after:    3752  3752  3752  3752 ...   (all three runs)
```

Toggle behaviour re-tested end to end: rest 300px / "Show more" / `aria-expanded=false` → expanded 2681px / "Show less" / `aria-expanded=true` → back, with `aria-controls` matching the body id throughout.

## Gates

axe 0 violations across 14 pages in both themes, 204 contrast pairs ≥ 4.5:1, dead CSS 14/14, `astro check`, changelog dates, file size, app doc links, wordmark inset.

**All 84 visual captures identical.** The rendered page doesn't change — only when it reaches that state.
