### PR TITLE
Drop the mobile docs section-nav row

### DIFF
--- a/site/src/components/starlight/PageSidebar.astro
+++ b/site/src/components/starlight/PageSidebar.astro
@@ -2,105 +2,36 @@
 import MobileTableOfContents from 'virtual:starlight/components/MobileTableOfContents';
 import TableOfContents from 'virtual:starlight/components/TableOfContents';
 
-const { sidebar: routeSidebar, toc } = Astro.locals.starlightRoute;
-const sidebar = routeSidebar as SidebarEntry[];
-
-type SidebarEntry = {
-  type: 'link' | string;
-  label?: string;
-  href?: string;
-  isCurrent?: boolean;
-  entries?: SidebarEntry[];
-};
-
-type SidebarLink = {
-  type: 'link';
-  href: string;
-  label: string;
-  isCurrent?: boolean;
-};
-
-const collectLinks = (entry: SidebarEntry): SidebarLink[] => {
-  if (entry.type === 'link' && entry.href && entry.label) {
-    return [
-      {
-        type: 'link',
-        href: entry.href,
-        label: entry.label,
-        isCurrent: entry.isCurrent,
-      },
-    ];
-  }
-  return (entry.entries ?? []).flatMap(collectLinks);
-};
-
-const mobileGroups = (sidebar ?? [])
-  .map((entry) => {
-    if (entry.type === 'link') {
-      return { label: 'Docs', entries: [entry] };
-    }
-
-    return {
-      label: entry.label,
-      entries: (entry.entries ?? []).flatMap(collectLinks),
-    };
-  })
-  .filter((group) => group.entries.length > 0);
-
-const currentLink =
-  mobileGroups.flatMap((group) => group.entries).find((entry) => entry.isCurrent) ??
-  mobileGroups[0]?.entries[0];
-
-const currentGroup = mobileGroups.find((group) =>
-  group.entries.some((entry) => entry.href === currentLink?.href)
-);
-
-const formatCrumb = (label: string | undefined) => {
-  if (!label) return '';
-  return label === label.toUpperCase()
-    ? label.charAt(0).toUpperCase() + label.slice(1).toLowerCase()
-    : label;
-};
-
-const currentGroupLabel = formatCrumb(currentGroup?.label) || 'Start';
+const { toc } = Astro.locals.starlightRoute;
 ---
 
-{
-  mobileGroups.length > 0 && (
-    <div class="docs-mobile-section-nav print:hidden">
-      <details id="netscli-mobile-docs-nav">
-        <summary>
-          <span class="docs-mobile-section-label">Docs</span>
-          <span class="docs-mobile-section-separator" aria-hidden="true">›</span>
-          <span class="docs-mobile-section-group">{currentGroupLabel}</span>
-          <span class="docs-mobile-section-separator" aria-hidden="true">›</span>
-          <span class="docs-mobile-section-current">{currentLink?.label ?? 'Overview'}</span>
-          <span class="docs-mobile-section-caret" aria-hidden="true">›</span>
-        </summary>
-        <div class="docs-mobile-section-menu">
-          {
-            mobileGroups.map((group) => (
-              <section>
-                <h2>{group.label}</h2>
-                <ul>
-                  {
-                    group.entries.map((entry) => (
-                      <li>
-                        <a href={entry.href} aria-current={entry.isCurrent ? 'page' : undefined}>
-                          {entry.label}
-                        </a>
-                      </li>
-                    ))
-                  }
-                </ul>
-              </section>
-            ))
-          }
-        </div>
-      </details>
-    </div>
-  )
-}
+{/*
+  There is no mobile section-nav row here any more.
+
+  It rendered "Docs › <group> › <page>" under the header on narrow screens,
+  and its dropdown listed every docs page. Measured on /docs/cli/ at 390x844,
+  that dropdown and the header's hamburger sidebar opened the IDENTICAL set of
+  11 links -- not overlapping, identical -- so two controls 43px apart did the
+  same job, and the header is `fixed`, meaning the hamburger never scrolls
+  away and was always the shorter route.
+
+  What it cost: the row was 43px of a 145px permanently-pinned stack (header
+  60 + row 43 + contents bar 42) on an 844px viewport, 17.2% of the screen
+  before the phone's own browser chrome. Without it the stack is 102px, 12.1%.
+
+  What it uniquely gave was orientation -- which group the current page sits
+  in. That is the real loss, and it is a deliberate trade: the page title is
+  the next thing on screen, and the hamburger shows the group with the current
+  page marked.
+
+  Its styles are gone from 17, 18, 20, 21, 22, 23 and 28 with it, along with a
+  `--netscli-mobile-docs-nav-height` token that only existed to offset the
+  contents bar below it, and a half-built hide-on-scroll-down treatment: 17
+  declared `transform: translateY(0)` with a 140ms transition, 21 forced
+  `transform: none !important` in both scroll states, and nothing ever set the
+  `data-mobile-scroll-direction` attribute those rules keyed off. It had been
+  tried and switched off without being removed.
+*/}
 
 {
   toc && (
@@ -122,32 +53,6 @@ const currentGroupLabel = formatCrumb(currentGroup?.label) || 'Start';
     </>
   )
 }
