### PR TITLE
Make the copy buttons dark in the light theme too

### DIFF
--- a/site/src/styles/code-surface.css
+++ b/site/src/styles/code-surface.css
@@ -87,4 +87,20 @@
   --netscli-text-strong: #f4f4f4;
   --netscli-text-muted: #9a9a9a;
   --netscli-accent-bright: var(--netscli-code-inline-fg);
+  /* The copy button sits INSIDE these blocks, and global.css draws it with
+   * `background: var(--netscli-surface-raised)` -- a page surface, which is
+   * near-white in the light theme. Measured on the landing page before this
+   * line: rgb(242,245,250) on an rgb(16,21,27) block, a white chip on a dark
+   * sample. The ramp above fixed the button's ink and left its background
+   * behind, because the background is not part of the text ramp.
+   *
+   * Same reasoning as the ramp: re-point the token rather than restate
+   * `background:` on `.copy-btn`, so anything else in here that paints a
+   * raised surface follows too.
+   *
+   * .faq-command is still absent from this list, and it matters more here
+   * than for the ink: its copy button really does sit on the light card, not
+   * on the chip, so it must keep the light surface. Only `.faq-command code`
+   * is remapped, and that element has no button inside it. */
+  --netscli-surface-raised: #20242b;
 }

--- a/site/src/styles/starlight/09-search-table-fit.css
+++ b/site/src/styles/starlight/09-search-table-fit.css
@@ -68,23 +68,26 @@ html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
   background: var(--netscli-table-stripe) !important;
 }
 
-html[data-theme='light'] .sl-markdown-content .expressive-code .copy button {
-  border-color: rgba(var(--netscli-hairline-rgb), 0.14) !important;
-  background: #e9eef2 !important;
-  color: var(--sl-color-gray-1) !important;
-  opacity: 1;
-  box-shadow: none !important;
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code .copy button:hover,
-html[data-theme='light'] .sl-markdown-content .expressive-code .copy button:focus-visible {
-  border-color: rgba(var(--netscli-accent-rgb), 0.32) !important;
-  background: #dde6ea !important;
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code .copy button::before {
-  border-color: rgba(var(--netscli-hairline-rgb), 0.26) !important;
-}
+/* The copy button has no light-theme treatment any more.
+ *
+ * It used to have three rules here -- a #e9eef2 background, a #dde6ea hover,
+ * and a lighter ::before border -- and all three were correct when the code
+ * block underneath them was white. It is #10151b in both themes now (see
+ * src/styles/code-surface.css), so those rules drew a near-white chip on a
+ * dark block: measured rgb(233,238,242) on rgb(16,21,27) in the light theme
+ * against rgb(37,43,54) in the dark one, for the same button on the same
+ * background.
+ *
+ * Deleted rather than remapped. The button is on a dark surface in both
+ * themes, so there is nothing left for a light-theme override to say, and the
+ * base rules in 05 and 07 already say it once.
+ *
+ * The `opacity: 1` in that first rule went with them, and it was doing real
+ * damage on its own: it overrode the hover-reveal in
+ * 07-docs-interaction-b.css, so in the light theme the button was permanently
+ * on and sat over the first line of code -- the exact overlap that rule was
+ * added to prevent, and which its own comment measured on 5 of 18 blocks on
+ * /docs/install/. Dark got the reveal; light did not. Both do now. */
 
 .sl-markdown-content .expressive-code .copy button {
   box-shadow: none !important;

--- a/site/src/styles/starlight/10-docs-feedback.css
+++ b/site/src/styles/starlight/10-docs-feedback.css
@@ -54,6 +54,3 @@
   background: #ffffff !important;
   box-shadow: none !important;
 }
-
-html[data-theme='light'] .sl-markdown-content .expressive-code .copy button[data-copied] {
-}

--- a/site/src/styles/starlight/12-docs-toc-responsive.css
+++ b/site/src/styles/starlight/12-docs-toc-responsive.css
@@ -183,22 +183,8 @@ html[data-theme='light'] mobile-starlight-toc .display-current {
   mask-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 8.2 6.1 11 13 4'/%3E%3C/svg%3E") !important;
 }
 
-html[data-theme='light'] .sl-markdown-content .expressive-code .copy button[data-copied] {
-  border-color: rgba(var(--netscli-hairline-rgb), 0.14) !important;
-  background: #e9eef2 !important;
-  color: #536176 !important;
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code .copy button[data-copied]::after {
-  background: #536176 !important;
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code .copy:has(.feedback.show) button {
-  border-color: rgba(var(--netscli-accent-rgb), 0.3) !important;
-  background: #e5f3ef !important;
-  color: var(--sl-color-accent) !important;
-}
-
-html[data-theme='light'] .sl-markdown-content .expressive-code .copy:has(.feedback.show) button::after {
-  background: var(--sl-color-accent) !important;
-}
+/* The copied and confirmation states have no light-theme treatment either,
+ * for the same reason the base button lost its own in
+ * 09-search-table-fit.css: the block under them is dark in both themes, so a
+ * #e9eef2 chip and a #e5f3ef confirmation were light-on-dark. The dark rules
+ * directly above cover both themes now. */


### PR DESCRIPTION
Left behind by #328: the code blocks went dark in both themes, the copy buttons sitting on top of them did not. Two separate causes, one on each half of the site.

Found by eye while looking at the preview, then confirmed by measurement — **no gate covers this**. The contrast sweep checks text nodes and the button's glyph is an SVG mask; axe agrees with it. Worth knowing before trusting the green ticks on this one.

## Measured

Headless Chrome at 1600px, copy-button background against an `rgb(16,21,27)` block:

| | before (light) | after (light) | dark |
|---|---|---|---|
| docs `.copy button` | `rgb(233,238,242)` | `rgb(37,43,54)` | `rgb(37,43,54)` |
| `.codeblock .copy-btn` | `rgb(242,245,250)` | `rgb(32,36,43)` | `rgb(32,36,43)` |
| `.faq-command .copy-btn` | `rgb(242,245,250)` | `rgb(242,245,250)` | unchanged |

## Docs

Three light-theme rules in `09-search-table-fit.css` and four more in `12-docs-toc-responsive.css` styled the Expressive Code copy button for a white block — a `#e9eef2` chip, a `#dde6ea` hover, a `#e5f3ef` confirmation. All were correct when the block underneath was white.

Deleted rather than remapped: the button is on `#10151b` in both themes now, so there is nothing left for a light-theme override to say, and the base rules in `05` and `07` already say it once. An empty light-theme rule in `10-docs-feedback.css` went with them.

**The first of those rules also carried `opacity: 1`**, which overrode the hover-reveal in `07-docs-interaction-b.css`. So in the light theme the button was permanently visible and sat over the first line of code — the exact overlap that reveal exists to prevent, and which its own comment measured on 5 of 18 blocks on `/docs/install/`. Dark got the reveal; light did not. Both do now (light opacity is back to `0` until hover).

## Landing page

`global.css` draws `.copy-btn` with `background: var(--netscli-surface-raised)` — a page surface, near-white in the light theme. The subtree ramp in `code-surface.css` fixed the button's ink and left its background, because a background is not part of a text ramp. Added the token to the same remap, so anything else in there painting a raised surface follows too.

`.faq-command` stays excluded, and it matters more here than it did for the ink: that row's button really does sit on the light card rather than on the dark chip, so it must keep the light surface. Only `.faq-command code` is remapped, and that element contains no button. Verified unchanged.

## Checks

axe clean in both themes, contrast sweep clean across 14 routes in both themes, dead CSS 14/14, `astro check` 0 errors, build clean.