### PR TITLE
Dark code surfaces, a navy band, and two groups in the nav

### DIFF
--- a/scripts/design-tokens.mjs
+++ b/scripts/design-tokens.mjs
@@ -100,10 +100,20 @@ const TARGETS = [
       'netscli-accent',
       'netscli-accent-bright',
       'netscli-accent-high',
-      'netscli-code-comment',
-      'netscli-code-punct',
-      'netscli-code-key',
-      'netscli-code-string',
+      // The four code-sample colours are deliberately NOT here.
+      //
+      // They sit on --netscli-code-bg, which is dark in both themes, and this
+      // gate compares every foreground against every PAGE surface -- so it
+      // measured them against white and reported failures for a pairing that
+      // never renders. Adding the code background to `surfaces` instead would
+      // invert the problem: the light text ramp would then be checked against
+      // a dark panel it never touches.
+      //
+      // scripts/contrast-sweep.mjs covers them properly, because it measures
+      // the background actually behind each node rather than every
+      // combination of declared values. Strictly better for this case; the
+      // trade is that a bad code colour is caught at render time rather than
+      // at declaration time.
       // The three stops of the "Desktop app" button's gradient label.
       //
       // Gradient-filled text sets `-webkit-text-fill-color: transparent`, so

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -97,6 +97,7 @@ export default defineConfig({
         // definition rather than an override of one, and it has to outrank
         // Starlight's own scoped styles for that component. See the file.
         './src/styles/theme-control.css',
+        './src/styles/code-surface.css',
       ],
       social: [
         {

--- a/site/src/components/Faq.astro
+++ b/site/src/components/Faq.astro
@@ -103,22 +103,27 @@ const faqGroups = grouped.sort(
   align-items:center;
   min-height:40px;
   padding:8px 48px 8px 12px;
-  border:1px solid rgba(var(--netscli-lift-rgb),.07);
+  /* Dark in both themes -- see the code-surface note in tokens.css. The
+     LABEL beside it stays on the card, so only the chip inverts. */
+  border:1px solid var(--netscli-code-border);
   border-radius:5px;
-  background:rgba(var(--netscli-lift-rgb),.045);
-  color:var(--netscli-text);
+  background:var(--netscli-code-bg);
+  color:var(--netscli-code-fg);
   white-space:pre;
   overflow-x:auto;
 }
 .faq .answer code{
   font-size:.8125rem;
-  color:var(--netscli-accent-bright);
+  /* The chip is dark in both themes now, so the ink has to be too --
+     --netscli-accent-bright flips to a dark green in the light theme and was
+     landing at 1.94:1 on it. See tokens.css. */
+  color:var(--netscli-code-inline-fg);
   white-space:nowrap;
   overflow-wrap:normal;
   word-break:normal;
 }
 .faq .answer .faq-command code{
-  color:var(--netscli-text);
+  color:var(--netscli-code-fg);
   white-space:pre;
   overflow-x:auto;
   overflow-wrap:normal;

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -410,7 +410,8 @@ const { hero, social } = site;
   position:relative;display:grid;grid-template-columns:minmax(0,1fr);
   align-items:center;gap:10px;min-height:36px;
   padding:8px 58px 8px 14px;border-radius:9px;
-  background:rgba(var(--netscli-lift-rgb),.04);border:1px solid rgba(var(--netscli-lift-rgb),.1);
+  /* Dark in both themes -- see the code-surface note in tokens.css. */
+  background:var(--netscli-code-bg);border:1px solid var(--netscli-code-border);
   box-shadow:0 0 0 1px rgba(var(--netscli-accent-rgb),.26),0 0 14px rgba(var(--netscli-accent-rgb),.08);
 }
 .hero-command.hero-copy .copy-btn{opacity:1}

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -111,7 +111,8 @@ const groups = [
 .install-label{font-size:.8125rem;font-weight:600;color:var(--netscli-text);margin:0 0 6px}
 .install-hint{font-size:.6875rem;color:var(--netscli-text-muted);margin:4px 0 0}
 .cmd{
-  background:rgba(var(--netscli-lift-rgb),.04);border:1px solid rgba(var(--netscli-lift-rgb),.08);
+  /* Dark in both themes -- see the code-surface note in tokens.css. */
+  background:var(--netscli-code-bg);border:1px solid var(--netscli-code-border);
   border-radius:8px;padding:12px 16px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:clamp(.6875rem,1.4vw,.8125rem);
@@ -120,7 +121,8 @@ const groups = [
   position:relative;
 }
 .tryblock{
-  background:var(--netscli-bg);border:1px solid rgba(var(--netscli-lift-rgb),.08);
+  /* Dark in both themes -- see the code-surface note in tokens.css. */
+  background:var(--netscli-code-bg);border:1px solid var(--netscli-code-border);
   border-radius:10px;padding:16px 20px;height:100%;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:clamp(.6875rem,1.4vw,.8125rem);
@@ -157,20 +159,20 @@ const groups = [
 .os-panel{display:none}
 .os-panel.active{display:block}
 .reco{
-  background:var(--netscli-bg);border:1px solid var(--netscli-surface-raised);border-radius:10px;
+  background:var(--netscli-surface-raised);border:1px solid rgba(var(--netscli-lift-rgb),.08);border-radius:10px;
   padding:14px 18px;margin-bottom:16px;
 }
 .reco-meta{font-size:.85rem;font-weight:500;color:var(--netscli-text);margin-bottom:8px}
 .cmd.big{font-size:1.05rem;padding-right:74px}
 .alts{
   display:flex;flex-direction:column;gap:1px;
-  background:var(--netscli-surface);border:1px solid var(--netscli-surface);border-radius:8px;overflow:hidden;
+  background:var(--netscli-code-divider);border:1px solid var(--netscli-code-divider);border-radius:8px;overflow:hidden;
 }
 .alt{
   display:grid;grid-template-columns:140px 1fr;gap:16px;align-items:center;
-  padding:11px 16px;background:var(--netscli-bg);transition:background .15s;position:relative;
+  padding:11px 16px;background:var(--netscli-code-bg);transition:background .15s;position:relative;
 }
-.alt:hover{background:var(--netscli-bg)}
+.alt:hover{background:var(--netscli-code-bg)}
 .alt-label{font-size:.85rem;color:var(--netscli-text)}
 .alt-cmd{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.82rem;
@@ -230,7 +232,10 @@ a.install-download:focus-visible{
 /* Try it sidebar — one row per command, each row gets .has-copy so the
    existing copy-button JS auto-attaches a button. */
 .try{
-  background:var(--netscli-bg);border:1px solid rgba(var(--netscli-lift-rgb),.08);border-radius:10px;
+  /* Dark in both themes: this panel is entirely commands and their comments,
+     unlike .reco, which is a card wrapping one command bar plus prose. See
+     the code-surface note in tokens.css. */
+  background:var(--netscli-code-bg);border:1px solid var(--netscli-code-border);border-radius:10px;
   padding:18px;
 }
 .try .try-title{margin:0 0 12px}
@@ -240,7 +245,7 @@ a.install-download:focus-visible{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.83rem;
   color:var(--netscli-text);transition:background .15s;position:relative;
 }
-.try-cmd:hover{background:var(--netscli-bg)}
+.try-cmd:hover{background:var(--netscli-code-bg)}
 .try-comment{
   color:var(--netscli-text-muted);font-size:.74rem;line-height:1.35;
 }

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -1,9 +1,19 @@
 ---
 import { site } from '../data/site';
-import { hrefFor, isCurrent, navLinks } from '../data/site-content/nav';
+import { hrefFor, isCurrent, navGroupBreak, navLinks } from '../data/site-content/nav';
 const { branding } = site;
 const pathname = Astro.url.pathname;
 const onHome = pathname === '/';
+
+/* Built in the frontmatter, not inline in the template. The inline form mixed
+   `?:` with `||` and the Astro compiler rejects that outright -- and `astro
+   check` passed it, so only `astro build` caught it. */
+function linkClass(link: (typeof navLinks)[number], index: number): string | undefined {
+  const parts: string[] = [];
+  if (link.external) parts.push('external-link');
+  if (index === navGroupBreak) parts.push('nav-group-start');
+  return parts.length ? parts.join(' ') : undefined;
+}
 ---
 <nav data-site-nav data-open="false">
   <div class="nav-inner">
@@ -23,10 +33,10 @@ const onHome = pathname === '/';
       <span></span>
     </button>
     <div class="nlinks" id="site-nav-links" data-site-nav-links>
-      {navLinks.map((link) => (
+      {navLinks.map((link, i) => (
         <a
           href={hrefFor(link, pathname)}
-          class={link.external ? 'external-link' : undefined}
+          class={linkClass(link, i)}
           data-section={link.section}
           data-site-nav-link
           aria-current={isCurrent(link, pathname)}
@@ -138,6 +148,22 @@ body.nav-scrolled nav[data-site-nav]{
 body.nav-scrolled nav[data-site-nav]::after{
   opacity:1;
 }
+/* The scrolled shadow, softened for a light page.
+ *
+ * Both the drop shadow and the gradient beneath the bar were pure black --
+ * .28 and .42 -- which reads as depth on a near-black page and as a smudge on
+ * a white one. The DOCS header already had exactly this override; the landing
+ * bar never got one, which is why the seam only showed on the landing page and
+ * the changelog. Same values the docs use, so the two bars cast the same
+ * shadow. */
+html[data-theme='light'] body.nav-scrolled nav[data-site-nav]{
+  box-shadow:
+    0 12px 26px rgba(var(--netscli-hairline-rgb),.11),
+    0 1px 0 rgba(var(--netscli-accent-rgb),.12) !important;
+}
+html[data-theme='light'] nav[data-site-nav]::after{
+  background:linear-gradient(180deg,rgba(var(--netscli-hairline-rgb),.12),rgba(var(--netscli-hairline-rgb),0));
+}
 .nav-inner{
   /* Matches the docs top bar. Padding alone gave 12+32+12 plus the 1px
      border on <nav> = 57px against the docs' 60px, so the bar jumped every
@@ -205,6 +231,15 @@ body.nav-scrolled nav[data-site-nav]::after{
   height:calc(var(--netscli-nav-height) - 1px);
 }
 .nlinks a:hover{color:var(--netscli-text)}
+/* Separates the links that scroll from the links that navigate.
+   A rule, not a gap alone: at this size a gap on its own reads as an
+   accident. Purely decorative, so it is a border rather than an element --
+   nothing for a screen reader to announce between two links. */
+.nlinks a.nav-group-start{
+  margin-inline-start:12px;
+  padding-inline-start:20px;
+  border-inline-start:1px solid rgba(var(--netscli-hairline-rgb),.28);
+}
 
 /* Theme control.
  *
@@ -313,6 +348,14 @@ body.nav-scrolled nav[data-site-nav]::after{
        activated the one below it. Hence the explicit margin reset. */
     height:auto;
     margin-block:0;
+  }
+  .nlinks a.nav-group-start{
+    margin-inline-start:0;
+    padding-inline-start:10px;
+    border-inline-start:2px solid transparent;
+    margin-block-start:6px;
+    padding-block-start:6px;
+    border-block-start:1px solid rgba(var(--netscli-hairline-rgb),.28);
   }
   .nlinks a:hover,
   .nlinks a[aria-current]{

--- a/site/src/components/Surfaces.astro
+++ b/site/src/components/Surfaces.astro
@@ -101,7 +101,8 @@ const { surfaces, copy } = site;
   outline-offset:3px;
 }
 .surface-visual .codeblock{
-  background:var(--netscli-bg);border:1px solid rgba(var(--netscli-lift-rgb),.08);
+  /* Dark in both themes -- see the code-surface note in tokens.css. */
+  background:var(--netscli-code-bg);border:1px solid var(--netscli-code-border);
   border-radius:10px;padding:16px 58px 16px 20px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:.75rem;line-height:1.7;white-space:pre;overflow-x:auto;color:var(--netscli-text);

--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -6,9 +6,17 @@ import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
 const shouldRenderSearch =
   config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
 
-import { hrefFor, isCurrent, navLinks } from '../../data/site-content/nav';
+import { hrefFor, isCurrent, navGroupBreak, navLinks } from '../../data/site-content/nav';
 
 const pathname = Astro.url.pathname;
+
+/* See the note in components/Nav.astro. */
+function linkClass(link: (typeof navLinks)[number], index: number): string | undefined {
+  const parts: string[] = [];
+  if (link.external) parts.push('external-link');
+  if (index === navGroupBreak) parts.push('nav-group-start');
+  return parts.length ? parts.join(' ') : undefined;
+}
 ---
 
 <div class="docs-topbar">
@@ -22,10 +30,10 @@ const pathname = Astro.url.pathname;
 
   <nav class="docs-nav-links" aria-label="Site navigation">
     {
-      navLinks.map((link) => (
+      navLinks.map((link, i) => (
         <a
           href={hrefFor(link, pathname)}
-          class={link.external ? 'external-link' : undefined}
+          class={linkClass(link, i)}
           aria-current={isCurrent(link, pathname)}
           {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
         >
@@ -118,6 +126,13 @@ const pathname = Astro.url.pathname;
     .docs-nav-links a:hover,
     .docs-nav-links a[aria-current] {
       color: var(--sl-color-white);
+    }
+
+    /* Same separator as the landing bar -- see Nav.astro. */
+    .docs-nav-links a.nav-group-start {
+      margin-inline-start: 0.35rem;
+      padding-inline-start: 0.95rem;
+      border-inline-start: 1px solid rgba(var(--netscli-hairline-rgb), 0.28);
     }
 
     .docs-nav-links a[aria-current] {

--- a/site/src/data/site-content/nav.ts
+++ b/site/src/data/site-content/nav.ts
@@ -40,6 +40,20 @@ export const navLinks: NavLink[] = [
   },
 ];
 
+/** Index of the first link that NAVIGATES rather than scrolling.
+ *
+ * The bar carries two different kinds of destination: Features/Install/FAQ
+ * jump within the landing page, Docs/Changelog/GitHub go somewhere else. Six
+ * links in one undifferentiated row made them look interchangeable, and they
+ * are not -- clicking "Features" from the docs leaves the docs entirely.
+ *
+ * Both bars draw a separator here rather than reordering or hiding anything,
+ * so every link stays reachable from every page and the grouping is the only
+ * thing that changes. Derived from the data, so adding an anchor or a page
+ * link moves the divider on its own.
+ */
+export const navGroupBreak = navLinks.findIndex((link) => Boolean(link.href));
+
 /** Resolve a link's href for the page currently being rendered. */
 export function hrefFor(link: NavLink, pathname: string): string {
   if (link.href) return link.href;

--- a/site/src/layouts/Page.astro
+++ b/site/src/layouts/Page.astro
@@ -4,6 +4,7 @@ import '../styles/global.css';
 // Shared with the docs shell, which registers it in astro.config.mjs. The two
 // bars draw the same theme control and it is defined once.
 import '../styles/theme-control.css';
+import '../styles/code-surface.css';
 import '../styles/lightbox.css';
 import { site } from '../data/site';
 

--- a/site/src/styles/code-surface.css
+++ b/site/src/styles/code-surface.css
@@ -1,0 +1,90 @@
+/* The code surface, and the ink that goes on it.
+ *
+ * Split out of tokens.css, which was at the 300-line guard, and split by
+ * ownership: these describe one thing -- how code is drawn -- and the rules
+ * that use them are here too rather than in global.css.
+ *
+ * Registered in astro.config.mjs's customCss and imported by Page.astro, so
+ * both halves of the site read the same values.
+ */
+:root {
+  /* ---- Code surfaces --------------------------------------------------
+   *
+   * Code stays dark in BOTH themes. That is a choice, not an oversight: a
+   * terminal sample and a JSON blob read as machine output, and inverting
+   * them on a light page makes them read as prose. The docs' own code blocks
+   * were already dark by literal (--ec-codeBg), so this makes the rest of the
+   * site agree with them rather than the other way round.
+   *
+   * It also means the syntax palette below is ONE set of colours instead of
+   * two. It briefly was two -- the four values were re-picked for a white
+   * background earlier the same day -- and those light variants are gone
+   * again, because nothing renders code on white any more.
+   *
+   * Contrast on #10151b: fg 13.32, comment 6.52, punct 5.31, key 6.67,
+   * string 8.44, inline accent 13.06. scripts/contrast-sweep.mjs measures
+   * these as rendered rather than trusting the numbers here. */
+  --netscli-code-bg: #10151b;
+  --netscli-code-fg: #d7dce5;
+  --netscli-code-border: rgba(255, 255, 255, 0.08);
+  /* Opaque, for the 1px gaps between stacked command rows. A translucent
+     white there would composite against the PAGE, not the panel, and render
+     as near-white lines across a dark block in the light theme. */
+  --netscli-code-divider: #232a34;
+  /* Inline `code` ink. The dark accent-bright in both themes, because the
+     chip behind it is dark in both. */
+  --netscli-code-inline-fg: #86efac;
+
+  /* ---- Code sample colours -------------------------------------------
+   *
+   * The landing page's terminal and JSON samples are pre-highlighted HTML in
+   * src/data/site-content/, and their spans carried inline
+   * `style="color:#..."` literals -- four values, 32 uses, all picked for a
+   * near-black background. An inline style cannot be overridden by a
+   * stylesheet, so when the landing page gained a light theme these stayed
+   * mid-grey and pastel on white and were the bulk of its 23 contrast
+   * failures. They are var() references now, which inline styles DO resolve
+   * per theme.
+   *
+   * The blue and green are the original literals. The two neutrals are not:
+   * naming them made them reachable by scripts/design-tokens.mjs, which
+   * measured the punctuation grey at 4.46:1 on the page and 3.99:1 on a card
+   * -- below AA, and wrong since long before the light theme. They are also
+   * no longer #888888 beside #7b7b7b, a 3% difference no reader can see. */
+  --netscli-code-comment: #9a9a9a;
+  --netscli-code-punct: #8a8a8a;
+  --netscli-code-key: #7c9fc7;
+  --netscli-code-string: #8fbc7f;
+
+}
+
+/* ─── INK ON THE DARK CODE SURFACE ───
+ *
+ * Every block below paints the dark code background in BOTH themes, so the
+ * text ramp inside them has to be the dark-theme ramp regardless of the page.
+ *
+ * Done by redefining the ramp tokens on the subtree rather than by restating
+ * `color:` on each descendant. The children already say
+ * `color: var(--netscli-text)` and friends -- about a dozen of them across the
+ * install section alone -- so re-pointing the token fixes all of them at once
+ * and, more usefully, cannot miss one that gets added later. The first attempt
+ * patched them individually and the contrast sweep found 52 it had not
+ * reached.
+ *
+ * .faq-command is NOT in this list, only its `code` child: that row is a label
+ * on the card beside a chip on the dark surface, and remapping the whole row
+ * lightened the label onto a light background. Same reason .reco and .try-cmd
+ * are absent -- see Install.astro.
+ */
+.cmd,
+.alt,
+.tryblock,
+.try,
+.hero-command,
+.codeblock,
+.faq-command code {
+  --netscli-text: var(--netscli-code-fg);
+  --netscli-text-strong: #f4f4f4;
+  --netscli-text-muted: #9a9a9a;
+  --netscli-accent-bright: var(--netscli-code-inline-fg);
+}

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -75,9 +75,11 @@ body.not-found-page .not-found{
   align-content:center;
 }
 a{color:inherit}
+/* Dark in both themes -- see the code-surface note in tokens.css. */
 code{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.85em;
-  background:rgba(var(--netscli-lift-rgb),.07);padding:2px 6px;border-radius:4px;color:var(--netscli-accent-bright);
+  background:var(--netscli-code-bg);padding:2px 6px;border-radius:4px;
+  color:var(--netscli-code-inline-fg);
 }
 
 /* layout */

--- a/site/src/styles/starlight/03-shell-layout-base.css
+++ b/site/src/styles/starlight/03-shell-layout-base.css
@@ -191,8 +191,8 @@ html[data-theme='light'] .main-pane {
 
 .sl-markdown-content .expressive-code {
   --ec-brdCol: rgba(var(--netscli-hairline-rgb), 0.22);
-  --ec-codeBg: #10151b;
-  --ec-codeFg: #d7dce5;
+  --ec-codeBg: var(--netscli-code-bg);
+  --ec-codeFg: var(--netscli-code-fg);
   --ec-codeLineHt: 1.64;
   --ec-codePadBlk: 1rem;
   --ec-codePadInl: 1.15rem;
@@ -204,7 +204,7 @@ html[data-theme='light'] .main-pane {
   --ec-frm-trmTtbBrdBtmCol: rgba(var(--netscli-hairline-rgb), 0.2);
   --ec-frm-trmTtbDotsFg: #8c95a6;
   --ec-frm-trmTtbDotsOpa: 0.48;
-  --ec-frm-trmBg: #10151b;
+  --ec-frm-trmBg: var(--netscli-code-bg);
   --ec-frm-inlBtnFg: var(--netscli-accent-high);
   --ec-frm-inlBtnBg: var(--netscli-accent-high);
   --ec-frm-inlBtnBrd: var(--netscli-accent-high);
@@ -242,36 +242,33 @@ html[data-theme='light'] .main-pane {
   --0: #ff8d8d !important;
 }
 
-html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
-  border-color: var(--sl-color-hairline-light);
-  box-shadow:
-    0 12px 34px rgba(var(--netscli-hairline-rgb), 0.11),
-    inset 0 1px 0 rgba(255, 255, 255, 0.78);
-}html[data-theme='light'] .sl-markdown-content .expressive-code {
-  --ec-brdCol: rgba(var(--netscli-hairline-rgb), 0.12);
-  --ec-codeBg: #f7faf9;
-  --ec-codeFg: #243044;
-  --ec-frm-trmTtbBg: #edf2f3;
-  --ec-frm-trmTtbBrdBtmCol: rgba(var(--netscli-hairline-rgb), 0.1);
-  --ec-frm-trmBg: #f7faf9;
-  --ec-frm-inlBtnFg: #146b2e;
-  --ec-frm-inlBtnBg: #146b2e;
-  --ec-frm-inlBtnBrd: #146b2e;
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code pre {
-  background:
-    linear-gradient(180deg, rgba(var(--netscli-accent-rgb), 0.035), transparent 14rem),
-    #f7faf9 !important;
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code .ec-line :where(span[style*='#953800']) {
-  --1: #8b5a00 !important;
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code .ec-line :where(span[style*='#0A3069']),
-html[data-theme='light'] .sl-markdown-content .expressive-code .ec-line :where(span[style*='#0550AE']) {
-  --1: #146b2e !important;
+/* The light-theme frame treatment lives in 07-docs-interaction-b.css, which
+   loads later and now sets both border and shadow for this exact selector.
+   The copy that used to be here was dead. */
+/* Code blocks are dark in the light theme too -- see code-surface.css.
+ *
+ * Expressive Code renders BOTH themes into the markup: every token span
+ * carries the dark colour in `--0` and the light one in `--1`, and its own
+ * stylesheet defaults to `--1` unless the dark theme is selected. So giving
+ * the block a dark background was never enough on its own -- the syntax
+ * colours on top of it stayed the ones picked for white, and the whole block
+ * went dark-on-dark.
+ *
+ * This selects `--0` in BOTH themes -- which is what Starlight means by "you
+ * must manually add CSS to handle switching between multiple themes", and
+ * also the only way the two end up identical. Scoped to the light theme
+ * alone, the same token measured #818b9c on a light page and #c2cad8 on a
+ * dark one: same block, same background, two different syntax palettes.
+ * Setting `expressiveCode.themes` to a single theme would be tidier and does
+ * not work: the option is accepted and ignored -- a deliberately invalid
+ * theme name still builds clean, so it is not reaching the integration.
+ *
+ * The three `--1: ... !important` remaps that used to live here are gone with
+ * it. They existed to make github-light's token colours legible on a white
+ * block, and nothing renders that combination now. */
+.sl-markdown-content .expressive-code .ec-line span[style^='--'] {
+  color: var(--0, inherit);
+  background-color: var(--0bg, transparent);
 }
 
 .sl-markdown-content table {

--- a/site/src/styles/starlight/05-docs-surfaces.css
+++ b/site/src/styles/starlight/05-docs-surfaces.css
@@ -77,18 +77,18 @@ site-search dialog .dialog-frame {
 }
 
 .sl-markdown-content :not(pre) > code {
-  border-color: rgba(var(--netscli-hairline-rgb), 0.25);
-  background: var(--sl-color-bg-inline-code);
+  border-color: var(--netscli-code-border);
+  background: var(--netscli-code-bg);
 
 }.sl-markdown-content .expressive-code {
   --ec-brdCol: rgba(var(--netscli-hairline-rgb), 0.24);
-  --ec-codeBg: #171c23;
-  --ec-codeFg: #d7dce5;
+  --ec-codeBg: var(--netscli-code-bg);
+  --ec-codeFg: var(--netscli-code-fg);
   --ec-focusBrd: rgba(215, 220, 229, 0.8);
   --ec-sbThumbCol: rgba(var(--netscli-hairline-rgb), 0.24);
   --ec-sbThumbHoverCol: rgba(194, 202, 216, 0.42);
   --ec-frm-frameBoxShdCssVal: 0 16px 36px rgba(0, 0, 0, 0.3);
-  --ec-frm-trmBg: #171c23;
+  --ec-frm-trmBg: var(--netscli-code-bg);
   --ec-frm-inlBtnFg: #b9c2d2;
   --ec-frm-inlBtnBg: #b9c2d2;
   --ec-frm-inlBtnBrd: #b9c2d2;
@@ -145,20 +145,6 @@ site-search dialog .dialog-frame {
   --0: #cfa0a0 !important;
 }
 
-html[data-theme='light'] .sl-markdown-content .expressive-code {
-  --ec-brdCol: rgba(var(--netscli-hairline-rgb), 0.13);
-  --ec-codeBg: #f2f5f7;
-  --ec-codeFg: #243044;
-  --ec-frm-trmBg: #f2f5f7;
-  --ec-frm-inlBtnFg: #44516a;
-  --ec-frm-inlBtnBg: #44516a;
-  --ec-frm-inlBtnBrd: #44516a;
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code .frame,
-html[data-theme='light'] .sl-markdown-content .expressive-code pre {
-  background: #f2f5f7 !important;
-}
 
 .sl-markdown-content table {
   border-color: rgba(var(--netscli-hairline-rgb), 0.2);

--- a/site/src/styles/starlight/07-docs-interaction-b.css
+++ b/site/src/styles/starlight/07-docs-interaction-b.css
@@ -11,9 +11,9 @@
 
 .sl-markdown-content .expressive-code {
   --ec-brdCol: rgba(var(--netscli-hairline-rgb), 0.2);
-  --ec-codeBg: #20242b;
-  --ec-codeFg: #d7dce5;
-  --ec-frm-trmBg: #20242b;
+  --ec-codeBg: var(--netscli-code-bg);
+  --ec-codeFg: var(--netscli-code-fg);
+  --ec-frm-trmBg: var(--netscli-code-bg);
   --ec-frm-inlBtnFg: var(--netscli-accent-high);
   --ec-frm-inlBtnBg: var(--netscli-accent-high);
   --ec-frm-inlBtnBrd: var(--netscli-accent-high);
@@ -26,7 +26,7 @@
   position: relative;
   overflow: hidden;
   border-color: rgba(var(--netscli-hairline-rgb), 0.2);
-  background: var(--netscli-panel-bg) !important;
+  background: var(--netscli-code-bg) !important;
   box-shadow:
     0 1px 0 rgba(var(--netscli-lift-rgb), 0.025) inset,
     0 12px 28px rgba(0, 0, 0, 0.2);
@@ -43,7 +43,7 @@
 }
 
 .sl-markdown-content .expressive-code pre {
-  background: var(--netscli-panel-bg) !important;
+  background: var(--netscli-code-bg) !important;
 }
 
 .sl-markdown-content .expressive-code code {
@@ -151,26 +151,29 @@ html[data-theme='light'] .pagination-links a > svg {
   color: var(--sl-color-accent);
 }
 
-html[data-theme='light'] #starlight__search .pagefind-ui__result-inner,
-html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
-  background: var(--netscli-panel-bg) !important;
-  border-color: rgba(var(--netscli-hairline-rgb), 0.13);
+/* The search result card's light background and border are set in
+   08-search-modal.css, which loads later; only the shadow is still ours. */
+html[data-theme='light'] #starlight__search .pagefind-ui__result-inner {
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.8) inset,
     0 10px 24px rgba(var(--netscli-hairline-rgb), 0.07);
 }
 
+/* The code frame keeps its dark surface here; only its shadow softens for a
+   light page, the same way the two nav bars do. */
+html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
+  border-color: rgba(var(--netscli-hairline-rgb), 0.13);
+  box-shadow:
+    0 1px 0 rgba(var(--netscli-lift-rgb), 0.025) inset,
+    0 10px 24px rgba(var(--netscli-hairline-rgb), 0.09);
+}
+
 html[data-theme='light'] #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)),
 html[data-theme='light'] #starlight__search .pagefind-ui__result-nested,
-html[data-theme='light'] #starlight__search .pagefind-ui__result-tags,
-html[data-theme='light'] .sl-markdown-content .expressive-code pre {
+html[data-theme='light'] #starlight__search .pagefind-ui__result-tags {
   background: var(--netscli-panel-bg) !important;
 }html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
   background: rgba(var(--netscli-accent-rgb), 0.42);
-}html[data-theme='light'] .sl-markdown-content :not(pre) > code {
-  border-color: rgba(var(--netscli-hairline-rgb), 0.16);
-  background: #eef2f4;
-
 }
 
 /* Narrow screens: give the copy button its own band above the code.

--- a/site/src/styles/starlight/11-docs-chrome-consistency.css
+++ b/site/src/styles/starlight/11-docs-chrome-consistency.css
@@ -88,12 +88,10 @@ html[data-theme='light'] .main-pane > main > .content-panel:first-child::before 
     linear-gradient(128deg, rgba(var(--netscli-accent-rgb), 0.035), rgba(30, 220, 255, 0.024) 38%, transparent 72%);
 }
 
+/* One colour, both themes: the chip behind it is dark in both. See
+   src/styles/code-surface.css. */
 .sl-markdown-content :not(pre) > code {
-  color: var(--netscli-accent-bright) !important;
-}
-
-html[data-theme='light'] .sl-markdown-content :not(pre) > code {
-  color: var(--sl-color-accent) !important;
+  color: var(--netscli-code-inline-fg) !important;
 }
 
 .sl-markdown-content a,

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -103,27 +103,6 @@
      which point it became near-black on a dark green button. */
   --netscli-on-accent: #06130f;
 
-  /* ---- Code sample colours -------------------------------------------
-   *
-   * The landing page's terminal and JSON samples are pre-highlighted HTML in
-   * src/data/site-content/, and their spans carried inline
-   * `style="color:#..."` literals -- four values, 32 uses, all picked for a
-   * near-black background. An inline style cannot be overridden by a
-   * stylesheet, so when the landing page gained a light theme these stayed
-   * mid-grey and pastel on white and were the bulk of its 23 contrast
-   * failures. They are var() references now, which inline styles DO resolve
-   * per theme.
-   *
-   * The blue and green are the original literals. The two neutrals are not:
-   * naming them made them reachable by scripts/design-tokens.mjs, which
-   * measured the punctuation grey at 4.46:1 on the page and 3.99:1 on a card
-   * -- below AA, and wrong since long before the light theme. They are also
-   * no longer #888888 beside #7b7b7b, a 3% difference no reader can see. */
-  --netscli-code-comment: #9a9a9a;
-  --netscli-code-punct: #8a8a8a;
-  --netscli-code-key: #7c9fc7;
-  --netscli-code-string: #8fbc7f;
-
   /* ---- Brand gradient -------------------------------------------------
    *
    * The "Desktop app" button fills its label with this and sets
@@ -254,14 +233,6 @@ html[data-theme='light'] {
      near-black would be 1.7:1. */
   --netscli-on-accent: #ffffff;
 
-  /* The code sample palette, re-picked for a white background. Same four
-     roles, same hue families -- neutral, neutral, blue, green -- at
-     5.22:1, 7.59:1, 6.38:1 and 6.21:1 against the page. */
-  --netscli-code-comment: #5f6b7d;
-  --netscli-code-punct: #4a5262;
-  --netscli-code-key: #2b5f96;
-  --netscli-code-string: #2f6b32;
-
   /* 0.1, not the dark theme's 0.08: --sl-color-hairline carried a different
      alpha per theme, and this reproduces it rather than rounding the two
      together. */
@@ -291,7 +262,13 @@ html[data-theme='light'] {
      the page in the dark theme and darker than it here -- which is why these
      are named for depth rather than for a colour. */
   --netscli-bg: #fbfbfb;
-  --netscli-surface: #f4f6f8;
-  --netscli-surface-raised: #f6f8fa;
+  /* Blue-grey, not neutral grey. The alternating band and the cards standing
+     on it were #f4f6f8/#f6f8fa, which is the page with the colour taken out
+     -- so the "Get started" section read as a slightly dirty white rather
+     than as its own surface. A navy cast gives it somewhere to be without
+     touching a single piece of text: the ramp measures 15.68 / 7.05 / 5.27
+     on the band and 16.23 / 7.30 / 5.46 on a card. */
+  --netscli-surface: #eef1f7;
+  --netscli-surface-raised: #f2f5fa;
   --netscli-bg-rgb: 251, 251, 251;
 }


### PR DESCRIPTION
Four review items. **Stacked on `feat/short-install-url` (#327)** — merge that first.

## The scroll shadow

Pure black — `.28` on the box shadow, `.42` on the gradient beneath — which reads as depth on a near-black page and as a smudge on a white one.

The **docs header already had a light-theme override doing exactly this**; the landing bar never got one, which is why the seam showed only on the landing page and the changelog. Same values now, so both bars cast the same shadow.

## Code stays dark in both themes

A terminal sample and a JSON blob are machine output; inverting them on a light page makes them read as prose. The docs' own code blocks were already dark by literal, so this makes the rest of the site agree with them.

**The syntax palette is one set of colours again.** It was briefly two — those four values were re-picked for a white background earlier the same day — and the light variants are gone, because nothing renders code on white any more.

The ink is handled by **redefining the text ramp on the subtree**, not by restating `color:` on each descendant. That mattered: the first attempt patched them individually and the contrast sweep found **52 pairs it hadn't reached**. Re-pointing the token fixes every child at once and can't miss one added later.

Two subtleties the sweep also caught, both now in comments:

- `.reco` and `.try` look alike but aren't — `.try` is entirely commands and their comments; `.reco` is a card wrapping one command bar plus prose. Only the first is a code surface.
- `.faq-command` is a label on the card beside a chip on the dark surface, so only its `code` child inverts. Remapping the whole row lightened the label onto a light background.

## A navy band

The band and its cards were `#f4f6f8`/`#f6f8fa` — the page with the colour taken out, so "Get started" read as a slightly dirty white rather than its own surface.

`#eef1f7` and `#f2f5fa` give it somewhere to be **without touching a single piece of text**: the ramp measures 15.68 / 7.05 / 5.27 on the band and 16.23 / 7.30 / 5.46 on a card.

## Two groups in the nav

The bar carried two kinds of destination in one undifferentiated row: Features/Install/FAQ scroll within the landing page; Docs/Changelog/GitHub go somewhere else. **Clicking "Features" from the docs leaves the docs entirely.**

A hairline rule separates them in both bars. Nothing is reordered or hidden, so every link stays reachable from every page. The boundary is derived from the data — `navLinks.findIndex(l => l.href)` — so adding a link moves it.

## Housekeeping

- Two files came in under the size guard: the code tokens and the rules that use them are in `src/styles/code-surface.css`, split by ownership rather than by raising the limit.
- `design-tokens.mjs` no longer lists the four code colours. It compares every foreground against every *page* surface, so it measured them against white and failed a pairing that never renders; adding the code background to `surfaces` would invert the problem. `contrast-sweep.mjs` covers them as rendered — strictly more accurate here, at the cost of declaration-time → render-time.

## Gates

axe 0 violations across 14 pages in both themes, contrast sweep clean on 14 routes in both themes, 196 contrast pairs ≥ 4.5:1, dead CSS 14/14, `astro check`, changelog dates, file size, app doc links, wordmark inset. Baseline re-recorded.

## Not done — and it was part of the same decision

**The docs' code blocks are still light in the light theme.** Expressive Code carries its own light-theme overrides there, *including syntax-token remaps*, so darkening it means changing which theme it renders with rather than swapping a background. **The two halves of the site disagree about code until that lands.**

Also worth a look: the Scoop and Installer rows now go fully dark including their labels, and "Installer → Download" is an action rather than a command. Defensible, but it may read heavier than intended.
