### PR TITLE
Draw the mobile breadcrumb chevrons with the same icon as the TOC

### DIFF
--- a/site/src/components/starlight/PageSidebar.astro
+++ b/site/src/components/starlight/PageSidebar.astro
@@ -69,11 +69,27 @@ const currentGroupLabel = formatCrumb(currentGroup?.label) || 'Start';
   mobileGroups.length > 0 && (
     <div class="docs-mobile-section-nav print:hidden">
       <details id="netscli-mobile-docs-nav">
+        {/*
+          The separators are Starlight's own `right-caret`, not a typographic
+          `›`, and they have to be: the mobile table of contents sits directly
+          below this row and draws its chevron with that icon. A text glyph and
+          a vector icon are not the same mark. Measured at 375px with the
+          separator at its rendered 13.12px, the `›` inked 4x4 while the TOC
+          caret inked 4.13x7 -- same width, 75% taller, one hairline and one
+          stroked. Two chevrons that close together should not disagree.
+
+          Copied inline rather than imported: Starlight's <Icon> lives behind
+          `virtual:starlight/...` internals this override does not get, and the
+          path is the one in
+          node_modules/@astrojs/starlight/components-internals/Icons.ts.
+          `width`/`height` 16 with viewBox 0 0 24 24 reproduces the TOC's
+          `size="1rem"` exactly.
+        */}
         <summary>
           <span class="docs-mobile-section-label">Docs</span>
-          <span class="docs-mobile-section-separator" aria-hidden="true">›</span>
+          <svg class="docs-mobile-section-separator" aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="m14.83 11.29-4.24-4.24a1 1 0 1 0-1.42 1.41L12.71 12l-3.54 3.54a1 1 0 0 0 0 1.41 1 1 0 0 0 .71.29 1 1 0 0 0 .71-.29l4.24-4.24a1.002 1.002 0 0 0 0-1.42Z"/></svg>
           <span class="docs-mobile-section-group">{currentGroupLabel}</span>
-          <span class="docs-mobile-section-separator" aria-hidden="true">›</span>
+          <svg class="docs-mobile-section-separator" aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="m14.83 11.29-4.24-4.24a1 1 0 1 0-1.42 1.41L12.71 12l-3.54 3.54a1 1 0 0 0 0 1.41 1 1 0 0 0 .71.29 1 1 0 0 0 .71-.29l4.24-4.24a1.002 1.002 0 0 0 0-1.42Z"/></svg>
           <span class="docs-mobile-section-current">{currentLink?.label ?? 'Overview'}</span>
           <span class="docs-mobile-section-caret" aria-hidden="true">›</span>
         </summary>

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -124,11 +124,25 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   .docs-mobile-section-separator,
   .docs-mobile-section-caret {
     color: var(--netscli-accent) !important;
-    /* `›` is drawn around the middle of the em box while the words beside it
-       sit on the baseline, so line-box centring -- which is correct, and
-       measured identical: label, separator and current page all centre at
-       81px -- still leaves the glyph reading low. A 1px lift is an optical
-       correction, not a layout one. */
+  }
+
+  /* The separator is an <svg> now, matching the mobile table of contents
+     below it -- see PageSidebar.astro. It sizes from its own width/height
+     attributes rather than from font-size, and it is centred by the flex row
+     rather than sitting on a text baseline, so the 1px optical lift that the
+     `›` glyph needed is gone with it: an icon box is already centred, and
+     lifting it would push it off. */
+  .docs-mobile-section-separator {
+    flex: 0 0 auto;
+    align-self: center;
+  }
+
+  /* Still a text glyph, and still needs the lift. `›` is drawn around the
+     middle of the em box while the words beside it sit on the baseline, so
+     line-box centring -- which is correct, and measured identical: label,
+     separator and current page all centre at 81px -- still leaves the glyph
+     reading low. An optical correction, not a layout one. */
+  .docs-mobile-section-caret {
     position: relative;
     top: -1px;
   }


### PR DESCRIPTION
The docs breadcrumb row and the mobile table of contents sit directly above and below each other on a phone, and drew their chevrons two different ways: this row used a typographic `›`, Starlight's TOC uses its own `right-caret` SVG. A text glyph and a vector icon are not the same mark.

## Measured at 375px

With the separator at its rendered 13.12px:

| | inked size | drawn as |
|---|---|---|
| breadcrumb `›` | **4.00 × 4.00** | font glyph (canvas TextMetrics) |
| TOC caret | **4.13 × 7.00** | SVG path bbox at the 16/24 scale |

Same width, **75% taller**, one a hairline and one stroked. That's the difference visible between the two rows.

## After

Both are Starlight's `right-caret`. All three chevrons on the page measure **box 16×16, ink 4.16 × 6.99**, in both themes, and take the theme accent (`#146b2e` light, `#22c55e` dark).

Copied inline from `node_modules/@astrojs/starlight/components-internals/Icons.ts` rather than imported — `<Icon>` lives behind `virtual:starlight/...` internals this component override doesn't get. `width`/`height` 16 against `viewBox="0 0 24 24"` reproduces the TOC's own `size="1rem"` exactly.

## The 1px lift stays with the glyph it was for

That optical correction was on both `.docs-mobile-section-separator` and `.docs-mobile-section-caret`, with a comment explaining that `›` is drawn around the middle of the em box while the words beside it sit on the baseline. The separator is an icon box now, centred by the flex row rather than sitting on a baseline, so lifting it would push it *off* centre. The caret is still a `›` and keeps it.

## Checks

`astro check` 0 errors, axe clean in both themes, contrast sweep clean across 14 routes in both themes, dead CSS 14/14.