### PR TITLE
Darken the wordmark on a light page

### DIFF
--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -182,7 +182,12 @@ html[data-theme='light'] nav[data-site-nav]::after{
 }
 .mark{
   display:inline-block;line-height:0;text-decoration:none;
-  filter:brightness(1);transition:filter 200ms;
+  /* No transition and no hover rule. Both used to be here and both were
+     no-ops: the base and the hover state were each `brightness(1)`, so the
+     200ms transition had nothing to animate between. Left as they were, the
+     hover rule would now undo the light theme's darkening the moment the
+     pointer touched the logo. */
+  filter:var(--netscli-mark-filter);
   /* Cancels the wordmark asset's own transparent left margin, so the glyph
      starts on the gutter the nav links start on. See tokens.css. */
   transform:translateX(calc(var(--netscli-mark-width) * var(--netscli-mark-inset-ratio) * -1));
@@ -190,7 +195,7 @@ html[data-theme='light'] nav[data-site-nav]::after{
 .mark img{
   display:block;width:var(--netscli-mark-width);height:auto;image-rendering:auto;
 }
-.mark:hover{filter:brightness(1)}
+
 .nav-menu-toggle{
   display:none;
   width:2.45rem;

--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -97,6 +97,9 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
       display: block;
       width: var(--netscli-mark-width);
       height: auto;
+      /* Same token as the landing bar's `.mark`, so both bars darken the
+         wordmark by the same amount on a light page. See tokens.css. */
+      filter: var(--netscli-mark-filter);
     }
 
     .docs-nav-links {

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -58,6 +58,13 @@
    * scripts/wordmark-inset.mjs re-derives the ratio from the PNG itself and
    * fails if this value has drifted from it. */
   --netscli-mark-width: 160px;
+
+  /* Both bars filter the wordmark through this. Dark leaves it alone; the
+     light theme darkens it -- see the override below for why. A token rather
+     than a rule on `.mark`, because the landing bar and the docs bar are
+     different components with their own scoped styles, and this is one
+     decision, not two. */
+  --netscli-mark-filter: none;
   --netscli-mark-inset-ratio: 0.0778;
 
   /* Tells the browser which way to draw the controls it renders itself: the
@@ -212,6 +219,24 @@
  * the two stacks cannot disagree about what "light" means. */
 html[data-theme='light'] {
   color-scheme: light;
+
+  /* The wordmark is a dark-theme asset and there is only one of it.
+   * netscli-wordmark.png runs green -> cyan and the cyan half is picked for a
+   * near-black bar, so on white the right side of the logo barely separates.
+   * Measured over its 34,754 opaque pixels: mean ink rgb(12,167,132) is
+   * 6.18:1 on #111 against 3.05:1 on white, and the cyan end rgb(27,213,235)
+   * is 1.79:1 on white. brightness(.62) takes the mean to 6.84:1 and the
+   * weakest pixel to 4.43:1.
+   *
+   * No gate caught this and none should have -- WCAG exempts logotypes from
+   * the contrast rules, so axe and contrast-sweep.mjs are correctly silent.
+   *
+   * A uniform multiply shifts the cyan towards teal instead of re-picking the
+   * gradient for a light page. A light-theme PNG would be more faithful and
+   * would also be a second file to keep in step with this one and with
+   * scripts/wordmark-inset.mjs. One declaration, reversible, until the hue
+   * shift bothers someone. */
+  --netscli-mark-filter: brightness(0.62);
 
   /* The accent, as a colour and as channels.
    *


### PR DESCRIPTION
`netscli-wordmark.png` is a dark-theme asset and there is only one of it — nothing swapped or adjusted it for the light theme.

## Why it looked washed out

Decoded the asset's 34,754 opaque pixels. The gradient runs green → cyan, and the cyan half is chosen for a near-black bar:

| | vs white | vs `#111` |
|---|---|---|
| mean ink `rgb(12,167,132)` | **3.05:1** | 6.18:1 |
| cyan end `rgb(27,213,235)` | **1.79:1** | — |
| teal bucket `rgb(32,192,192)`, 5,149px | **2.24:1** | 8.42:1 |

The colours that read best on `#111` are exactly the ones that fail hardest on white, so the right side of the logo barely separated from the page.

**No gate caught this and none should have** — WCAG exempts logotypes from the contrast rules, so axe and `contrast-sweep.mjs` are both correctly silent. Reported by eye.

## The change

`filter: brightness(.62)` in the light theme only, computed with the same filter maths browsers apply: mean ink becomes `rgb(8,103,82)` at **6.84:1**, and the weakest pixel goes from **1.79:1 to 4.43:1**.

Carried on `--netscli-mark-filter` in `tokens.css`, because the landing bar and the docs bar are separate components with their own scoped styles and this is one decision rather than two. Verified resolving as `brightness(0.62)` on both bars in light and `none` in both in dark.

**The tradeoff, stated plainly:** a uniform multiply shifts the cyan towards teal rather than re-picking the gradient for a light background. A light-theme PNG would render the brand more faithfully — it would also be a second file to keep in step with this one and with `wordmark-inset.mjs`, which derives the inset ratio from the asset's own alpha channel. This is one declaration and reversible; worth revisiting if the hue shift bothers you.

## Also removed

`Nav.astro`'s `.mark` loses `transition: filter 200ms` and `.mark:hover{filter:brightness(1)}`. Both were no-ops — base and hover were each `brightness(1)`, so the transition had nothing to animate between — and left in place, the hover rule would have undone the darkening the moment the pointer touched the logo.

## Checks

`astro check` 0 errors, wordmark inset 0.0778 measured against 0.0778 declared, dead CSS 14/14, build clean.