-
-<script>
-  const docsNav = document.getElementById('netscli-mobile-docs-nav') as HTMLDetailsElement | null;
-
-  if (docsNav) {
-    const closeDocsNav = () => {
-      docsNav.open = false;
-    };
-
-    docsNav.querySelectorAll('a').forEach((link) => {
-      link.addEventListener('click', closeDocsNav);
-    });
-
-    window.addEventListener('click', (event) => {
-      if (event.target instanceof Node && !docsNav.contains(event.target)) closeDocsNav();
-    });
-
-    window.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape' && docsNav.open) {
-        const hasFocus = docsNav.contains(document.activeElement);
-        closeDocsNav();
-        if (hasFocus) docsNav.querySelector('summary')?.focus();
-      }
-    });
-  }
-</script>
 
 <style>
   @layer starlight.core {
@@ -177,10 +82,6 @@ const currentGroupLabel = formatCrumb(currentGroup?.label) || 'Start';
 
     .right-sidebar-panel :global(:where(a):hover) {
       color: var(--sl-color-white);
-    }
-
-    .docs-mobile-section-nav {
-      display: none;
     }
 
     @media (min-width: 72rem) {

--- a/site/src/styles/starlight/14-docs-nav-table.css
+++ b/site/src/styles/starlight/14-docs-nav-table.css
@@ -183,8 +183,13 @@
   }
 }
 
+/* Only the shadow. The `background: var(--netscli-menu-bg)` that used to sit
+   here was already dead -- 18-mobile-shell-closeout-b.css redeclares it, for
+   the same selector and the same value, and loads later. It was invisible to
+   the shadowing gate only because that rule's selector list also named the
+   mobile section menu, which no longer exists; removing that selector left
+   this provable. */
 html[data-theme='light'] mobile-starlight-toc .dropdown {
-  background: var(--netscli-menu-bg) !important;
   box-shadow: 0 14px 32px rgba(var(--netscli-hairline-rgb), 0.12) !important;
 }
 

