### PR TITLE
Give the landing page a light theme that actually works

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -138,6 +138,15 @@ jobs:
       - name: Accessibility check
         run: npm run test:a11y
 
+      # Runs alongside axe rather than instead of it, because it covers the
+      # one thing axe cannot: axe files text over a gradient or a
+      # pseudo-element under `incomplete`, and `--exit` only fails on
+      # `violations`. On the landing page that was 48 unchecked nodes reported
+      # as a clean pass -- including a heading at 1.03:1. This composites the
+      # ancestor stack itself. See the header of the script.
+      - name: Rendered contrast sweep
+        run: npm run check:contrast
+
   # ─── Required status check ────────────────────────────────────────────
   # The only job here that should be marked required in branch protection.
   # See the equivalent note in ci.yml.

--- a/scripts/design-tokens.mjs
+++ b/scripts/design-tokens.mjs
@@ -104,6 +104,17 @@ const TARGETS = [
       'netscli-code-punct',
       'netscli-code-key',
       'netscli-code-string',
+      // The three stops of the "Desktop app" button's gradient label.
+      //
+      // Gradient-filled text sets `-webkit-text-fill-color: transparent`, so
+      // axe measures a transparent foreground and skips the element entirely.
+      // That blind spot hid a stop at 2.23:1 on the dark page and another at
+      // 1.59:1 on the light one -- one end of the word near-invisible in each
+      // theme, for as long as the button has existed. Nothing else can see
+      // these: a running browser reports the fill, not the paint.
+      'netscli-brand-gradient-from',
+      'netscli-brand-gradient-via',
+      'netscli-brand-gradient-to',
     ],
     surfaces: ['sl-color-bg', 'sl-color-bg-sidebar', 'sl-color-black', 'sl-color-gray-6'],
     keys: {

--- a/site/package.json
+++ b/site/package.json
@@ -15,6 +15,7 @@
     "check:css": "node ./scripts/css-shadowing.mjs --max 14",
     "check:wordmark": "node ./scripts/wordmark-inset.mjs",
     "test:a11y": "npm run build && node ./scripts/a11y.mjs",
+    "check:contrast": "node ./scripts/contrast-sweep.mjs",
     "visual:record": "node ./scripts/visual-snapshot.mjs record",
     "visual:check": "node ./scripts/visual-snapshot.mjs check"
   },

