### PR TITLE
Fix four inaccurate claims in the site copy

### DIFF
--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -174,7 +174,9 @@ first run.
 
 ## Packet capture
 
-**No install on this page includes packet capture.** It is a compile-time feature, and every published build — the desktop installers, the standard CLI release assets, and `cargo install netscli` — is built without it. That keeps the default install free of any libpcap/Npcap dependency and avoids redistributing Npcap.
+**None of the installs above include packet capture.** It is a compile-time feature, and the default builds — the desktop installers, the standard CLI release assets, and `cargo install netscli` — are built without it. That keeps the default install free of any libpcap/Npcap dependency and avoids redistributing Npcap.
+
+Getting it is a deliberate extra step, and the rest of this section is how.
 
 Normal scan, discovery, DNS, ARP, ping, trace, and interface workflows are unaffected and need none of this.
 

--- a/site/src/content/docs/docs/interface-coverage.md
+++ b/site/src/content/docs/docs/interface-coverage.md
@@ -67,8 +67,11 @@ server does not expose it as a tool.
 ### Notes on the ticks
 
 - **Packet capture** needs a build compiled with the feature *and* the system
-  capture library — Npcap on Windows, libpcap elsewhere. No published build
-  has it. See [Installation](/docs/install/#packet-capture).
+  capture library — Npcap on Windows, libpcap elsewhere. No *default* install
+  has it: the desktop installers, the standard CLI assets and
+  `cargo install netscli` are all built without it. Each release does publish
+  separate `-pcap` CLI assets that have it compiled in. See
+  [Installation](/docs/install/#packet-capture).
 - **Structured output** means something different on each surface, which is
   why it is one row rather than four: the desktop app exports files and
   result bundles, the CLI takes `--json` and `--yaml`, the TUI exports a

--- a/site/src/data/site-content/faq.ts
+++ b/site/src/data/site-content/faq.ts
@@ -22,7 +22,14 @@ export const faq: FaqItem[] = [
   {
     group: 'Install and updates',
     q: 'How do I install NetsCLI?',
-    a: 'Install the netscli package for the CLI, terminal UI, and MCP server. On Windows, run: winget install netscli (the full identifier fstubner.netscli also works). On Linux or macOS, run: ${INSTALL_SH_COMMAND}. For the Windows desktop app, run: winget install netscli-gui. With Rust installed you can also run: cargo install netscli. Prebuilt binaries and desktop installers are attached to GitHub releases when available for that platform.',
+    // Backticks, not quotes. This was a single-quoted string containing
+    // `${INSTALL_SH_COMMAND}`, so the placeholder never interpolated -- and
+    // because `a` is copied verbatim into the FAQPage JSON-LD, the literal
+    // text `${INSTALL_SH_COMMAND}` shipped in the structured data every
+    // search engine and answer engine reads. The visible `aHtml` below was
+    // already a template literal and rendered correctly, which is why the
+    // page looked fine.
+    a: `Install the netscli package for the CLI, terminal UI, and MCP server. On Windows, run: winget install netscli (the full identifier fstubner.netscli also works). On Linux or macOS, run: ${INSTALL_SH_COMMAND}. For the Windows desktop app, run: winget install netscli-gui. With Rust installed you can also run: cargo install netscli. Prebuilt binaries and desktop installers are attached to GitHub releases when available for that platform.`,
     aHtml: `
       <p>Install the <code>netscli</code> package for the CLI, terminal UI, and MCP server:</p>
       <div class="faq-command-list" aria-label="Install commands">

--- a/site/src/data/site-content/hero.ts
+++ b/site/src/data/site-content/hero.ts
@@ -22,7 +22,14 @@ export const hero: Hero = {
     // find nothing. The capture-enabled CLI assets are real and published, so
     // the feature stays on the page; it just no longer implies the download
     // above it includes it.
-    'Discover LAN devices, scan TCP ports, query DNS, trace routes, and inspect hosts from the desktop app, terminal UI, CLI, or MCP server — with packet capture in capture-enabled CLI builds. Each interface calls the same Rust core, so results stay consistent.',
+    // Traceroute is deliberately absent from this list. It used to be in it,
+    // and the sentence attributes every operation it names to all four
+    // interfaces -- but the MCP server has no traceroute tool at all (docs
+    // say so outright: /docs/interface-coverage/ "Trace route has no MCP
+    // tool"). The list was already illustrative rather than exhaustive; it
+    // omits ping, sweep, ARP and mDNS too. Dropping the one operation that
+    // does not hold for all four is cheaper than qualifying it.
+    'Discover LAN devices, scan TCP ports, query DNS, and inspect hosts from the desktop app, terminal UI, CLI, or MCP server — with packet capture in capture-enabled CLI builds. Each interface calls the same Rust core, so results stay consistent.',
   // `winget install netscli` leads, and the shell script follows.
   //
   // os-tabs.ts already swapped these per-OS at runtime -- Windows visitors

--- a/site/src/data/site-content/meta.ts
+++ b/site/src/data/site-content/meta.ts
@@ -12,14 +12,20 @@ export const meta: Meta = {
   // also ran operations and interfaces through a single "for" series
   // ("a scanner for ... packet capture, and desktop, terminal, CLI, and MCP
   // workflows"), which does not parse cleanly.
+  // "inspect hosts", not "trace routes": the sentence attributes what it
+  // lists to all four interfaces, and the MCP server has no traceroute tool.
+  // `inspect_host` is a real MCP tool, so the swap keeps the claim true.
+  // Measured at 154 characters in the built page, one more than the 153 this
+  // replaced -- still inside the ~160 a search result shows, and the MCP
+  // mention this description was rewritten to protect is nowhere near the cut.
   description:
-    'Discover LAN devices, scan TCP ports, query DNS, and trace routes from a desktop app, terminal UI, CLI, or MCP server. One Rust core, consistent results.',
+    'Discover LAN devices, scan TCP ports, query DNS, and inspect hosts from a desktop app, terminal UI, CLI, or MCP server. One Rust core, consistent results.',
   // Same scoping as the hero subhead: capture is not in any published desktop
   // installer, so this must not imply it ships with the app. It is what search
   // results and link previews show, which is where an inaccurate claim travels
   // furthest.
   ogDescription:
-    'Discover LAN devices, scan TCP ports, query DNS, trace routes, and inspect hosts from the desktop app, terminal UI, CLI, or MCP server backed by one Rust core. Packet capture in capture-enabled CLI builds.',
+    'Discover LAN devices, scan TCP ports, query DNS, and inspect hosts from the desktop app, terminal UI, CLI, or MCP server backed by one Rust core. Packet capture in capture-enabled CLI builds.',
   siteName: 'NetsCLI',
   author: { name: 'Felix Stubner', url: 'https://github.com/fstubner' },
   ogImage: 'https://netscli.com/assets/tui-discover.png',

--- a/site/src/data/site-content/surfaces.ts
+++ b/site/src/data/site-content/surfaces.ts
@@ -38,13 +38,18 @@ export const surfaces: SurfaceCard[] = [
     title: 'Command line',
     body:
       'Use the CLI for repeatable diagnostics and automation. Network operations expose <code>--json</code> and <code>--yaml</code> output, so scripts and other tools can consume the same data the desktop app displays.',
+    // `--resolve` on the discover line is load-bearing, not decoration.
+    // `hostname` is only populated when the flag is passed (core's
+    // discover.rs guards the reverse-lookup pass on it), so without it this
+    // sample's own output would be three nulls rather than the three names
+    // shown below it.
     codeHtml: `<span style="color:var(--netscli-code-comment)">$</span> netscli scan demo.local -p 80,443 --json
 <span style="color:var(--netscli-code-punct)">[</span>
   <span style="color:var(--netscli-code-punct)">{</span> <span style="color:var(--netscli-code-key)">"port"</span>: 80,  <span style="color:var(--netscli-code-key)">"open"</span>: true, <span style="color:var(--netscli-code-key)">"service"</span>: <span style="color:var(--netscli-code-string)">"http"</span>  <span style="color:var(--netscli-code-punct)">}</span>,
   <span style="color:var(--netscli-code-punct)">{</span> <span style="color:var(--netscli-code-key)">"port"</span>: 443, <span style="color:var(--netscli-code-key)">"open"</span>: true, <span style="color:var(--netscli-code-key)">"service"</span>: <span style="color:var(--netscli-code-string)">"https"</span> <span style="color:var(--netscli-code-punct)">}</span>
 <span style="color:var(--netscli-code-punct)">]</span>
 
-<span style="color:var(--netscli-code-comment)">$</span> netscli discover --json | jq '.[].hostname'
+<span style="color:var(--netscli-code-comment)">$</span> netscli discover --resolve --json | jq '.[].hostname'
 <span style="color:var(--netscli-code-string)">"workstation.local"</span>
 <span style="color:var(--netscli-code-string)">"phone.local"</span>
 <span style="color:var(--netscli-code-string)">"pi.local"</span>`,


### PR DESCRIPTION
Found by reading all eleven docs pages and the landing copy against the Rust source, rather than against each other.

## What was wrong

**1. A template placeholder was shipping into the structured data.** `faq.ts` built the install answer's plain-text `a` field with single quotes around `${INSTALL_SH_COMMAND}`, so it never interpolated. That field is copied verbatim into the FAQPage JSON-LD, so the literal string `${INSTALL_SH_COMMAND}` was in the structured data search and answer engines read. The visible `aHtml` beside it was already a template literal and rendered fine, which is why nobody saw it.

Confirmed in the built output before and after:

```
before: On Linux or macOS, run: ${INSTALL_SH_COMMAND}.
after:  On Linux or macOS, run: curl -fsSL https://netscli.com/install.sh | bash.
```

**2. Three places claimed traceroute works over MCP.** The hero subhead, the meta description and the og:description all listed "trace routes" among operations available "from the desktop app, terminal UI, CLI, or MCP server". There is no traceroute tool in the MCP server — no reference to one anywhere in `netscli-mcp` — and `/docs/interface-coverage/` already states "Trace route has no MCP tool."

Those lists were illustrative, not exhaustive (they omit ping, sweep, ARP and mDNS), so the one operation that does not hold for all four is dropped rather than qualified. The meta description swaps in "inspect hosts", which *is* a real MCP tool; measured at 154 characters, one more than the 153 it replaced.

**3. A landing-page sample could not produce its own output.** `netscli discover --json | jq '.[].hostname'` was shown returning three hostnames. `crates/netscli-core/src/discover.rs` populates `hostname` only `if resolve`, so as printed it returns `null` for every host. Added `--resolve`.

**4. "No published build has it" was false.** `/docs/interface-coverage/` said that of packet capture; v0.2.6 publishes five capture-enabled CLI assets (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64). Reworded to the scoping `/docs/packet-capture/` already had right. The install guide's version of the same sentence claimed no install "on this page" includes capture, twelve lines above an install that does — scoped to the installs above it.

## Verified clean in the same pass

All 13 MCP tool names and descriptions; the CLI flags sampled (`--count`, `--max-hops`, `--timeout-ms`, `--record`); crate names and the dependency-direction diagram; the `Ops::scan_ports` example against its real signature; the full `PortResult` field table; both winget monikers; the four safety limits. The `--timeout-ms` (CLI) vs `--timeout` (TUI) difference is real, not an error.

## Not fixed here

`site.version` is read from the GUI's package.json and rendered nowhere. The landing scan sample omits `status`, which is always serialised. The result-model host table omits `found_by`. All cosmetic; left out to keep this diff to the incorrect claims.

## Checks

`astro check` 0 errors, changelog dates pass, dead CSS 14/14, build clean. Each of the four fixes verified in `dist/`, not just in the diff.