### PR TITLE
Stop the contents rail at the title band, and square up two insets

### DIFF
--- a/site/src/styles/starlight/02-search-and-sidebar-base.css
+++ b/site/src/styles/starlight/02-search-and-sidebar-base.css
@@ -152,6 +152,14 @@ html[data-theme='light'] starlight-menu-button[aria-expanded='true'] button {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-weight: 760;
+  /* Flush right, so the group's chevron lines up with the right edge of the
+     current page's highlight rather than sitting 8px inside it.
+
+     Upstream pads the summary equally on both sides, which put the chevron at
+     239.2px while the highlight below it ran to 247.2px -- reading as a
+     background that spilled past the control it was meant to sit under. The
+     links set their own inline padding, so only this side needs unsetting. */
+  padding-inline-end: 0;
 }
 
 .sidebar-content a {

--- a/site/src/styles/starlight/03-shell-layout-base.css
+++ b/site/src/styles/starlight/03-shell-layout-base.css
@@ -1,8 +1,9 @@
 /* Main-frame/sidebar responsive layout and main-pane/content-panel base overrides. */
 
-.right-sidebar-panel {
-  border-inline-start: 1px solid var(--sl-color-hairline);
-}
+/* The divider between the content column and the contents rail is drawn in
+   13-docs-rail-alignment.css -- not here, and not by Starlight's border on
+   .right-sidebar, which is fixed and full-height and so ran straight up
+   through the title band. */
 
 /* The sidebar's inset has to be the frame's inset, exactly.
  *
@@ -62,11 +63,10 @@
      * level with the page title inside the band -- reading as a second
      * heading on the same row rather than as navigation for the body below.
      * The band's height plus its 1px bottom border puts the panel's top edge
-     * exactly on the band's bottom edge, so its own left divider starts where
-     * the band's underline ends instead of crossing it.
+     * exactly on the band's bottom edge.
      *
-     * A margin rather than padding: the divider is a border on this element,
-     * so padding would leave the line running up beside the band. */
+     * The divider itself is drawn in 13-docs-rail-alignment.css, not by a
+     * border here -- see the note at the top of this file. */
     margin-block-start: calc(var(--netscli-docs-hero-height) + 1px);
   }
 

--- a/site/src/styles/starlight/13-docs-rail-alignment.css
+++ b/site/src/styles/starlight/13-docs-rail-alignment.css
@@ -41,3 +41,48 @@
     padding-inline-start: var(--sl-content-inline-start) !important;
   }
 }
+
+/* ---- The contents rail's divider and the title band's underline ----------
+ *
+ * Moved here from 03-shell-layout-base.css, which had crossed the 300-line
+ * guard, and this file is named for exactly this. Nothing between the two
+ * touches .right-sidebar-container, so the later load order changes nothing;
+ * verified by measurement after the move.
+ */
+@media (min-width: 72rem) {
+  /* Starlight draws the divider on .right-sidebar, which is fixed and
+     full-viewport, so it had no way to stop at the band. */
+  .right-sidebar {
+    border-inline-start: 0;
+  }
+
+  .right-sidebar-container {
+    position: relative;
+  }
+
+  /* The band's bottom border, continued across the contents rail so it reaches
+     the frame's right edge. The band cannot do this itself: it lives in
+     .main-pane, the column beside this rail, so its own border stops where
+     that column does -- 256px short. */
+  .right-sidebar-container::before {
+    content: "";
+    position: absolute;
+    inset-inline: 0;
+    inset-block-start: var(--netscli-docs-hero-height);
+    height: 1px;
+    background: var(--sl-color-hairline);
+    pointer-events: none;
+  }
+
+  /* The divider, starting where the band's underline ends rather than
+     crossing it. */
+  .right-sidebar-container::after {
+    content: "";
+    position: absolute;
+    inset-inline-start: 0;
+    inset-block: calc(var(--netscli-docs-hero-height) + 1px) 0;
+    width: 1px;
+    background: var(--sl-color-hairline);
+    pointer-events: none;
+  }
+}

--- a/site/src/styles/theme-control.css
+++ b/site/src/styles/theme-control.css
@@ -104,10 +104,15 @@ starlight-theme-select label .label-icon,
   inset-inline-start: 0.65rem;
 }
 
+/* Same 0.65rem inset as the leading icon above, for the same reason.
+   Upstream pins both against the padding box, and the rule above had already
+   moved the leading one in to clear the border -- leaving the caret alone at
+   0. Measured: the icon sat 11.2px from the label's left edge and the caret
+   0.8px from its right, inside 10.4px of padding on both sides. */
 starlight-theme-select label .caret,
 .netscli-theme-select label .caret {
   font-size: var(--sl-caret-size);
-  inset-inline-end: 0;
+  inset-inline-end: 0.65rem;
 }
 
 starlight-theme-select select,


### PR DESCRIPTION
Three visual defects from review, each measured before and after.

## 1. The theme control's caret had no right-hand padding

The caret sat **0.8px** from the label's right edge while the leading icon sat **11.2px** from its left — inside 10.4px of padding on both sides.

Upstream pins both icons against the padding box, and the rule that moved the *leading* icon in to clear the border had left the caret behind. Same 0.65rem inset on both now: **11.2px each side**. The select keeps its 32px inline-end padding, which already clears the caret's new position.

## 2. The contents rail ran up through the title band

Two problems, one cause. The divider crossed the band's own bottom border instead of starting at it, and the band stopped **256px short of the frame's right edge** — because the band lives in `.main-pane`, the column *beside* the rail.

Starlight draws that divider on `.right-sidebar`, which is **fixed and full-viewport**, so it had no way to stop anywhere. It's drawn on `.right-sidebar-container` instead — the one box that starts under the header and spans the document, so one pseudo-element can begin the line at the band's bottom edge and another can carry the band's underline across the rest of the frame.

Measured in both themes:

| | result |
|---|---|
| band underline | y = **192** — the same pixel as the band's own border |
| underline reaches | **1557.6** — the frame's right edge exactly |
| divider starts | y = **193** |
| `.right-sidebar` border | **0** |

## 3. The section chevrons looked outdented

They sat 8px inside the summary's right edge while the current page's highlight ran to the full width — so the highlight read as spilling past the control above it.

Upstream pads the summary equally on both sides; the links set their own inline padding, so only that side needed unsetting. Chevron and highlight now share a right edge at **247.2px**.

## A file split on the way

`03-shell-layout-base.css` crossed the 300-line guard, so the rail rules moved to `13-docs-rail-alignment.css` — named for exactly this, and already holding `.right-sidebar` rules. Nothing between the two files touches `.right-sidebar-container`, so the later load order changes nothing; re-measured after the move, identical in both themes.

## Gates

axe 0 violations across 14 pages in both themes, 204 contrast pairs ≥ 4.5:1, dead CSS 14/14, `astro check`, changelog dates, file size, app doc links, wordmark inset.

56 visual captures moved, and the diffs are tightly bounded:

- **Landing page and changelog:** 68 pixels, in a 20×6 box. The caret, and nothing else.
- **Docs pages:** the caret, the chevrons, and the two rail lines.
- **Nothing at 700px**, where the rail isn't rendered.

Baseline re-recorded.