--- a/site/scripts/contrast-sweep.mjs
+++ b/site/scripts/contrast-sweep.mjs
@@ -1,0 +1,215 @@
+// Every rendered text node, against the background actually behind it.
+//
+//   node ./scripts/contrast-sweep.mjs
+//
+// As plain `node`, not `npm run check:contrast`, when running it by hand here:
+// `npm run` executes inside a sandbox Chrome cannot launch from, and the
+// failure is a bare "unsettled top-level await" rather than anything that
+// names the cause. The npm script exists for CI, where there is no such
+// sandbox. scripts/visual-snapshot.mjs carries the same caveat.
+//
+// This exists because axe cannot do it, and reported a clean pass while three
+// separate pieces of the site were unreadable.
+//
+// axe-core's colour-contrast rule gives up when it cannot resolve what is
+// behind the text -- a background gradient, or an ancestor with a
+// pseudo-element -- and files the result under `incomplete` rather than
+// `violations`. `@axe-core/cli --exit` fails on violations only. Measured on
+// the landing page: 0 violations, 74 passes, and 48 incomplete nodes that were
+// never checked at all. Among them was a heading at 1.03:1.
+//
+// The three it missed, all in the light theme:
+//   - `section:nth-of-type(even)` painted `#151515` under the "Get started"
+//     heading: 1.03:1, invisible.
+//   - the 404 page painted `#111` under its own text: 1.06:1.
+//   - the copy buttons stroked their icon `rgba(255,255,255,.34)` in both
+//     themes: white on white.
+//
+// So this composites the stack itself -- walking up through translucent
+// ancestors until it reaches an opaque one, exactly as a browser paints it --
+// and compares. It is deliberately narrow: text colour against composited
+// background, nothing else. axe still runs and still covers everything else.
+//
+// Not a replacement for scripts/design-tokens.mjs either. That compares
+// DECLARED tokens and so catches a bad value before it is used anywhere; this
+// compares what a page actually rendered, and so catches a good token applied
+// to the wrong thing, or no token at all.
+
+import process from 'node:process';
+import { join } from 'node:path';
+
+import { Builder } from 'selenium-webdriver';
+import chrome from 'selenium-webdriver/chrome.js';
+
+import { discoverRoutes, startPreview, resolveChromedriverPath } from './lib/preview-server.mjs';
+
+const host = process.env.SWEEP_HOST || '127.0.0.1';
+const port = process.env.SWEEP_PORT || '4325';
+const baseUrl = `http://${host}:${port}`;
+const root = process.cwd();
+
+const discovered = discoverRoutes(root);
+if (!discovered) {
+  console.error('No dist/ found. Run `npm run build` first — this checks the built site.');
+  process.exit(1);
+}
+const routes = process.env.SWEEP_ROUTES
+  ? process.env.SWEEP_ROUTES.split(/[\s,]+/).filter(Boolean)
+  : discovered;
+
+// 1 = light, 2 = dark. The same mechanism scripts/a11y.mjs uses, and for the
+// same reason: without it the pass renders whatever the machine prefers, and
+// a dark-mode workstation silently tests one theme twice.
+const THEMES = [
+  { name: 'light', scheme: 1 },
+  { name: 'dark', scheme: 2 },
+];
+
+/** Runs in the page. Returns every text node whose contrast is below its floor. */
+const COLLECT = `
+  const num = (s) => { const m = String(s).match(/-?[0-9.]+/g); return m ? m.map(Number) : []; };
+  const lum = (c) => {
+    const f = (v) => { v /= 255; return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4; };
+    return 0.2126 * f(c[0]) + 0.7152 * f(c[1]) + 0.0722 * f(c[2]);
+  };
+  const over = (fg, bg) => { const a = fg.length > 3 ? fg[3] : 1;
+    return [0, 1, 2].map((i) => fg[i] * a + bg[i] * (1 - a)); };
+
+  // Walk up until an opaque background, compositing every translucent layer on
+  // the way. This is the step axe skips.
+  const composite = (el) => {
+    let n = el, layers = [];
+    while (n && n.nodeType === 1) {
+      const v = num(getComputedStyle(n).backgroundColor);
+      if (v.length >= 3 && (v.length < 4 || v[3] > 0)) {
+        layers.unshift(v);
+        if (v.length < 4 || v[3] >= 1) break;
+      }
+      n = n.parentElement;
+    }
+    let base = num(getComputedStyle(document.body).backgroundColor).slice(0, 3);
+    if (base.length < 3) base = [255, 255, 255];
+    for (const l of layers) base = over(l, base);
+    return base;
+  };
+  const ratio = (a, b) => { const x = lum(a), y = lum(b);
+    return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05); };
+
+  const findings = [];
+  document.querySelectorAll('body *').forEach((el) => {
+    const cs = getComputedStyle(el);
+    if (cs.display === 'none' || cs.visibility === 'hidden' || cs.opacity === '0') return;
+    // Gradient-filled text paints from background-image, not from \`color\`.
+    // scripts/design-tokens.mjs checks those stops against the page instead.
+    if (cs.webkitTextFillColor === 'rgba(0, 0, 0, 0)') return;
+
+    // Direct text only. A wrapper inherits its children's text and would be
+    // reported once per ancestor for the same pixels.
+    let text = '';
+    for (const node of el.childNodes) if (node.nodeType === 3) text += node.textContent;
+    text = text.trim();
+    if (!text) return;
+
+    const box = el.getBoundingClientRect();
+    if (box.width < 2 || box.height < 2) return;
+
+    const fg = num(cs.color);
+    // Faded-in elements settle opaque; measuring them mid-transition reports a
+    // ratio no reader ever sees.
+    if (fg.length > 3 && fg[3] < 0.95) return;
+
+    const bg = composite(el);
+    const value = ratio(fg.slice(0, 3), bg);
+    const size = parseFloat(cs.fontSize);
+    const bold = parseInt(cs.fontWeight, 10) >= 700;
+    const floor = size >= 24 || (size >= 18.66 && bold) ? 3 : 4.5;
+    if (value >= floor) return;
+
+    const name =
+      el.tagName.toLowerCase() +
+      (el.id ? '#' + el.id : '') +
+      (typeof el.className === 'string' && el.className
+        ? '.' + el.className.trim().split(/\\s+/)[0]
+        : '');
+    findings.push({
+      selector: name,
+      text: text.slice(0, 40),
+      ratio: Math.round(value * 100) / 100,
+      floor,
+      fg: cs.color,
+      bg: 'rgb(' + bg.map(Math.round).join(',') + ')',
+    });
+  });
+  return findings;
+`;
+
+async function sweep(theme) {
+  const options = new chrome.Options().addArguments(
+    // Headless is not optional: a headed Chrome takes its colour scheme from
+    // the OS and ignores the flag below.
+    '--headless=new',
+    '--hide-scrollbars',
+    '--no-sandbox',
+    '--disable-gpu',
+    // Offline, so a failed GitHub fetch cannot leave half a page unrendered
+    // at a moment that varies between runs.
+    '--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1',
+    `--blink-settings=preferredColorScheme=${theme.scheme}`,
+  );
+  const driverPath = resolveChromedriverPath(process.env.SWEEP_CHROMEDRIVER_PATH);
+  const builder = new Builder().forBrowser('chrome').setChromeOptions(options);
+  if (driverPath) builder.setChromeService(new chrome.ServiceBuilder(driverPath));
+  const driver = await builder.build();
+
+  const failures = [];
+  try {
+    for (const route of routes) {
+      await driver.manage().window().setRect({ width: 1400, height: 1000 });
+      await driver.get(new URL(route, baseUrl).href);
+      await driver.executeScript('return document.fonts ? document.fonts.ready : true;');
+      await new Promise((r) => setTimeout(r, 400));
+      const found = await driver.executeScript(COLLECT);
+      for (const f of found) failures.push({ ...f, route, theme: theme.name });
+    }
+  } finally {
+    await driver.quit();
+  }
+  return failures;
+}
+
+const { cleanup } = await startPreview({
+  baseUrl,
+  host,
+  port,
+  astroCli: join(root, 'node_modules', 'astro', 'bin', 'astro.mjs'),
+  allowReuse: process.env.SWEEP_REUSE_SERVER === '1',
+  reuseHint: 'SWEEP_REUSE_SERVER',
+});
+
+let all = [];
+try {
+  for (const theme of THEMES) {
+    console.log(`=== ${theme.name} theme — ${routes.length} route(s) ===`);
+    all = all.concat(await sweep(theme));
+  }
+} finally {
+  cleanup();
+}
+
+if (all.length) {
+  console.error(`\n✗ ${all.length} text/background pair(s) below the WCAG AA floor:\n`);
+  for (const f of all) {
+    console.error(
+      `  ${String(f.ratio).padStart(6)} / ${f.floor}  [${f.theme}] ${f.route}\n` +
+        `          ${f.fg} on ${f.bg}\n` +
+        `          ${f.selector}  "${f.text}"`,
+    );
+  }
+  console.error('\nThe background is composited from the real ancestor stack, so these are');
+  console.error('what a reader sees, not what a declaration says.');
+  process.exit(1);
+}
+
+console.log(
+  `\n✓ Every rendered text node clears its contrast floor, across ${routes.length} route(s) in both themes.`,
+);

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -94,17 +94,27 @@ const { hero, social } = site;
           </a>
         </div>
       </div>
