### PR TITLE
Serve the install scripts from netscli.com and say what the button downloads

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -94,6 +94,13 @@ const { hero, social } = site;
           </a>
         </div>
       </div>
+      {/* What the button will download, said out loud.
+          Clicking it starts a download immediately, and nothing on the page
+          named the file or the platform first -- so the only way to find out
+          what you were getting was to get it. Server-rendered with the
+          Windows default so it matches the href beside it before any script
+          runs; scripts/landing/os-tabs.ts rewrites both together. */}
+      <p class="hero-primary-cue" id="hero-desktop-cue">Windows &middot; .msi installer</p>
       {/* The SCRIPT one-liner sits here, in the wide slot beside the button,
           and the package-manager command goes in the narrower row below.
 
@@ -228,7 +235,16 @@ const { hero, social } = site;
    stops a screen reader announcing "middle dot" three times. */
 .hero .social-proof .sep{color:#555}
 .hero-cta{
-  width:min(560px,62vw);
+  /* 610, not 560, and sized off the viewport rather than a vw fraction.
+     At 560 the wide command slot was 351px against 397px of text, so
+     `iwr -useb https://netscli.com/install.ps1 | iex` was still clipped by
+     46px even after the URL was shortened -- measured, not estimated. The
+     62vw term also made the width non-monotonic: it governed between 900 and
+     984px and put the CTA back under 560 there, so a cap alone would have
+     fixed only the widest screens. Below 820px the CTA switches to a wrapped
+     column and each command gets the full width, so this only governs the
+     grid layout. */
+  width:min(610px,calc(100vw - 72px));
   margin:28px auto 0;
   display:grid;gap:12px;
 }
@@ -403,6 +419,22 @@ const { hero, social } = site;
   color:var(--netscli-text);font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:.78rem;background:transparent;border:0;padding:0;
 }
+/* Under the button, not beside it.
+ *
+ * .hero-cta-main is a two-column grid and this is its second child, so
+ * without an explicit placement it would take row 1 column 2 and push the
+ * command bar down a row. Placed rather than reordered so the DOM order stays
+ * button-then-caption, which is what a screen reader should hear. */
+.hero-primary-cue{
+  grid-column:1;
+  grid-row:2;
+  margin:2px 0 0;
+  font-size:.7rem;
+  line-height:1.3;
+  color:var(--netscli-text-muted);
+  text-align:center;
+  white-space:nowrap;
+}
 .hero-install-link{
   justify-self:end;
   display:inline-flex;align-items:center;
@@ -420,12 +452,9 @@ const { hero, social } = site;
 .hero .links a:hover{color:var(--netscli-text);border-bottom-color:rgba(255,255,255,.5)}
 .hero .links a.plain{border-bottom:0}
 .hero .links a.plain:hover{border-bottom:0}
-@media(max-width:900px){
-  .hero-cta{width:min(560px,calc(100vw - 72px))}
-}
 @media(max-width:820px){
   .hero-cta{
-    width:min(430px,calc(100vw - 48px));
+    width:min(450px,calc(100vw - 48px));
     display:flex;
     flex-wrap:wrap;
     justify-content:center;
@@ -439,20 +468,30 @@ const { hero, social } = site;
      installer menu -- anchored to its left edge -- opened off to one side
      and past the column. Matching the bars lines all four rows up on the
      same edges and gives the menu the same width to open into. */
+  /* 400, not 380: the wide command needs 323px of text plus the bar's 72px
+     of padding and copy-button reserve. All three stay equal so the button,
+     its menu and both command bars share one set of edges. */
   .hero-primary-wrap{
     order:1;
-    width:min(100%,380px);
-    flex:0 1 min(100%,380px);
+    width:min(100%,400px);
+    flex:0 1 min(100%,400px);
+  }
+  .hero-primary-cue{
+    order:2;
+    grid-column:auto;
+    grid-row:auto;
+    flex:0 0 100%;
+    margin:0;
   }
   .hero-command-wide{
     order:3;
-    flex:0 1 min(100%,380px);
-    width:min(100%,380px);
+    flex:0 1 min(100%,400px);
+    width:min(100%,400px);
   }
   .hero-cta-sub .hero-command{
     order:4;
-    flex:0 1 min(100%,380px);
-    width:min(100%,380px);
+    flex:0 1 min(100%,400px);
+    width:min(100%,400px);
   }
   /* Exactly the button's outer edges, not its padding box. The trigger has
      a 1px gradient border, so a plain `width:100%` left the menu inset by a

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -40,7 +40,7 @@ scoop install netscli-gui
 Or the PowerShell install script, which picks the right asset for your machine:
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.ps1 | iex
+iwr -useb https://netscli.com/install.ps1 | iex
 ```
 
 Direct Windows installers are attached to GitHub Releases. They are not Authenticode-signed yet, so Windows may show a publisher warning when installing outside winget. The winget manifests verify release asset hashes.
@@ -56,7 +56,7 @@ brew tap fstubner/tap && brew install netscli
 Or use the install script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash
+curl -fsSL https://netscli.com/install.sh | bash
 ```
 
 Desktop `.dmg` artifacts are attached to GitHub Releases where the release workflow publishes them. macOS may require the usual first-run approval for unsigned or independently distributed apps.
@@ -66,7 +66,7 @@ Desktop `.dmg` artifacts are attached to GitHub Releases where the release workf
 Use the install script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash
+curl -fsSL https://netscli.com/install.sh | bash
 ```
 
 Install with Homebrew on Linux when you use Linuxbrew:
@@ -185,11 +185,11 @@ If you do want packet capture, you need **both** a build that has the feature co
 The install script does both at once — it selects the `-pcap` build *and* installs the system library:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | NETSCLI_PCAP=1 bash
+curl -fsSL https://netscli.com/install.sh | NETSCLI_PCAP=1 bash
 ```
 
 ```powershell
-$env:NETSCLI_PCAP=1; iwr -useb https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.ps1 | iex
+$env:NETSCLI_PCAP=1; iwr -useb https://netscli.com/install.ps1 | iex
 ```
 
 On Windows this runs the Npcap installer, which needs administrator rights. Add `NETSCLI_SKIP_NPCAP=1` (or `NETSCLI_SKIP_LIBPCAP=1` on Unix) if you manage the capture library yourself.

--- a/site/src/data/site-content/faq.ts
+++ b/site/src/data/site-content/faq.ts
@@ -1,4 +1,5 @@
 import type { FaqItem, SectionCopy } from './types';
+import { INSTALL_SH_COMMAND } from './install-urls';
 
 export const faqCopy: SectionCopy = {
   heading: 'FAQ',
@@ -21,12 +22,12 @@ export const faq: FaqItem[] = [
   {
     group: 'Install and updates',
     q: 'How do I install NetsCLI?',
-    a: 'Install the netscli package for the CLI, terminal UI, and MCP server. On Windows, run: winget install netscli (the full identifier fstubner.netscli also works). On Linux or macOS, run: curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash. For the Windows desktop app, run: winget install netscli-gui. With Rust installed you can also run: cargo install netscli. Prebuilt binaries and desktop installers are attached to GitHub releases when available for that platform.',
+    a: 'Install the netscli package for the CLI, terminal UI, and MCP server. On Windows, run: winget install netscli (the full identifier fstubner.netscli also works). On Linux or macOS, run: ${INSTALL_SH_COMMAND}. For the Windows desktop app, run: winget install netscli-gui. With Rust installed you can also run: cargo install netscli. Prebuilt binaries and desktop installers are attached to GitHub releases when available for that platform.',
     aHtml: `
       <p>Install the <code>netscli</code> package for the CLI, terminal UI, and MCP server:</p>
       <div class="faq-command-list" aria-label="Install commands">
         <div class="faq-command"><span>Windows</span><code>winget install netscli</code></div>
-        <div class="faq-command"><span>Linux/macOS</span><code>curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash</code></div>
+        <div class="faq-command"><span>Linux/macOS</span><code>${INSTALL_SH_COMMAND}</code></div>
         <div class="faq-command"><span>Rust</span><code>cargo install netscli</code></div>
       </div>
       <p>Install the Windows desktop app separately:</p>
@@ -95,7 +96,7 @@ export const faq: FaqItem[] = [
         <div class="faq-command"><span>Windows app</span><code>winget install netscli-gui</code></div>
         <div class="faq-command"><span>Windows</span><code>scoop bucket add fstubner https://github.com/fstubner/scoop-bucket &amp;&amp; scoop install netscli</code></div>
         <div class="faq-command"><span>macOS</span><code>brew tap fstubner/tap &amp;&amp; brew install netscli</code></div>
-        <div class="faq-command"><span>Linux</span><code>curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash</code></div>
+        <div class="faq-command"><span>Linux</span><code>${INSTALL_SH_COMMAND}</code></div>
         <div class="faq-command"><span>Arch Linux</span><code>yay -S netscli-bin</code></div>
       </div>
       <p>Packet capture is the only workflow that needs a system capture library: libpcap on Linux/macOS or Npcap on Windows. mDNS discovery is pure Rust and is included in the published app, CLI, and MCP builds.</p>

--- a/site/src/data/site-content/hero.ts
+++ b/site/src/data/site-content/hero.ts
@@ -1,4 +1,5 @@
 import type { Hero } from './types';
+import { INSTALL_SH_COMMAND } from './install-urls';
 
 export const hero: Hero = {
   // Platforms only. "Open source" and "MIT" repeat in the footer and the
@@ -34,8 +35,7 @@ export const hero: Hero = {
   // winget catalog, so the short form resolves. The canonical identifier
   // stays in the install guide for anyone who wants to be unambiguous.
   quickInstall: 'winget install netscli',
-  quickInstallAlt:
-    'curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash',
+  quickInstallAlt: INSTALL_SH_COMMAND,
   installLinkLabel: 'More install options ↓',
   heroImage: '/assets/tui-discover.png',
   heroImageWebp: '/assets/tui-discover.webp',

--- a/site/src/data/site-content/install-urls.ts
+++ b/site/src/data/site-content/install-urls.ts
@@ -1,0 +1,29 @@
+import { meta } from './meta';
+
+/**
+ * Where the install one-liners point.
+ *
+ * These are served BY THIS SITE, from src/pages/install.sh.ts and
+ * src/pages/install.ps1.ts, which read the real scripts out of the repo at
+ * build time. There is no second copy of either script to drift.
+ *
+ * The reason is length, not branding. The raw.githubusercontent.com form is
+ * 91 characters -- 624px of monospace -- and the widest slot the hero can give
+ * it is 351px, so the command a reader is meant to copy rendered as
+ * `iwr -useb https://raw.githubusercont...`. Copy still worked; nothing about
+ * the ellipsis said so. These are 46 and 47 characters and fit with room.
+ *
+ * Defined once because the same two URLs appear in the hero, the OS tab
+ * script, the install section and twice in the FAQ. They were nine separate
+ * literals.
+ */
+const base = meta.domain.replace(/\/$/, '');
+
+export const INSTALL_SH_URL = `${base}/install.sh`;
+export const INSTALL_PS1_URL = `${base}/install.ps1`;
+
+/** `curl -fsSL https://netscli.com/install.sh | bash` */
+export const INSTALL_SH_COMMAND = `curl -fsSL ${INSTALL_SH_URL} | bash`;
+
+/** `iwr -useb https://netscli.com/install.ps1 | iex` */
+export const INSTALL_PS1_COMMAND = `iwr -useb ${INSTALL_PS1_URL} | iex`;

--- a/site/src/data/site-content/install.ts
+++ b/site/src/data/site-content/install.ts
@@ -1,4 +1,5 @@
 import type { PlatformInstall, Platform, SectionCopy, TryCommand } from './types';
+import { INSTALL_PS1_COMMAND, INSTALL_SH_COMMAND } from './install-urls';
 
 export const installCopy: SectionCopy = {
   heading: 'Get started',
@@ -54,7 +55,7 @@ export const installByPlatform: Record<Platform, PlatformInstall> = {
       {
         label: 'PowerShell script',
         command:
-          'iwr -useb https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.ps1 | iex',
+          INSTALL_PS1_COMMAND,
       },
     ],
     desktop: [
@@ -85,7 +86,7 @@ export const installByPlatform: Record<Platform, PlatformInstall> = {
       {
         label: 'Install script',
         command:
-          'curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash',
+          INSTALL_SH_COMMAND,
       },
     ],
     desktop: [
@@ -114,7 +115,7 @@ export const installByPlatform: Record<Platform, PlatformInstall> = {
       {
         label: 'Install script',
         command:
-          'curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash',
+          INSTALL_SH_COMMAND,
       },
       {
         label: 'AUR (Arch)',

--- a/site/src/pages/install.ps1.ts
+++ b/site/src/pages/install.ps1.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * /install.ps1 — the repo's own scripts/install.ps1, served from this domain.
+ *
+ * Same reasoning as install.sh.ts: read at build time so there is one script,
+ * not a copy under public/ that drifts from it.
+ *
+ * This is what `iwr -useb https://netscli.com/install.ps1 | iex` fetches.
+ */
+export async function GET() {
+  const source = path.join(process.cwd(), '..', 'scripts', 'install.ps1');
+  const body = fs.readFileSync(source, 'utf8');
+  if (!body.trim()) throw new Error(`${source} is empty; refusing to publish it.`);
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+}

--- a/site/src/pages/install.sh.ts
+++ b/site/src/pages/install.sh.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * /install.sh — the repo's own scripts/install.sh, served from this domain.
+ *
+ * Read at build time rather than copied into public/, so there is exactly one
+ * install script in this repository. A copy under public/ would be a second
+ * one, and the two would differ the first time anybody edited the real one.
+ *
+ * This is what `curl -fsSL https://netscli.com/install.sh | bash` fetches. If
+ * the file ever moves, this build fails rather than publishing an empty or
+ * stale script to a URL people are told to pipe into a shell.
+ */
+export async function GET() {
+  const source = path.join(process.cwd(), '..', 'scripts', 'install.sh');
+  const body = fs.readFileSync(source, 'utf8');
+  if (!body.trim()) throw new Error(`${source} is empty; refusing to publish it.`);
+  return new Response(body, {
+    headers: {
+      // text/plain, not application/x-sh: a browser should show it, since
+      // "read the script before you pipe it" is advice worth making easy.
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+}

--- a/site/src/scripts/landing-page.ts
+++ b/site/src/scripts/landing-page.ts
@@ -117,14 +117,26 @@ export function initLandingPage(repo: string): void {
           menu.hidden = !willOpen;
           button.setAttribute("aria-expanded", String(willOpen));
         });
-        document.addEventListener("click", (event) => {
-          if (
-            !menu.hidden
-            && event.target instanceof Node
-            && !menu.contains(event.target)
-            && event.target !== button
-          ) closeMenu();
-        });
+        // Capture phase, deliberately.
+        //
+        // In the bubble phase this never fired for a click on a copy button,
+        // because copy-buttons.ts calls `stopPropagation()` on its own click
+        // — so opening the installer menu and then copying the command beside
+        // it left the menu hanging open over the page. "Click anywhere else
+        // and I close" should not be defeatable by whatever you clicked on;
+        // capture runs before any of it.
+        document.addEventListener(
+          "click",
+          (event) => {
+            if (
+              !menu.hidden
+              && event.target instanceof Node
+              && !menu.contains(event.target)
+              && event.target !== button
+            ) closeMenu();
+          },
+          true,
+        );
         menu.querySelectorAll("a").forEach((link) => {
           link.addEventListener("click", closeMenu);
         });

--- a/site/src/scripts/landing/os-tabs.ts
+++ b/site/src/scripts/landing/os-tabs.ts
@@ -8,6 +8,7 @@
  * derived from both.
  */
 import type { NavigatorWithUserAgentData, OperatingSystem } from './os-types';
+import { INSTALL_PS1_COMMAND, INSTALL_SH_COMMAND } from '../../data/site-content/install-urls';
 
 export function initOsTabs(): void {
   // OS tab swap. Keep visual state and ARIA state aligned so package
@@ -127,17 +128,17 @@ export function initOsTabs(): void {
         // canonical `fstubner.netscli`, so both resolve.
         packageManager: "winget install netscli",
         script:
-          "iwr -useb https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.ps1 | iex",
+          INSTALL_PS1_COMMAND,
       },
       macos: {
         packageManager: "brew tap fstubner/tap && brew install netscli",
         script:
-          "curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash",
+          INSTALL_SH_COMMAND,
       },
       linux: {
         packageManager: "yay -S netscli-bin",
         script:
-          "curl -fsSL https://raw.githubusercontent.com/fstubner/netscli/main/scripts/install.sh | bash",
+          INSTALL_SH_COMMAND,
       },
     };
 
@@ -174,6 +175,17 @@ export function initOsTabs(): void {
       };
       desktopDownload.href = desktopUrls[detected];
 
+      // Keep the caption and the href saying the same thing. They are set
+      // together on purpose: a cue that describes a different file from the
+      // one the button fetches is worse than no cue.
+      const cueText: Record<OperatingSystem, string> = {
+        windows: 'Windows · .msi installer',
+        macos: 'macOS · Intel .dmg',
+        linux: 'Linux · .AppImage',
+      };
+      const cue = document.getElementById('hero-desktop-cue');
+      if (cue) cue.textContent = cueText[detected];
+
       if (detected === "macos") {
         // High-entropy hints are async and Chromium-only; Safari never
         // resolves this, which is exactly why the default above has to
@@ -183,6 +195,10 @@ export function initOsTabs(): void {
           .then(({ architecture }) => {
             if (architecture === "arm") {
               desktopDownload.href = `${base}/netscli-gui-macos-aarch64.dmg`;
+              // The caption moves with the href. Without this the button
+              // would fetch the Apple Silicon build while the line under it
+              // still read "Intel .dmg".
+              if (cue) cue.textContent = 'macOS · Apple silicon .dmg';
             }
           })
           .catch(() => {


### PR DESCRIPTION
## The short URL

The hero's script one-liner was 91 characters — **624px of monospace against a 351px slot** — so it rendered as `iwr -useb https://raw.githubusercont…`. Copy still worked; nothing about the ellipsis said so.

`/install.sh` and `/install.ps1` are now served by this site, from endpoints that read `scripts/install.sh` and `scripts/install.ps1` **out of the repo at build time**. No copy under `public/`, so there is exactly one of each script and the two cannot drift — verified byte-identical after a build. The endpoints throw if the source is missing or empty rather than publishing nothing to a URL people are told to pipe into a shell.

The command is 46 characters now. Measured at ten viewport widths: **clipped at every one before, fits at every one down to 560px after.**

Two widths had to change, both measured rather than guessed:

| | was | now | why |
|---|---|---|---|
| CTA cap | 560px | 610px | the slot was **46px** short |
| wrapped column (<820px) | 380px | 400px | **9px** short |

The `62vw` term became `calc(100vw - 72px)` because it governed between 900 and 984px and put the width back under 560 there — a cap alone would have fixed only the widest screens.

The URL is defined once now; it was **nine separate literals** across the hero, the OS tab script, the install section and the FAQ. The docs' install page moved to the same URLs too — docs telling people to run a different command from the landing page is worse than either command being long.

> ### ⚠️ This depends on a deploy
>
> netscli.com does not serve `/install.sh` or `/install.ps1` until the site is published, and the site is currently **stale** — `/docs/` still 404s. Merging this without deploying puts a **broken install command** on the live landing page. Deploy first, or together.

## What the button downloads

Clicking "Desktop app" started a download immediately and nothing on the page named the file or the platform — the only way to learn what you were getting was to get it.

There's a caption under the button now: **"Windows · .msi installer"**, server-rendered with the same default as the `href` beside it so the two agree before any script runs. `os-tabs.ts` rewrites both together — **including the Apple-silicon upgrade path**, which previously changed the href alone and would have left the caption reading "Intel .dmg" over a button fetching the arm64 build.

Placed with an explicit grid row rather than reordered, so the DOM order stays button-then-caption for a screen reader.

## The dropdown not closing

**Reproduced:** open the installer menu, click the copy button on the command beside it → menu stays open.

`copy-buttons.ts` calls `stopPropagation()` on its own click, so the document-level close listener never ran. The listener is on the **capture phase** now — "click anywhere else and I close" shouldn't be defeatable by whatever you happened to click. Re-tested: closes on the copy button, and still closes on a plain outside click and on Escape.

## Gates

axe 0 violations across 14 pages in both themes, contrast sweep clean on 14 routes in both themes, 228 contrast pairs ≥ 4.5:1, dead CSS 14/14, `astro check`, changelog dates, file size, app doc links, wordmark inset. Baseline re-recorded.

## Known

Below about 560px the command still truncates. 323px of monospace doesn't fit a phone minus the bar's padding, and shrinking the font to force it would cost more than the ellipsis does.