--- a/site/src/styles/starlight/17-mobile-shell-closeout-a.css
+++ b/site/src/styles/starlight/17-mobile-shell-closeout-a.css
@@ -43,7 +43,9 @@
     inset-block-start: var(--sl-nav-height) !important;
   }}@media (max-width: 71.99rem) {
   :root {
-    --netscli-mobile-docs-nav-height: 2.625rem;
+    /* --netscli-mobile-docs-nav-height is gone with the section-nav row it
+       measured; the contents bar and the main frame now offset from
+       --sl-nav-height alone. See PageSidebar.astro. */
     --netscli-mobile-toc-bar-height: 2.625rem;
   }
 
@@ -69,84 +71,4 @@
     padding: 0 !important;
     overflow: visible !important;
     border: 0 !important;
-  }
-
-  .docs-mobile-section-nav {
-    display: block !important;
-    position: sticky !important;
-    top: var(--sl-nav-height) !important;
-    z-index: calc(var(--sl-z-index-navbar) - 1) !important;
-    width: 100% !important;
-    border-bottom: 1px solid var(--sl-color-hairline) !important;
-    background: var(--sl-color-bg-nav) !important;
-    backdrop-filter: blur(16px);
-    transform: translateY(0);
-    transition: transform 140ms linear;
-  }
-
-  .docs-mobile-section-nav details {
-    position: relative;
-  }
-
-  .docs-mobile-section-nav summary {
-    display: flex;
-    align-items: center;
-    gap: 0.65rem;
-    min-height: var(--netscli-mobile-docs-nav-height);
-    padding: 0 clamp(1rem, 3.4vw, 1.75rem);
-    list-style: none;
-    cursor: pointer;
-    outline-offset: var(--sl-outline-offset-inside);
-  }
-
-  .docs-mobile-section-nav summary::marker,
-  .docs-mobile-section-nav summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .docs-mobile-section-label {
-    color: var(--sl-color-white);
-    font-size: 0.82rem;
-    font-weight: 720;
-  }
-
-  .docs-mobile-section-current {
-    min-width: 0;
-    overflow: hidden;
-    color: var(--sl-color-gray-3);
-    font-size: 0.84rem;
-    line-height: 1.2;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .docs-mobile-section-caret {
-    color: var(--netscli-accent);
-    font-size: 1rem;
-    line-height: 1;
-
-  }.docs-mobile-section-menu {
-    position: absolute;
-    inset-inline: 0;
-    top: 100%;
-    max-height: min(58vh, 30rem);
-    overflow-y: auto;
-    overscroll-behavior: contain;
-    padding: 0.8rem clamp(1rem, 3.4vw, 1.75rem) 1rem;
-    border-block: 1px solid var(--sl-color-hairline);
-    background: var(--netscli-menu-bg);
-  }
-
-  .docs-mobile-section-menu section + section {
-    margin-top: 0.95rem;
-  }
-
-  .docs-mobile-section-menu h2 {
-    margin: 0 0 0.35rem;
-    color: var(--sl-color-gray-3);
-    font-size: 0.68rem;
-    font-weight: 760;
-    letter-spacing: 0.08em;
-    line-height: 1.2;
-    text-transform: uppercase;
   }

--- a/site/src/styles/starlight/18-mobile-shell-closeout-b.css
+++ b/site/src/styles/starlight/18-mobile-shell-closeout-b.css
@@ -1,33 +1,4 @@
-/* Mobile shell close-out, part 2 of 2 (continues 16-mobile-shell-closeout-a.css). */
 
-  .docs-mobile-section-menu ul {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    border-inline-start: 1px solid var(--sl-color-hairline);
-  }
-
-  .docs-mobile-section-menu a {
-    display: flex;
-    align-items: center;
-    min-height: 2.25rem;
-    padding: 0.35rem 0.75rem;
-    border-inline-start: 1px solid transparent;
-    color: var(--sl-color-gray-2);
-    text-decoration: none;
-  }
-
-  .docs-mobile-section-menu a:hover,
-  .docs-mobile-section-menu a:focus-visible {
-    color: var(--sl-color-white);
-    background: transparent;
-  }
-
-  .docs-mobile-section-menu a[aria-current='page'] {
-    color: var(--sl-color-white);
-    border-inline-start-color: var(--netscli-accent);
-    background: rgba(var(--netscli-accent-rgb), 0.07);
-  }
 
   mobile-starlight-toc {
     display: block !important;
@@ -138,25 +109,16 @@
   }
 }
 