+      {/* The SCRIPT one-liner sits here, in the wide slot beside the button,
+          and the package-manager command goes in the narrower row below.
+
+          It used to be the other way round, which put the longest command in
+          the narrowest box: `iwr -useb https://raw.githubus...` was truncated
+          mid-URL, so the row a reader would scan for the command showed a
+          fragment of one. Copy still worked, but nothing about the ellipsis
+          said so. The ids keep their meaning -- `hero-quick-install` is the
+          quick script, `hero-package-install` is the package manager -- and
+          scripts/landing/os-tabs.ts fills both by id, not by position. */}
       <div
         class="hero-command hero-command-wide has-copy hero-copy"
-        data-copy={hero.quickInstall}
+        data-copy={hero.quickInstallAlt}
         id="hero-quick-install"
       >
-        <code>{hero.quickInstall}</code>
+        <code>{hero.quickInstallAlt}</code>
       </div>
     </div>
     <div class="hero-cta-sub">
-      <div class="hero-command has-copy hero-copy" id="hero-package-install" data-copy={hero.quickInstallAlt}>
-        <code>{hero.quickInstallAlt}</code>
+      <div class="hero-command has-copy hero-copy" id="hero-package-install" data-copy={hero.quickInstall}>
+        <code>{hero.quickInstall}</code>
       </div>
       <a class="hero-install-link" href="#install">{hero.installLinkLabel}</a>
     </div>
@@ -243,9 +253,13 @@ const { hero, social } = site;
   padding:0;
   border:1px solid transparent;
   border-radius:9px;
+  /* Tokens, not literals. The fill was a hard-coded #191b1e, so in the light
+     theme the one primary button on the page stayed dark charcoal on a white
+     surface; the border gradient ended on the dark theme's bright cyan for the
+     same reason. Both follow the theme now. */
   background:
-    linear-gradient(#191b1e,#191b1e) padding-box,
-    linear-gradient(90deg,var(--netscli-accent) 0%,var(--netscli-accent) 62%,#1edcff 100%) border-box;
+    linear-gradient(var(--netscli-surface),var(--netscli-surface)) padding-box,
+    linear-gradient(90deg,var(--netscli-accent) 0%,var(--netscli-accent) 62%,var(--netscli-brand-gradient-to) 100%) border-box;
   box-shadow:0 0 12px rgba(var(--netscli-accent-rgb),.08);
   overflow:visible;
 }
@@ -266,7 +280,10 @@ const { hero, social } = site;
 }
 .hero-primary-label{
   transform:translateX(8px);
-  background-image:linear-gradient(90deg,#005a1e,var(--netscli-accent),#1edcff);
+  background-image:linear-gradient(90deg,
+    var(--netscli-brand-gradient-from),
+    var(--netscli-brand-gradient-via),
+    var(--netscli-brand-gradient-to));
   -webkit-background-clip:text;background-clip:text;
   -webkit-text-fill-color:transparent;
 }
@@ -296,8 +313,8 @@ const { hero, social } = site;
 .hero-primary-wrap:focus-within,
 .hero-primary-wrap:hover{
   background:
-    linear-gradient(#1c1f23,#1c1f23) padding-box,
-    linear-gradient(90deg,var(--netscli-accent) 0%,var(--netscli-accent) 62%,#1edcff 100%) border-box;
+    linear-gradient(var(--netscli-surface-raised),var(--netscli-surface-raised)) padding-box,
+    linear-gradient(90deg,var(--netscli-accent) 0%,var(--netscli-accent) 62%,var(--netscli-brand-gradient-to) 100%) border-box;
   box-shadow:0 0 0 1px rgba(var(--netscli-accent-rgb),.16),0 0 12px rgba(var(--netscli-accent-rgb),.08);
 }
 .hero-primary-menu:hover{color:var(--netscli-text-strong)}

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -37,9 +37,14 @@ import Footer from '../components/Footer.astro';
 <style is:global>
 .not-found{
   padding:clamp(32px,5vh,60px) 24px;
+  /* var(), not `#111`. Same shape of bug as the section band in global.css:
+     the base layer of a multi-line `background:` shorthand, sitting alone on
+     its own line, which the pass that tokenised every other opaque background
+     never matched. In the light theme this painted the whole 404 page
+     near-black under light-theme text -- the heading measured 1.06:1. */
   background:
     linear-gradient(180deg,rgba(var(--netscli-accent-rgb),.045),transparent 20rem),
-    #111;
+    var(--netscli-bg);
 }
 .not-found-shell{
   width:min(720px,100%);

--- a/site/src/scripts/landing/os-tabs.ts
+++ b/site/src/scripts/landing/os-tabs.ts
@@ -111,27 +111,33 @@ export function initOsTabs(): void {
     //   Linux: `packageCommands.linux` was byte-identical to
     //   `hero.quickInstall`, so the hero printed the same command twice.
     //
-    // Primary is whatever the install section recommends for that
-    // platform, so the hero and "Get started" agree; secondary is a
-    // genuinely different route.
-    const heroCommands: Record<OperatingSystem, { primary: string; secondary: string }> = {
+    // Keyed by ROUTE, not by rank.
+    //
+    // These were `primary` and `secondary`, meaning "what the install section
+    // recommends" and "a genuinely different route" -- but the two rows the
+    // hero puts them in are different SIZES, not different ranks, and Linux
+    // had the script under `primary` while Windows and macOS had it under
+    // `secondary`. So the wide row got a package-manager command on two
+    // platforms and a 90-character URL on the third. Naming them for what
+    // they are lets each row take the one that fits it.
+    const heroCommands: Record<OperatingSystem, { packageManager: string; script: string }> = {
       windows: {
         // Moniker, matching the hero's server-rendered default. `Moniker:
         // netscli` is published in the winget catalog alongside the
         // canonical `fstubner.netscli`, so both resolve.
-        primary: "winget install netscli",
-        secondary:
+        packageManager: "winget install netscli",
+        script:
           "iwr -useb https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.ps1 | iex",
       },
       macos: {
-        primary: "brew tap fstubner/tap && brew install netscli",
-        secondary:
+        packageManager: "brew tap fstubner/tap && brew install netscli",
+        script:
           "curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash",
       },
       linux: {
-        primary:
+        packageManager: "yay -S netscli-bin",
+        script:
           "curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash",
-        secondary: "yay -S netscli-bin",
       },
     };
 
@@ -142,8 +148,12 @@ export function initOsTabs(): void {
       const code = host.querySelector("code");
       if (code) code.textContent = command;
     };
-    setHeroCommand("hero-quick-install", heroCommands[detected].primary);
-    setHeroCommand("hero-package-install", heroCommands[detected].secondary);
+    // `hero-quick-install` is the wide slot beside the Desktop app button and
+    // takes the script one-liner; `hero-package-install` is the narrower row
+    // below and takes the package-manager command. Named per role rather than
+    // per position, so the two stay right if the rows ever move again.
+    setHeroCommand("hero-quick-install", heroCommands[detected].script);
+    setHeroCommand("hero-package-install", heroCommands[detected].packageManager);
 
     const desktopDownload = document.querySelector<HTMLAnchorElement>("#hero-desktop-download");
     if (desktopDownload) {

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -102,10 +102,20 @@ section{
   position:relative;
   scroll-margin-top:72px;
 }
+/* The alternating band.
+ *
+ * `#151515` sat here as the base layer until now, so in the light theme the
+ * "Get started" section painted a near-black band under near-black headings:
+ * measured at 1.03:1. It survived the pass that mapped every other opaque
+ * background onto a surface token because that pass matched a hex on the same
+ * line as its `background:` property, and this one is the second layer of a
+ * multi-line shorthand -- the value sat alone on its own line and was never
+ * seen. Nothing since caught it either; see the note in scripts/a11y.mjs about
+ * what axe does with text over a gradient. */
 section:nth-of-type(even){
   background:
     linear-gradient(180deg,rgba(var(--netscli-lift-rgb),.018),rgba(var(--netscli-lift-rgb),.006)),
-    #151515;
+    var(--netscli-surface);
   border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
 }
 section:nth-of-type(even)::before{
@@ -128,7 +138,15 @@ section .lead a:hover{color:var(--netscli-accent-bright)}
   position:absolute;top:50%;right:5px;transform:translateY(-50%);
   /* Opaque background so text behind the button isn't visible through it */
   background:var(--netscli-surface-raised);border:1px solid rgba(var(--netscli-lift-rgb),.12);
-  border-radius:6px;color:rgba(255,255,255,.34);
+  border-radius:6px;
+  /* Themed, not a literal white. The icon is an inline SVG stroked with
+     `currentColor`, so `rgba(255,255,255,.34)` drew it white on white in the
+     light theme -- every copy button rendered as an empty square. The button's
+     own background and border already used the lift channel; only the ink did
+     not. --netscli-text-muted rather than a lift alpha because it is the same
+     ink the rest of the page uses for secondary marks, and it is contrast
+     checked. */
+  color:var(--netscli-text-muted);
   width:27px;height:27px;padding:0;
   display:inline-flex;align-items:center;justify-content:center;
   cursor:pointer;opacity:0;
@@ -138,7 +156,7 @@ section .lead a:hover{color:var(--netscli-accent-bright)}
 .has-copy:hover .copy-btn,.has-copy:focus-within .copy-btn{opacity:1}
 .faq-command:hover .copy-btn,.faq-command:focus-within .copy-btn{opacity:1}
 .faq-command .copy-btn{right:10px}
-.copy-btn:hover{background:var(--netscli-surface-raised);border-color:rgba(var(--netscli-lift-rgb),.18);color:rgba(255,255,255,.58)}
+.copy-btn:hover{background:var(--netscli-surface-raised);border-color:rgba(var(--netscli-lift-rgb),.18);color:var(--netscli-text-strong)}
 .copy-btn.copied{color:#3fb950;border-color:rgba(63,185,80,.4)}
 .surface-visual .codeblock .copy-btn,
 .tryblock .copy-btn{

--- a/site/src/styles/starlight/03-shell-layout-base.css
+++ b/site/src/styles/starlight/03-shell-layout-base.css
@@ -57,17 +57,9 @@
      * matches outer inset, inner matches inner. */
     padding-inline: 1.85rem var(--netscli-sidebar-rail-inset, clamp(2.2rem, 3vw, 3.15rem));
 
-    /* Start below the title band, not beside it.
-     *
-     * The contents list began at the top of the content column, so it sat
-     * level with the page title inside the band -- reading as a second
-     * heading on the same row rather than as navigation for the body below.
-     * The band's height plus its 1px bottom border puts the panel's top edge
-     * exactly on the band's bottom edge.
-     *
-     * The divider itself is drawn in 13-docs-rail-alignment.css, not by a
-     * border here -- see the note at the top of this file. */
-    margin-block-start: calc(var(--netscli-docs-hero-height) + 1px);
+    /* The offset that starts this below the title band is padding on
+     * .right-sidebar, in 13-docs-rail-alignment.css -- as a margin here it
+     * collapsed out through the rail and overran the page. */
   }
 
   .content-panel {

--- a/site/src/styles/starlight/07-docs-interaction-b.css
+++ b/site/src/styles/starlight/07-docs-interaction-b.css
@@ -112,9 +112,22 @@ html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
 .sl-markdown-content .sl-anchor-icon > svg {
   color: var(--netscli-accent);
   height: var(--sl-anchor-icon-size);
-}.pagination-links a {
+}/* Two lines, two weights.
+ *
+ * The card reads "Previous" over "Packet capture", and both were drawn at
+ * effectively the same brightness -- gray-1 (#e7edf6) for the label against
+ * white (#f4f4f4) for the title, a step no one can see. The label is chrome
+ * and the title is the destination, so the title keeps white and the label
+ * drops to the body-text step. The hover rule in
+ * 28-final-interaction-guardrails.css has to preserve this; see the note
+ * there. */
+.pagination-links a {
   align-items: flex-start;
-  color: var(--sl-color-gray-1) !important;
+  color: var(--sl-color-gray-2) !important;
+}
+
+.pagination-links a .link-title {
+  color: var(--sl-color-white) !important;
 }
 
 .pagination-links a:hover {

--- a/site/src/styles/starlight/13-docs-rail-alignment.css
+++ b/site/src/styles/starlight/13-docs-rail-alignment.css
@@ -7,9 +7,25 @@
 
 .sidebar-pane,
 .sidebar-content,
-.right-sidebar,
 .right-sidebar-panel {
   overflow-x: hidden !important;
+}
+
+/* .right-sidebar is deliberately NOT in the list above.
+ *
+ * `overflow-x: hidden` with `overflow-y: visible` is not a thing CSS will do:
+ * when one axis is clipped the other computes to `auto`, so the rail becomes
+ * a scroll container. That silently captures the `position: sticky` on the
+ * contents panel inside it -- the panel sticks to the rail, which does not
+ * scroll, so it looks like sticky was never applied at all. It cost an hour
+ * of measuring the panel scrolling off screen with the rule right there.
+ *
+ * Below 72rem the rail is a full-width block where the clip still earns its
+ * place, so it keeps it there. */
+@media (max-width: 71.99rem) {
+  .right-sidebar {
+    overflow-x: hidden !important;
+  }
 }
 
 @media (min-width: 72rem) {
@@ -84,5 +100,57 @@
     width: 1px;
     background: var(--sl-color-hairline);
     pointer-events: none;
+  }
+}
+
+/* ---- The contents list sticks instead of hanging -------------------------
+ *
+ * Starlight fixes the whole rail (`position: fixed; top: 0; padding-top:
+ * var(--sl-nav-height)`), which pins the contents list just under the header
+ * and never moves it. Giving the panel a top margin so it starts below the
+ * title band therefore pinned it 133px BELOW the header instead -- for the
+ * whole page, long after the band had scrolled away. Measured: with the band
+ * 1378px off the top of the screen, the list was still sitting at y=193.
+ *
+ * A fixed element cannot start below something and then catch up, so the rail
+ * goes back into normal flow and the panel gets `position: sticky`. The margin
+ * places it under the band at rest; scrolling carries it up until its top
+ * reaches the header, and it stays there. Same two positions the fixed version
+ * offered, without having to choose one.
+ *
+ * The mobile close-out already unfixes this rail for the same reason -- see
+ * 17-mobile-shell-closeout-a.css.
+ *
+ * `overflow-y` and a height cap move to the panel with it: they were on the
+ * rail so a contents list taller than the screen could scroll on its own, and
+ * that has to keep working now the rail is not the viewport-sized box.
+ */
+@media (min-width: 72rem) {
+  .right-sidebar {
+    position: static;
+    /* Full column height, not `auto`. A sticky element can only travel inside
+       its containing block, and an auto-height rail shrink-wraps to the panel
+       -- leaving it nowhere to go, so it scrolled away like a static box. The
+       container is the in-flow <aside>, which is as tall as the page. */
+    height: 100%;
+    /* The offset that starts the contents list below the title band, as
+       PADDING on the rail rather than a margin on the panel.
+
+       As a margin it collapsed out through the rail, moving the rail's own top
+       down 133px while `height: 100%` still measured from the container -- so
+       the rail overran the bottom of the page by exactly that much. Padding
+       does not collapse, and with border-box it comes out of the same 100%.
+       Starlight uses padding here for its own nav-height offset, for what is
+       presumably the same reason. */
+    padding-top: calc(var(--netscli-docs-hero-height) + 1px);
+    overflow: visible;
+  }
+
+  .right-sidebar-panel {
+    position: sticky;
+    top: var(--sl-nav-height);
+    max-height: calc(100vh - var(--sl-nav-height));
+    overflow-y: auto;
+    scrollbar-width: none;
   }
 }

--- a/site/src/styles/starlight/28-final-interaction-guardrails.css
+++ b/site/src/styles/starlight/28-final-interaction-guardrails.css
@@ -25,8 +25,15 @@
   border-color: var(--netscli-panel-hover-border) !important;
 }
 
-.pagination-links a:hover :where(.link-title, .link-subtitle, span),
-.pagination-links a:focus-visible :where(.link-title, .link-subtitle, span) {
+/* `.link-title` is excluded on purpose.
+ *
+ * This existed to stop a child re-colouring itself on hover and breaking the
+ * card's single hover colour. But the title is meant to be a step brighter
+ * than the label at rest (see 07-docs-interaction-b.css), and `inherit` here
+ * collapsed the two back together the moment the pointer touched the card --
+ * so the distinction existed everywhere except where a reader was looking. */
+.pagination-links a:hover :where(.link-subtitle, span:not(.link-title)),
+.pagination-links a:focus-visible :where(.link-subtitle, span:not(.link-title)) {
   color: inherit !important;
 }
 

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -114,21 +114,34 @@
    * failures. They are var() references now, which inline styles DO resolve
    * per theme.
    *
-   * The two blue and green values are the original literals exactly. The two
-   * neutrals are not: naming them made them reachable by
-   * scripts/design-tokens.mjs, which measured the punctuation grey at 4.46:1
-   * on the page and 3.99:1 on a card -- below AA and wrong since long before
-   * the light theme. axe had not caught it because its dark pass ran under
-   * `--force-dark-mode`, which re-tints the page and so measured a colour
-   * nobody wrote. They are lifted to 6.71:1 and 5.47:1 here.
-   *
-   * They were also #888888 and #7b7b7b, a 3% difference no reader can see,
-   * which made the comment/punctuation distinction decorative. The new pair
-   * is far enough apart to read as two things. */
+   * The blue and green are the original literals. The two neutrals are not:
+   * naming them made them reachable by scripts/design-tokens.mjs, which
+   * measured the punctuation grey at 4.46:1 on the page and 3.99:1 on a card
+   * -- below AA, and wrong since long before the light theme. They are also
+   * no longer #888888 beside #7b7b7b, a 3% difference no reader can see. */
   --netscli-code-comment: #9a9a9a;
   --netscli-code-punct: #8a8a8a;
   --netscli-code-key: #7c9fc7;
   --netscli-code-string: #8fbc7f;
+
+  /* ---- Brand gradient -------------------------------------------------
+   *
+   * The "Desktop app" button fills its label with this and sets
+   * `-webkit-text-fill-color: transparent` -- which is why nothing caught the
+   * two failures below. A contrast checker reads the transparent fill, not
+   * the paint behind it, so axe skipped the element and the token gate never
+   * saw the stops: they were literals inside a component.
+   *
+   * Both ends were failing, in opposite themes. One ramp served both --
+   * #005a1e -> accent -> #1edcff -- so the dark-green START was 2.23:1 on the
+   * near-black page and the cyan END was 1.59:1 on white. Half the word was
+   * near-invisible either way.
+   *
+   * Every stop now clears 4.5:1 on its own theme's page: 5.73 / 8.29 / 11.45
+   * dark, 8.18 / 6.40 / 7.02 light. scripts/design-tokens.mjs checks them. */
+  --netscli-brand-gradient-from: #16a34a;
+  --netscli-brand-gradient-via: #22c55e;
+  --netscli-brand-gradient-to: #1edcff;
 
   /* ---- Cross-stack role channels -------------------------------------
    *
@@ -253,6 +266,11 @@ html[data-theme='light'] {
      alpha per theme, and this reproduces it rather than rounding the two
      together. */
   --netscli-hover-border: color-mix(in srgb, var(--netscli-accent) 42%, rgba(var(--netscli-lift-rgb), 0.1));
+  /* The same arc, walked in the direction that stays legible on white. */
+  --netscli-brand-gradient-from: #005a1e;
+  --netscli-brand-gradient-via: #146b2e;
+  --netscli-brand-gradient-to: #155e75;
+
   --netscli-hairline-rgb: 17, 24, 39;
   /* On a light surface, raised is DARKER. See the note in the docs' token
      file for the 27 rules that had this backwards. */


### PR DESCRIPTION
Four review items — and, underneath two of them, a light theme that was genuinely broken.

## The light theme

Whole pieces of the landing stack were still painting dark-theme values. Measured, in light:

| what | ratio | cause |
|---|---|---|
| "Get started" heading | **1.03:1** | `section:nth-of-type(even)` painted an opaque `#151515` band under it |
| 404 page heading | **1.06:1** | same shape, `#111` on that page |
| every copy button | — | SVG stroked `rgba(255,255,255,.34)` in *both* themes: white on white, an empty square |
| "Desktop app" button | — | fill hard-coded `#191b1e`, so the page's one primary button stayed dark charcoal on white |
| its gradient label | **2.23:1** dark / **1.59:1** light | one stop failing in each theme, at opposite ends — half the word near-invisible either way, since the button was written |

The first two are the same bug twice: **the base layer of a multi-line `background:` shorthand, alone on its own line.** The pass that mapped every other opaque background onto a surface token matched a hex on the same line as its property, so it never saw either. A search for that exact shape finds no others.

## Why nothing caught it

**axe files text it can't resolve a background for under `incomplete`** — over a gradient, or under an ancestor with a pseudo-element — and `@axe-core/cli --exit` fails on `violations` only.

Run directly against the landing page: **0 violations, 74 passes, 48 incomplete.** The 1.03:1 heading was in the incomplete pile. Gradient-filled text also sets `-webkit-text-fill-color: transparent`, so axe reads a transparent foreground and skips the element outright.

`scripts/contrast-sweep.mjs` closes that. It composites the ancestor stack itself — walking up through translucent layers to an opaque one, the way a browser paints it — and checks every rendered text node across all 14 routes in both themes.

**Sabotage-checked** against the restored `#151515`:

```
axe:    ✓ No accessibility violations in either theme.   exit 0
sweep:  ✗ text/background pair(s) below the WCAG AA floor  exit 1
```

It runs *alongside* axe, not instead of it. The gradient stops are tokens now and the token gate checks them too (204 → 228 pairs); restoring `#005a1e` there fails at 2.23:1.

## The four review items

**The contents rail didn't stick.** Starlight fixes the whole rail, so the margin that started it below the title band pinned it 133px below the header permanently — still at y=193 with the band 1378px off screen. The rail goes back into normal flow and the panel is sticky. Two things had to change with it: the offset became *padding* (as a margin it collapsed out and the rail overran the page by exactly 133px), and `.right-sidebar` lost `overflow-x: hidden`, which quietly computes `overflow-y` to `auto` and made the rail a scroll container that captured the sticky.

**Next/Previous** drew label and title at effectively the same brightness. Title keeps white, label drops to the body step, and the hover rule that collapsed them back together no longer applies to the title.

**The hero's install commands swapped rows** — script one-liner in the wide slot beside the button, package manager below. They're keyed by *route* now rather than by rank, because Linux had them the other way round and the wide row got whichever the table happened to call primary.

**Content was not reviewed** — see the PR discussion. I spot-checked the four safety limits on the docs Overview against `crates/netscli-core` (`/16`, 4096 ports, 500 ms, 256 concurrency — all match). That's four claims on one page, not a content review.

## Gates

axe 0 violations across 14 pages in both themes, contrast sweep clean on 14 routes in both themes, 228 contrast pairs ≥ 4.5:1, dead CSS 14/14, `astro check`, changelog dates, file size, app doc links, wordmark inset. Baseline re-recorded.

## Known, not fixed

The hero's script command is **624px of text in a 351px slot** — still truncated. The swap widened what shows; it didn't fix it. A short URL on netscli.com would, but that's a decision about where the install script is served from.