-@media (max-width: 49.99rem) {
-  .docs-mobile-section-nav {
-  }mobile-starlight-toc nav {
+@media (max-width: 49.99rem) {mobile-starlight-toc nav {
     position: fixed !important;
     inset-inline: 0 !important;
-    top: calc(var(--sl-nav-height) + var(--netscli-mobile-docs-nav-height)) !important;
-    transition: top 140ms linear;
-  }
-
-  html[data-mobile-scroll-direction='down'] mobile-starlight-toc nav {
     top: var(--sl-nav-height) !important;
   }}
 
-html[data-theme='light'] .docs-mobile-section-menu,
 html[data-theme='light'] mobile-starlight-toc .dropdown {
   background: var(--netscli-menu-bg) !important;
 }
 
-html[data-theme='light'] .docs-mobile-section-menu a[aria-current='page'],
 html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true'],
 html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true']:hover,
 html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true']:focus-visible {
@@ -166,7 +128,4 @@ html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true']:f
 }
 
 @media (min-width: 50rem) {
-  .docs-mobile-section-nav {
-    display: none !important;
-  }
 }

--- a/site/src/styles/starlight/20-docs-shell-closeout.css
+++ b/site/src/styles/starlight/20-docs-shell-closeout.css
@@ -113,48 +113,6 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 }
 
 @media (max-width: 71.99rem) {
-  .docs-mobile-section-separator,
-  .docs-mobile-section-group {
-    flex: 0 0 auto;
-    color: var(--sl-color-gray-3);
-    font-size: 0.82rem;
-    line-height: 1.2;
-  }
-
-  .docs-mobile-section-separator,
-  .docs-mobile-section-caret {
-    color: var(--netscli-accent) !important;
-    /* `›` is drawn around the middle of the em box while the words beside it
-       sit on the baseline, so line-box centring -- which is correct, and
-       measured identical: label, separator and current page all centre at
-       81px -- still leaves the glyph reading low. A 1px lift is an optical
-       correction, not a layout one. */
-    position: relative;
-    top: -1px;
-  }
-
-  .docs-mobile-section-caret {
-    display: none !important;
-    margin-left: 0;
-    transform: none !important;
-    transition: none !important;
-  }
-
-  .docs-mobile-section-caret::before {
-    content: "›";
-  }
-
-  .docs-mobile-section-nav details[open] .docs-mobile-section-caret::before {
-    content: "⌄";
-  }
-
-  .docs-mobile-section-nav details[open] .docs-mobile-section-caret {
-    transform: none !important;
-  }.docs-mobile-section-menu a:hover,
-  .docs-mobile-section-menu a:focus-visible {
-    color: var(--sl-color-white) !important;
-    background: rgba(var(--netscli-lift-rgb), 0.04) !important;
-  }
 
   mobile-starlight-toc nav {
     box-shadow: none !important;

--- a/site/src/styles/starlight/21-mobile-docs-shell-verified.css
+++ b/site/src/styles/starlight/21-mobile-docs-shell-verified.css
@@ -28,18 +28,6 @@
     padding: 0 !important;
     border: 0 !important;
     overflow: visible !important;
-  }.docs-mobile-section-nav {
-    position: fixed !important;
-    inset-inline: 0 !important;
-  }
-
-  .docs-mobile-section-nav {
-    top: var(--sl-nav-height) !important;
-    transform: none !important;
-  }
-
-  html[data-mobile-scroll-direction='down'] .docs-mobile-section-nav {
-    transform: none !important;
   }
 
   .content-panel:first-child {

--- a/site/src/styles/starlight/22-mobile-docs-correction.css
+++ b/site/src/styles/starlight/22-mobile-docs-correction.css
@@ -37,7 +37,7 @@
   .netscli-mobile-toc-wrapper {
     display: block !important;
     position: sticky !important;
-    top: calc(var(--sl-nav-height) + var(--netscli-mobile-docs-nav-height)) !important;
+    top: var(--sl-nav-height) !important;
     z-index: calc(var(--sl-z-index-navbar) - 2) !important;
     width: 100% !important;
     background: var(--sl-color-bg-nav) !important;
@@ -84,16 +84,11 @@
   .netscli-mobile-toc-wrapper mobile-starlight-toc .dropdown a:focus-visible,
   .netscli-mobile-toc-wrapper mobile-starlight-toc .dropdown a[aria-current='true'] {
     color: var(--netscli-accent-high) !important;
-  }
-
-  .docs-mobile-section-menu {
-    box-shadow: 0 18px 42px rgba(0, 0, 0, 0.34) !important;
-  }
-}
+  }}
 
 @media (max-width: 49.99rem) {
   .main-frame {
-    padding-top: calc(var(--sl-nav-height) + var(--netscli-mobile-docs-nav-height)) !important;
+    padding-top: var(--sl-nav-height) !important;
   }
 
   .main-pane > .content-panel:first-of-type,

--- a/site/src/styles/starlight/23-regression-guardrails.css
+++ b/site/src/styles/starlight/23-regression-guardrails.css
@@ -7,8 +7,6 @@
   border-inline-start-color: var(--netscli-accent) !important;
 }
 
-.docs-mobile-section-nav summary,
-.docs-mobile-section-nav a,
 .netscli-mobile-toc-wrapper mobile-starlight-toc summary,
 .netscli-mobile-toc-wrapper mobile-starlight-toc .toggle,
 .netscli-mobile-toc-wrapper mobile-starlight-toc .display-current,

--- a/site/src/styles/starlight/28-final-interaction-guardrails.css
+++ b/site/src/styles/starlight/28-final-interaction-guardrails.css
@@ -169,16 +169,17 @@ a.download-count:focus-visible,
     margin-inline-end: .15rem !important;
   }
 
-  /* Not the section menu.
-     PageSidebar renders the mobile section dropdown inside .right-sidebar, so
-     this rule -- written to flatten the ToC rail -- also stripped the marker
-     off the current page in that menu. Every other entry there reserves 2px
-     for a border, so the one item that should have been marked was the only
-     one with no border at all. The contents dropdown, which lives in the same
-     component, had lost its marker the same way. */
+  /* Not the contents dropdown.
+     PageSidebar renders it inside .right-sidebar, so this rule -- written to
+     flatten the ToC rail -- also stripped the marker off the heading you are
+     on. Every other entry there reserves 2px for a border, so the one item
+     that should have been marked was the only one with none.
+
+     The exclusion list used to name `.docs-mobile-section-menu a` first, for
+     the mobile section dropdown that lived in this component and had lost its
+     marker the same way. That row is gone; see PageSidebar.astro. */
   .right-sidebar
     :where(a:hover, a[aria-current="true"], a[aria-current="page"]):not(
-      .docs-mobile-section-menu a,
       mobile-starlight-toc .dropdown a
     ) {
     background: transparent !important;


### PR DESCRIPTION
The row rendered `Docs › <group> › <page>` under the header on narrow screens, and its dropdown listed every docs page.

## Why

Measured on `/docs/cli/` at 390×844: **that dropdown and the header's hamburger sidebar opened the identical set of 11 links** — not overlapping, identical. Two controls 43px apart doing the same job, and the header is `fixed`, so the hamburger never scrolls away and was always the shorter route.

| | before | after |
|---|---|---|
| header | 60px | 60px |
| section-nav row | 43px | — |
| contents bar | 42px | 43px |
| **pinned total** | **145px (17.2% of 844)** | **103px (12.2%)** |

The page `h1` starts 40px higher (144 → 104.6), and the contents bar now pins directly under the header — its sticky offset was `calc(--sl-nav-height + --netscli-mobile-docs-nav-height)`, and that token existed only to reserve space for this row, so it's gone and all three call sites read `--sl-nav-height` alone.

## What's lost, honestly

Orientation — which group the current page sits in. That's a real trade, not a free win: the page title is the next thing on screen and the hamburger shows the group with the current page marked, but the breadcrumb said it without a tap.

The contents bar that remains does something nothing else does, and keeps doing it while you read: its label tracked `Overview` → `Command list` across the same scroll.

## Also removed

Across `17/18/20/21/22/23/28`: **27 rule blocks** whose selectors named only this row, and three mixed selector lists trimmed to their surviving members.

Plus a **half-built hide-on-scroll-down treatment** — `17` declared `transform: translateY(0)` with a 140ms transition, `21` forced `transform: none !important` in *both* scroll states, and nothing anywhere set the `data-mobile-scroll-direction` attribute those rules keyed off. It had been tried and switched off without being deleted. Worth knowing, since it's the same idea as one of the options considered here.

Trimming one selector list also made a pre-existing dead declaration provable: `14-docs-nav-table.css` set `background: var(--netscli-menu-bg)` on `html[data-theme='light'] mobile-starlight-toc .dropdown`, which `18` redeclares identically and later. The shadowing gate couldn't prove it while `18`'s selector list also named the section menu. Deleted, so the budget holds at 14.

## Supersedes #332

That PR made this row's chevrons match the contents bar. The row no longer exists, so there is nothing left for it to fix — closing it rather than merging.

## Checks

Verified at 390×844 on the built site: row absent, contents bar at `top: 60` when scrolled, hamburger present, contents label still tracking the heading. `astro check` clean, axe clean in both themes, contrast sweep clean across 14 routes in both themes, dead CSS 14/14.