### PR TITLE
Light-theme and landing-page pass: two dark bands, theme-following chips, and a lot of measuring

### DIFF
--- a/site/src/components/Faq.astro
+++ b/site/src/components/Faq.astro
@@ -46,13 +46,26 @@ const faqGroups = grouped.sort(
 
 <style is:global>
 /* ─── FAQ ─── */
-.faq{display:grid;gap:22px;margin-top:14px}
+/* Five groups, not thirteen rows.
+ *
+ * The section is 1221px of near-identical closed pills -- roughly a quarter
+ * of the page, and the last thing before the footer. The grouping that would
+ * break it up already existed and was doing nothing: a .72rem muted label
+ * with 22px between groups and 8px between rows is a 14px difference, which
+ * nobody reads as a boundary.
+ *
+ * 40px between groups against 8px within one is a gap you can see, and the
+ * title takes the strong ink with a hairline under it so each group reads as
+ * a block with a heading rather than as more list. */
+.faq{display:grid;gap:40px;margin-top:18px}
 .faq-section{display:grid;gap:8px}
 .faq-section-title{
-  margin:0 0 2px;
-  color:var(--netscli-text-muted);
-  font-size:.72rem;
-  font-weight:600;
+  margin:0 0 6px;
+  padding-bottom:8px;
+  border-bottom:1px solid rgba(var(--netscli-hairline-rgb),.16);
+  color:var(--netscli-text-strong);
+  font-size:.78rem;
+  font-weight:700;
   letter-spacing:.08em;
   text-transform:uppercase;
 }

--- a/site/src/components/Faq.astro
+++ b/site/src/components/Faq.astro
@@ -116,12 +116,14 @@ const faqGroups = grouped.sort(
   align-items:center;
   min-height:40px;
   padding:8px 48px 8px 12px;
-  /* Dark in both themes -- see the code-surface note in tokens.css. The
-     LABEL beside it stays on the card, so only the chip inverts. */
-  border:1px solid var(--netscli-code-border);
+  /* A chip, so it follows the theme like the hero and install ones. It was
+     pinned dark in both themes, which left black bars running down a light
+     FAQ answer once everything around them had gone light. The LABEL beside
+     it sits on the card either way. */
+  border:1px solid var(--netscli-chip-border);
   border-radius:5px;
-  background:var(--netscli-code-bg);
-  color:var(--netscli-code-fg);
+  background:var(--netscli-chip-bg);
+  color:var(--netscli-chip-fg);
   white-space:pre;
   overflow-x:auto;
 }
@@ -138,7 +140,7 @@ const faqGroups = grouped.sort(
   word-break:normal;
 }
 .faq .answer .faq-command code{
-  color:var(--netscli-code-fg);
+  color:var(--netscli-chip-fg);
   white-space:pre;
   overflow-x:auto;
   overflow-wrap:normal;

--- a/site/src/components/Faq.astro
+++ b/site/src/components/Faq.astro
@@ -127,10 +127,12 @@ const faqGroups = grouped.sort(
 }
 .faq .answer code{
   font-size:.8125rem;
-  /* The chip is dark in both themes now, so the ink has to be too --
-     --netscli-accent-bright flips to a dark green in the light theme and was
-     landing at 1.94:1 on it. See tokens.css. */
-  color:var(--netscli-code-inline-fg);
+  /* The chip follows the theme now, so the ink has to as well. This was
+     pinned to --netscli-code-inline-fg back when the chip was dark in both
+     themes; left pinned, that light-on-dark green landed on the new light
+     chip at 1.28:1. --netscli-chip-code-fg is the pair that moves with the
+     surface: 13.06:1 dark, 8.66:1 light. */
+  color:var(--netscli-chip-code-fg);
   white-space:nowrap;
   overflow-wrap:normal;
   word-break:normal;

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -410,8 +410,10 @@ const { hero, social } = site;
   position:relative;display:grid;grid-template-columns:minmax(0,1fr);
   align-items:center;gap:10px;min-height:36px;
   padding:8px 58px 8px 14px;border-radius:9px;
-  /* Dark in both themes -- see the code-surface note in tokens.css. */
-  background:var(--netscli-code-bg);border:1px solid var(--netscli-code-border);
+  /* A chip, not a code surface: dark in the dark theme, light in the light
+     one, so it carries the same weight as the Desktop app button beside it.
+     See the chip note in code-surface.css. */
+  background:var(--netscli-chip-bg);border:1px solid var(--netscli-chip-border);
   box-shadow:0 0 0 1px rgba(var(--netscli-accent-rgb),.26),0 0 14px rgba(var(--netscli-accent-rgb),.08);
 }
 .hero-command.hero-copy .copy-btn{opacity:1}

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -209,7 +209,7 @@ const { hero, social } = site;
   border-radius:6px;
   background:var(--netscli-surface);
   color:var(--netscli-text);
-  box-shadow:0 12px 28px rgba(0,0,0,.32);
+  box-shadow:var(--netscli-lift-sm);
   font-size:.72rem;
   line-height:1.25;
   pointer-events:none;
@@ -366,7 +366,7 @@ const { hero, social } = site;
   /* See the wrapped-layout rule below, which widens this to the trigger. */
   padding:5px;border-radius:8px;
   background:var(--netscli-surface);border:1px solid rgba(var(--netscli-lift-rgb),.12);
-  box-shadow:0 18px 40px rgba(0,0,0,.42);
+  box-shadow:var(--netscli-lift-md);
 }
 .hero-desktop-menu a{
   display:grid;grid-template-columns:16px minmax(0,1fr) auto;
@@ -563,7 +563,7 @@ const { hero, social } = site;
   margin:48px auto 78px;max-width:980px;
   border-radius:10px;overflow:hidden;
   border:1px solid rgba(var(--netscli-lift-rgb),.08);
-  box-shadow:0 32px 80px rgba(0,0,0,.6);
+  box-shadow:var(--netscli-lift-lg);
 }
 .bigshot img{width:100%;height:auto;display:block}
 .bigshot img,

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -42,6 +42,19 @@ const { hero, social } = site;
           href="https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-windows-x86_64.msi"
         >
           <span class="hero-primary-label">Desktop app</span>
+          {/* What the button will download, said out loud, and inside the
+              button rather than under it.
+              Clicking starts a download immediately and nothing else on the
+              page names the file or the platform first, so the only way to
+              find out what you were getting was to get it. It used to sit
+              below as a sibling, which put it in row 2 column 1 of the CTA
+              grid -- hanging off the left column while the command chip
+              beside it had nothing underneath. Inside the button it is
+              attached to the thing it describes and the row is even again.
+              Server-rendered with the Windows default so it matches the href
+              before any script runs; scripts/landing/os-tabs.ts rewrites the
+              text and the href together. */}
+          <span class="hero-primary-cue" id="hero-desktop-cue">Windows &middot; .msi installer</span>
         </a>
         <button
           class="hero-primary-menu"
@@ -94,13 +107,6 @@ const { hero, social } = site;
           </a>
         </div>
       </div>
-      {/* What the button will download, said out loud.
-          Clicking it starts a download immediately, and nothing on the page
-          named the file or the platform first -- so the only way to find out
-          what you were getting was to get it. Server-rendered with the
-          Windows default so it matches the href beside it before any script
-          runs; scripts/landing/os-tabs.ts rewrites both together. */}
-      <p class="hero-primary-cue" id="hero-desktop-cue">Windows &middot; .msi installer</p>
       {/* The SCRIPT one-liner sits here, in the wide slot beside the button,
           and the package-manager command goes in the narrower row below.
 
@@ -288,7 +294,12 @@ const { hero, social } = site;
   border:0;
 }
 .hero-primary{
-  min-width:0;padding:8px 10px 8px 13px;border-radius:0;
+  /* Two stacked lines now -- the label and the download cue -- so this
+     overrides the row layout it shares with .hero-primary-menu above. */
+  flex-direction:column;
+  justify-content:center;
+  gap:0;
+  min-width:0;padding:6px 10px 7px 13px;border-radius:0;
   text-decoration:none;font-size:.82rem;font-weight:760;
   letter-spacing:.005em;
   font-family:Inter,system-ui,-apple-system,Segoe UI,sans-serif;
@@ -422,19 +433,24 @@ const { hero, social } = site;
   color:var(--netscli-text);font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:.78rem;background:transparent;border:0;padding:0;
 }
-/* Under the button, not beside it.
+/* The button's second line. Stacked under the label inside the anchor, so it
+ * moves, wraps and hit-tests with the button rather than beside it.
  *
- * .hero-cta-main is a two-column grid and this is its second child, so
- * without an explicit placement it would take row 1 column 2 and push the
- * command bar down a row. Placed rather than reordered so the DOM order stays
- * button-then-caption, which is what a screen reader should hear. */
+ * translateX matches .hero-primary-label's: that 8px nudge optically centres
+ * the text against the caret column on its right, and both lines have to
+ * carry it or they sit on different centres.
+ *
+ * -webkit-text-fill-color is reset because the label above it paints itself
+ * with a gradient and `transparent` fill; without this the cue inherits the
+ * transparent fill and renders as nothing. */
 .hero-primary-cue{
-  grid-column:1;
-  grid-row:2;
-  margin:2px 0 0;
-  font-size:.7rem;
-  line-height:1.3;
+  transform:translateX(8px);
+  margin:1px 0 0;
+  font-size:.66rem;
+  font-weight:500;
+  line-height:1.25;
   color:var(--netscli-text-muted);
+  -webkit-text-fill-color:currentColor;
   text-align:center;
   white-space:nowrap;
 }
@@ -479,13 +495,8 @@ const { hero, social } = site;
     width:min(100%,400px);
     flex:0 1 min(100%,400px);
   }
-  .hero-primary-cue{
-    order:2;
-    grid-column:auto;
-    grid-row:auto;
-    flex:0 0 100%;
-    margin:0;
-  }
+  /* The cue used to be a sibling here and needed its own flex order; it is
+     inside the button now and moves with it. */
   .hero-command-wide{
     order:3;
     flex:0 1 min(100%,400px);

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -300,9 +300,26 @@ const { hero, social } = site;
   box-shadow:0 0 12px rgba(var(--netscli-accent-rgb),.08);
   overflow:visible;
 }
+/* One control height for the whole CTA block.
+ *
+ * The button carries two lines and the command chips carry one, so left to
+ * their content they came out 50px against 38px -- three controls in a small
+ * area at two different heights, which reads as a mistake rather than as
+ * hierarchy. 44px fits the button's two lines (13px label + 11px cue plus
+ * padding) without inflating the chips much beyond the 38px they were.
+ *
+ * Set on the wrapper and the chips rather than on the inner anchor, and
+ * box-sizing is border-box globally, so the number is the outer height on
+ * both -- borders included, which is where the button's extra 2px lived. */
+.hero-cta{
+  --netscli-cta-height:44px;
+}
+.hero-primary-wrap{
+  min-height:var(--netscli-cta-height);
+}
 .hero-primary,
 .hero-primary-menu{
-  min-height:34px;
+  min-height:calc(var(--netscli-cta-height) - 2px);
   display:inline-flex;align-items:center;justify-content:center;
   background:transparent;
   background-image:none;
@@ -315,6 +332,10 @@ const { hero, social } = site;
   justify-content:center;
   gap:0;
   min-width:0;padding:6px 10px 7px 13px;border-radius:0;
+  /* The label inherits body's 1.6, which makes a 13px line 21px tall and
+     pushed the two-line button to 50px against the chips' 44. At 1.15 the
+     label is 15px and the button lands on the shared height. */
+  line-height:1.15;
   text-decoration:none;font-size:.82rem;font-weight:760;
   letter-spacing:.005em;
   font-family:Inter,system-ui,-apple-system,Segoe UI,sans-serif;
@@ -434,7 +455,7 @@ const { hero, social } = site;
 .hero-desktop-menu a:hover{background:rgba(var(--netscli-accent-rgb),.12);color:#1ec88c}
 .hero-command{
   position:relative;display:grid;grid-template-columns:minmax(0,1fr);
-  align-items:center;gap:10px;min-height:36px;
+  align-items:center;gap:10px;min-height:var(--netscli-cta-height);
   padding:8px 58px 8px 14px;border-radius:9px;
   /* A chip, not a code surface: dark in the dark theme, light in the light
      one, so it carries the same weight as the Desktop app button beside it.

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -168,8 +168,19 @@ const { hero, social } = site;
   max-width:34ch;
 }
 .hero .sub{font-size:1.0625rem;color:var(--netscli-text-muted);max-width:640px;margin:14px auto 0}
+/* .8125rem and the body ink, not .75rem and the muted step.
+ *
+ * The line was 12px at rgb(89,100,120) -- 5.77:1, so legible, but it read as
+ * a footnote rather than as the star count, the download count and the
+ * version, which are the only third-party evidence above the fold. Size was
+ * the bigger half of that: 12px is the smallest thing on the page and it sat
+ * directly under a 17px subhead.
+ *
+ * 13px and the body step measure 7.71:1 light and 11.45:1 dark. The `·`
+ * separators keep the muted colour below, so the line still reads as one
+ * group rather than four competing items. */
 .hero .social-proof{
-  margin:12px auto 0;font-size:.75rem;color:var(--netscli-text-muted);
+  margin:12px auto 0;font-size:.8125rem;color:var(--netscli-text);
   display:flex;justify-content:center;align-items:center;gap:10px;
   font-variant-numeric:tabular-nums;min-height:1em;
 }
@@ -239,7 +250,11 @@ const { hero, social } = site;
    and lifting them to 4.5:1 would give a punctuation mark the same
    visual weight as the metrics it separates. Marking them hidden also
    stops a screen reader announcing "middle dot" three times. */
-.hero .social-proof .sep{color:#555}
+/* The muted step, not a literal. This was #555 -- a dark-theme grey that the
+   light theme had no say over, and the one thing on this line that did not
+   move when the rest of it did. It is the separator's job to sit behind the
+   items it separates, so it takes the muted token they just left. */
+.hero .social-proof .sep{color:var(--netscli-text-muted)}
 .hero-cta{
   /* 610, not 560, and sized off the viewport rather than a vw fraction.
      At 560 the wide command slot was 351px against 397px of text, so

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -162,6 +162,20 @@ const groups = [
   background:var(--netscli-surface-raised);border:1px solid rgba(var(--netscli-lift-rgb),.08);border-radius:10px;
   padding:14px 18px;margin-bottom:16px;
 }
+/* On a white page the border is the whole card.
+ *
+ * The fill is rgb(242,245,250) and the page is rgb(251,251,251) -- 1.06:1,
+ * which is not a card, it is a rounding error. While this section sat on a
+ * tinted band that did not matter; with the band gone the border is the only
+ * thing left marking the card, and at .08 it composites to rgb(232,233,234),
+ * 1.17:1, which is barely more visible than the fill it is outlining.
+ *
+ * .20 gives rgb(204,206,209) -- 1.52:1, a hairline you can actually see. Only
+ * the light theme needs it: in dark the lift channel is white and the card
+ * reads against a near-black page already. */
+html[data-theme='light'] .reco{
+  border-color:rgba(var(--netscli-lift-rgb),.20);
+}
 .reco-meta{font-size:.85rem;font-weight:500;color:var(--netscli-text);margin-bottom:8px}
 .cmd.big{font-size:1.05rem;padding-right:74px}
 .alts{

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -146,7 +146,14 @@ const groups = [
 }
 .os-tabs{
   grid-column:1;grid-row:1;display:flex;gap:0;
-  border-bottom:1px solid var(--netscli-surface-raised);margin-bottom:20px;
+  /* A hairline on the band, not a near-white bar.
+     --netscli-surface-raised is a PAGE surface: on a light page it resolves
+     to #f2f5fa, so against the navy band this drew a solid near-white 1px
+     line under the tabs -- brighter than the 2px accent underline it sits
+     level with, and a different kind of mark from every other divider in the
+     section. The hairline channel inverts with the band's ink, so this is a
+     faint light rule on navy and a faint dark one anywhere light. */
+  border-bottom:1px solid rgba(var(--netscli-hairline-rgb),.18);margin-bottom:20px;
 }
 .install-content{grid-column:1;grid-row:2}
 .try{grid-column:2;grid-row:2}
@@ -163,6 +170,14 @@ const groups = [
   background:var(--netscli-surface-raised);border:1px solid rgba(var(--netscli-lift-rgb),.08);border-radius:10px;
   padding:14px 18px;margin-bottom:16px;
 }
+/* A step above the band in the dark theme, not level with it.
+   --netscli-surface-raised is #20242b and the band is #1c2634: 1.02:1, so
+   once #install became a band the card stopped reading as a card at all in
+   dark. This is the same relationship the light theme gets from white on
+   navy, at the only strength a dark page allows. */
+#install .reco{
+  background:#26313f;
+}
 /* On a white page the border is the whole card.
  *
  * The fill is rgb(242,245,250) and the page is rgb(251,251,251) -- 1.06:1,
@@ -174,8 +189,25 @@ const groups = [
  * .20 gives rgb(204,206,209) -- 1.52:1, a hairline you can actually see. Only
  * the light theme needs it: in dark the lift channel is white and the card
  * reads against a near-black page already. */
-html[data-theme='light'] .reco{
-  border-color:rgba(var(--netscli-lift-rgb),.20);
+/* The card is a lifted white surface; the chip inside it is recessed.
+ *
+ * They were identical -- both rgb(242,245,250) with the same
+ * rgba(17,24,39,.2) border -- so the recommended command read as a box
+ * drawn inside an identical box rather than as a control on a card. Nothing
+ * separated the two objects because nothing about them differed.
+ *
+ * White for the card and a shadow to lift it off the navy band, leaving the
+ * chip on the #f2f5fa chip surface: card, then a step down to the control,
+ * then the band. The chip's own 1.52:1 border does the edge work, so the
+ * step between the two fills only has to be visible, not strong. */
+/* `#install .reco` in the selector, not just `.reco`: the dark-theme rule
+   above is id-scoped (1,0,1) and would otherwise outrank a plain
+   `html[data-theme='light'] .reco` (0,1,2) and paint the light card dark --
+   measured at 1.65:1 before this line was matched to it. */
+html[data-theme='light'] #install .reco{
+  background:#ffffff;
+  border-color:rgba(var(--netscli-lift-rgb),.14);
+  box-shadow:var(--netscli-lift-sm);
 }
 .reco-meta{font-size:.85rem;font-weight:500;color:var(--netscli-text);margin-bottom:8px}
 .cmd.big{font-size:1.05rem;padding-right:74px}

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -111,8 +111,9 @@ const groups = [
 .install-label{font-size:.8125rem;font-weight:600;color:var(--netscli-text);margin:0 0 6px}
 .install-hint{font-size:.6875rem;color:var(--netscli-text-muted);margin:4px 0 0}
 .cmd{
-  /* Dark in both themes -- see the code-surface note in tokens.css. */
-  background:var(--netscli-code-bg);border:1px solid var(--netscli-code-border);
+  /* A chip, not a code surface: dark in the dark theme, light in the light
+     one. See the chip note in code-surface.css. */
+  background:var(--netscli-chip-bg);border:1px solid var(--netscli-chip-border);
   border-radius:8px;padding:12px 16px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:clamp(.6875rem,1.4vw,.8125rem);
@@ -178,15 +179,19 @@ html[data-theme='light'] .reco{
 }
 .reco-meta{font-size:.85rem;font-weight:500;color:var(--netscli-text);margin-bottom:8px}
 .cmd.big{font-size:1.05rem;padding-right:74px}
+/* The container is the divider: the rows sit on it with a 1px gap, so its
+   background shows through as the hairline between them. Chip tokens, so the
+   rule between two light rows is a light hairline rather than a near-black
+   one. */
 .alts{
   display:flex;flex-direction:column;gap:1px;
-  background:var(--netscli-code-divider);border:1px solid var(--netscli-code-divider);border-radius:8px;overflow:hidden;
+  background:var(--netscli-chip-divider);border:1px solid var(--netscli-chip-divider);border-radius:8px;overflow:hidden;
 }
 .alt{
   display:grid;grid-template-columns:140px 1fr;gap:16px;align-items:center;
-  padding:11px 16px;background:var(--netscli-code-bg);transition:background .15s;position:relative;
+  padding:11px 16px;background:var(--netscli-chip-bg);transition:background .15s;position:relative;
 }
-.alt:hover{background:var(--netscli-code-bg)}
+.alt:hover{background:var(--netscli-chip-bg)}
 .alt-label{font-size:.85rem;color:var(--netscli-text)}
 .alt-cmd{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.82rem;

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -161,8 +161,21 @@ html[data-theme='light'] body.nav-scrolled nav[data-site-nav]{
     0 12px 26px rgba(var(--netscli-hairline-rgb),.11),
     0 1px 0 rgba(var(--netscli-accent-rgb),.12) !important;
 }
+/* No second layer on a light page.
+ *
+ * The bar casts a 26px blurred box-shadow AND this 22px hard gradient, and
+ * they stack. Softening only the box-shadow -- which is what the previous
+ * pass did -- left the heavier of the two untouched: measured on
+ * rgb(251,251,251), the shadow alone composites to rgb(225,226,228) and this
+ * gradient then takes it to rgb(200,202,205), a 1.59:1 step in a 22px band
+ * directly under the bar. That reads as a grey smear, not depth.
+ *
+ * The gradient exists for the dark theme, where it is rgba(0,0,0,.42) against
+ * a near-black page and does real work selling the bar as floating. On white
+ * the blurred shadow is enough on its own, so this drops to nothing rather
+ * than to a smaller number -- one soft layer is the whole effect. */
 html[data-theme='light'] nav[data-site-nav]::after{
-  background:linear-gradient(180deg,rgba(var(--netscli-hairline-rgb),.12),rgba(var(--netscli-hairline-rgb),0));
+  opacity:0;
 }
 .nav-inner{
   /* Matches the docs top bar. Padding alone gave 12+32+12 plus the 1px

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -251,12 +251,28 @@ html[data-theme='light'] nav[data-site-nav]::after{
 .nlinks a:hover{color:var(--netscli-text)}
 /* Separates the links that scroll from the links that navigate.
    A rule, not a gap alone: at this size a gap on its own reads as an
-   accident. Purely decorative, so it is a border rather than an element --
-   nothing for a screen reader to announce between two links. */
+   accident. Purely decorative, so it is drawn rather than announced --
+   nothing here for a screen reader to find between two links.
+
+   A short centred rule, not a border. These links are the full height of the
+   bar so the underline for the current page can sit on the bar's bottom edge,
+   which meant `border-inline-start` drew a 59px line floor to ceiling -- a
+   divider that split the bar in two rather than grouping the links. The
+   pseudo-element is 18px, centred on the text it sits between. */
 .nlinks a.nav-group-start{
+  position:relative;
   margin-inline-start:12px;
   padding-inline-start:20px;
-  border-inline-start:1px solid rgba(var(--netscli-hairline-rgb),.28);
+}
+.nlinks a.nav-group-start::before{
+  content:"";
+  position:absolute;
+  inset-inline-start:0;
+  top:50%;
+  width:1px;
+  height:18px;
+  margin-block-start:-9px;
+  background:rgba(var(--netscli-hairline-rgb),.28);
 }
 
 /* Theme control.
@@ -374,6 +390,11 @@ html[data-theme='light'] nav[data-site-nav]::after{
     margin-block-start:6px;
     padding-block-start:6px;
     border-block-start:1px solid rgba(var(--netscli-hairline-rgb),.28);
+  }
+  /* The stacked menu divides the two groups with the horizontal rule above,
+     so the vertical one has nothing to do here. */
+  .nlinks a.nav-group-start::before{
+    content:none;
   }
   .nlinks a:hover,
   .nlinks a[aria-current]{

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -60,7 +60,24 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
       <div class="netscli-theme-select">
         <label>
           <span class="sr-only">Select theme</span>
-          <svg aria-hidden="true" class="icon label-icon" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+          {/* All three icons, one shown at a time.
+              The docs bar swaps its icon through Starlight's ThemeProvider,
+              which clones from a `<template id="theme-icons">` and only
+              queries `starlight-theme-select`. Neither exists on the landing
+              page, so this control was stuck on the laptop glyph whatever you
+              picked. Rendering all three and hiding two is simpler than
+              importing that machinery, and it needs no JavaScript to be
+              correct on first paint -- the pre-paint script in Page.astro
+              already sets data-theme-choice before this is visible.
+              Starlight's own sun, moon and laptop paths, so the two bars show
+              the same glyphs. */}
+          <svg aria-hidden="true" class="icon label-icon" data-icon="light" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M5 12a1 1 0 0 0-1-1H3a1 1 0 0 0 0 2h1a1 1 0 0 0 1-1Zm.64 5-.71.71a1 1 0 0 0 0 1.41 1 1 0 0 0 1.41 0l.71-.71A1 1 0 0 0 5.64 17ZM12 5a1 1 0 0 0 1-1V3a1 1 0 0 0-2 0v1a1 1 0 0 0 1 1Zm5.66 2.34a1 1 0 0 0 .7-.29l.71-.71a1 1 0 1 0-1.41-1.41l-.66.71a1 1 0 0 0 0 1.41 1 1 0 0 0 .66.29Zm-12-.29a1 1 0 0 0 1.41 0 1 1 0 0 0 0-1.41l-.71-.71a1.004 1.004 0 1 0-1.43 1.41l.73.71ZM21 11h-1a1 1 0 0 0 0 2h1a1 1 0 0 0 0-2Zm-2.64 6A1 1 0 0 0 17 18.36l.71.71a1 1 0 0 0 1.41 0 1 1 0 0 0 0-1.41l-.76-.66ZM12 6.5a5.5 5.5 0 1 0 5.5 5.5A5.51 5.51 0 0 0 12 6.5Zm0 9a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm0 3.5a1 1 0 0 0-1 1v1a1 1 0 0 0 2 0v-1a1 1 0 0 0-1-1Z" />
+          </svg>
+          <svg aria-hidden="true" class="icon label-icon" data-icon="dark" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M21.64 13a1 1 0 0 0-1.05-.14 8.049 8.049 0 0 1-3.37.73 8.15 8.15 0 0 1-8.14-8.1 8.59 8.59 0 0 1 .25-2A1 1 0 0 0 8 2.36a10.14 10.14 0 1 0 14 11.69 1 1 0 0 0-.36-1.05Zm-9.5 6.69A8.14 8.14 0 0 1 7.08 5.22v.27a10.15 10.15 0 0 0 10.14 10.14 9.784 9.784 0 0 0 2.1-.22 8.11 8.11 0 0 1-7.18 4.32v-.04Z" />
+          </svg>
+          <svg aria-hidden="true" class="icon label-icon" data-icon="auto" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
             <path d="M21 14h-1V7a3 3 0 0 0-3-3H7a3 3 0 0 0-3 3v7H3a1 1 0 0 0-1 1v2a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3v-2a1 1 0 0 0-1-1ZM6 7a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v7H6V7Zm14 10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-1h16v1Z" />
           </svg>
           <select autocomplete="off" data-theme-select>

--- a/site/src/components/Surfaces.astro
+++ b/site/src/components/Surfaces.astro
@@ -59,20 +59,6 @@ const { surfaces, copy } = site;
 .surfaces-section{
   background:var(--netscli-surface);
   border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
-  /* Clips the band bleed, and `clip` rather than `hidden` on purpose.
-   *
-   * The bands below are full-bleed via `inset-inline: calc(50% - 50vw)`, and
-   * 100vw counts the classic scrollbar while the layout box does not. So each
-   * side overhangs by half a scrollbar and the right one produces a real
-   * horizontal scrollbar: measured 5px of overflow at 1280, 1440 and 1600,
-   * every width, with a 10px scrollbar.
-   *
-   * `overflow-x: hidden` would also stop it and would cost more than it
-   * fixes: on an element whose other axis is visible it computes to `auto`,
-   * making this a scroll container and capturing any `position: sticky`
-   * inside it -- the exact trap that broke the docs contents rail earlier.
-   * `clip` does not create a scroll container. */
-  overflow-x:clip;
 }
 .surfaces-section::before{
   content:none;
@@ -88,73 +74,22 @@ const { surfaces, copy } = site;
 .surfaces{display:grid;gap:90px}
 .surface{
   display:grid;grid-template-columns:1fr 1fr;gap:64px;align-items:start;
-  position:relative;
 }
-/* Every other card sits on a full-bleed dark band.
+/* No band on the surface cards.
  *
- * A pseudo-element rather than a background, because the card is inside `.w`,
- * which is width-capped and centred -- a background on the card itself would
- * stop at the reading column and read as a panel, not a band. `50% - 50vw`
- * pushes the edges back out to the viewport.
+ * They had one -- every other card on a full-bleed #1c2634 -- and it made
+ * the page invert seven times between the hero and the footer, each join a
+ * 14.75:1 step. That reads as stripes rather than as sections.
  *
- * `inset-block:-45px` is half the 90px gap between cards at each end, so
- * consecutive bands meet exactly rather than leaving a stripe of page colour
- * between them.
+ * Gradient joins were tried as a softener and were worse: fading #1c2634
+ * into #fbfbfb runs through a muddy mid-grey, so 64px of it at every edge
+ * looked like a blur artifact. Spreading a 14.75:1 step does not shrink it,
+ * which is the tell that the edge was never the problem.
  *
- * Both themes, so the rhythm is not a light-mode-only device. The two do not
- * carry equal weight and cannot: measured, the band is 14.75:1 against the
- * light page and 1.24:1 against the dark one. On a dark page a band can only
- * ever be a lift, and 1.24:1 is about as far as one goes before it stops
- * looking like the same page. */
-.surface:nth-child(odd)::before{
-  content:"";
-  position:absolute;
-  inset-block:-45px;
-  inset-inline:calc(50% - 50vw);
-  z-index:0;
-  pointer-events:none;
-  background:var(--netscli-band-dark);
-  /* On the pseudo, not the card: this is the element that spans the full
-     viewport width, so the inner edge runs the whole band rather than
-     stopping at the reading column. */
-  box-shadow:var(--netscli-band-inset);
-}
-/* Above the band, and re-inked for it. The ink values are shared with the
-   navy footer -- see the on-dark block in code-surface.css -- rather than
-   copied, which is how the footer's copy and this one would have drifted. */
-.surface:nth-child(odd)>*{position:relative;z-index:1}
-.surface:nth-child(odd){
-  /* The same colour on the element itself, not only on the ::before.
-   *
-   * The pseudo-element is what reaches the viewport edges; this covers the
-   * card's own box. They are the same value so the join is invisible, and
-   * carrying both means the ink is never relying on a decorative pseudo to be
-   * legible. scripts/contrast-sweep.mjs composites real ancestor backgrounds
-   * and cannot see a ::before, so with the pseudo alone it read this card's
-   * body text as rgb(154,164,184) on the white PAGE -- 2.42:1, a fail. It was
-   * right to: if the pseudo ever stops painting, that is exactly what a
-   * reader gets. */
-  background:var(--netscli-band-dark);
-  color:var(--netscli-ondark-text);
-  --netscli-text:var(--netscli-ondark-text);
-  --netscli-text-strong:var(--netscli-ondark-text-strong);
-  --netscli-text-muted:var(--netscli-ondark-text-muted);
-  --netscli-accent:var(--netscli-ondark-accent);
-  --netscli-accent-rgb:var(--netscli-ondark-accent-rgb);
-  --netscli-accent-bright:var(--netscli-ondark-accent-bright);
-  --netscli-hairline-rgb:255, 255, 255;
-  --netscli-lift-rgb:255, 255, 255;
-}
-/* The code sample needs an edge here, not a darker fill.
- *
- * `.codeblock` is #10151b and the band is #1c2634: 1.20:1. No navy that still
- * reads as dark gets that separation -- the lightest one tried, #273246, only
- * reached 1.42:1 while costing contrast everywhere else. So the block is
- * delineated by its border instead, lifted from .08 to .18 on these cards,
- * and by its own dark fill against the lighter band around it. */
-.surface:nth-child(odd) .codeblock{
-  border-color:rgba(255,255,255,.18);
-}
+ * The two dark moments that remain are the install section and the footer --
+ * see global.css. Three edges instead of seven, and the four cards read as
+ * one continuous tour rather than as alternating stripes. */
+
 /* Grid children default to min-width:auto (content-based), which lets a
    long <pre> codeblock force the grid wider than the viewport. Clamping
    to 0 lets the codeblock's own overflow-x:auto contain the overflow. */

--- a/site/src/components/Surfaces.astro
+++ b/site/src/components/Surfaces.astro
@@ -74,6 +74,68 @@ const { surfaces, copy } = site;
 .surfaces{display:grid;gap:90px}
 .surface{
   display:grid;grid-template-columns:1fr 1fr;gap:64px;align-items:start;
+  position:relative;
+}
+/* Every other card sits on a full-bleed dark band.
+ *
+ * A pseudo-element rather than a background, because the card is inside `.w`,
+ * which is width-capped and centred -- a background on the card itself would
+ * stop at the reading column and read as a panel, not a band. `50% - 50vw`
+ * pushes the edges back out to the viewport.
+ *
+ * `inset-block:-45px` is half the 90px gap between cards at each end, so
+ * consecutive bands meet exactly rather than leaving a stripe of page colour
+ * between them.
+ *
+ * Both themes, so the rhythm is not a light-mode-only device. The two do not
+ * carry equal weight and cannot: measured, the band is 14.75:1 against the
+ * light page and 1.24:1 against the dark one. On a dark page a band can only
+ * ever be a lift, and 1.24:1 is about as far as one goes before it stops
+ * looking like the same page. */
+.surface:nth-child(even)::before{
+  content:"";
+  position:absolute;
+  inset-block:-45px;
+  inset-inline:calc(50% - 50vw);
+  z-index:0;
+  pointer-events:none;
+  background:var(--netscli-band-dark);
+}
+/* Above the band, and re-inked for it. The ink values are shared with the
+   navy footer -- see the on-dark block in code-surface.css -- rather than
+   copied, which is how the footer's copy and this one would have drifted. */
+.surface:nth-child(even)>*{position:relative;z-index:1}
+.surface:nth-child(even){
+  /* The same colour on the element itself, not only on the ::before.
+   *
+   * The pseudo-element is what reaches the viewport edges; this covers the
+   * card's own box. They are the same value so the join is invisible, and
+   * carrying both means the ink is never relying on a decorative pseudo to be
+   * legible. scripts/contrast-sweep.mjs composites real ancestor backgrounds
+   * and cannot see a ::before, so with the pseudo alone it read this card's
+   * body text as rgb(154,164,184) on the white PAGE -- 2.42:1, a fail. It was
+   * right to: if the pseudo ever stops painting, that is exactly what a
+   * reader gets. */
+  background:var(--netscli-band-dark);
+  color:var(--netscli-ondark-text);
+  --netscli-text:var(--netscli-ondark-text);
+  --netscli-text-strong:var(--netscli-ondark-text-strong);
+  --netscli-text-muted:var(--netscli-ondark-text-muted);
+  --netscli-accent:var(--netscli-ondark-accent);
+  --netscli-accent-rgb:var(--netscli-ondark-accent-rgb);
+  --netscli-accent-bright:var(--netscli-ondark-accent-bright);
+  --netscli-hairline-rgb:255, 255, 255;
+  --netscli-lift-rgb:255, 255, 255;
+}
+/* The code sample needs an edge here, not a darker fill.
+ *
+ * `.codeblock` is #10151b and the band is #1c2634: 1.20:1. No navy that still
+ * reads as dark gets that separation -- the lightest one tried, #273246, only
+ * reached 1.42:1 while costing contrast everywhere else. So the block is
+ * delineated by its border instead, lifted from .08 to .18 on these cards,
+ * and by its own dark fill against the lighter band around it. */
+.surface:nth-child(even) .codeblock{
+  border-color:rgba(255,255,255,.18);
 }
 /* Grid children default to min-width:auto (content-based), which lets a
    long <pre> codeblock force the grid wider than the viewport. Clamping

--- a/site/src/components/Surfaces.astro
+++ b/site/src/components/Surfaces.astro
@@ -73,7 +73,13 @@ const { surfaces, copy } = site;
 }
 .surfaces{display:grid;gap:90px}
 .surface{
-  display:grid;grid-template-columns:1fr 1fr;gap:64px;align-items:start;
+  display:grid;grid-template-columns:1fr 1fr;gap:64px;
+  /* Centred, not top-aligned. Every text block in this section is 118px tall
+     and every visual beside it is 218-296px, so `start` left 100-178px of
+     empty column under each paragraph -- about 560px of void in a 1608px
+     section, which is what made the tour read as ragged rather than as four
+     matched rows. */
+  align-items:center;
 }
 /* No band on the surface cards.
  *
@@ -108,7 +114,7 @@ const { surfaces, copy } = site;
   display:block;
   width:100%;height:auto;border-radius:10px;
   border:1px solid rgba(var(--netscli-lift-rgb),.08);
-  box-shadow:0 12px 40px rgba(0,0,0,.4);
+  box-shadow:var(--netscli-lift-md);
 }
 .surface-visual img:focus-visible,
 .bigshot img:focus-visible{
@@ -121,7 +127,7 @@ const { surfaces, copy } = site;
   border-radius:10px;padding:16px 58px 16px 20px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:.75rem;line-height:1.7;white-space:pre;overflow-x:auto;color:var(--netscli-text);
-  box-shadow:0 12px 40px rgba(0,0,0,.4);
+  box-shadow:var(--netscli-lift-md);
   position:relative;
 }
 @media(max-width:720px){

--- a/site/src/components/Surfaces.astro
+++ b/site/src/components/Surfaces.astro
@@ -59,6 +59,20 @@ const { surfaces, copy } = site;
 .surfaces-section{
   background:var(--netscli-surface);
   border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
+  /* Clips the band bleed, and `clip` rather than `hidden` on purpose.
+   *
+   * The bands below are full-bleed via `inset-inline: calc(50% - 50vw)`, and
+   * 100vw counts the classic scrollbar while the layout box does not. So each
+   * side overhangs by half a scrollbar and the right one produces a real
+   * horizontal scrollbar: measured 5px of overflow at 1280, 1440 and 1600,
+   * every width, with a 10px scrollbar.
+   *
+   * `overflow-x: hidden` would also stop it and would cost more than it
+   * fixes: on an element whose other axis is visible it computes to `auto`,
+   * making this a scroll container and capturing any `position: sticky`
+   * inside it -- the exact trap that broke the docs contents rail earlier.
+   * `clip` does not create a scroll container. */
+  overflow-x:clip;
 }
 .surfaces-section::before{
   content:none;

--- a/site/src/components/Surfaces.astro
+++ b/site/src/components/Surfaces.astro
@@ -92,7 +92,7 @@ const { surfaces, copy } = site;
  * light page and 1.24:1 against the dark one. On a dark page a band can only
  * ever be a lift, and 1.24:1 is about as far as one goes before it stops
  * looking like the same page. */
-.surface:nth-child(even)::before{
+.surface:nth-child(odd)::before{
   content:"";
   position:absolute;
   inset-block:-45px;
@@ -100,12 +100,16 @@ const { surfaces, copy } = site;
   z-index:0;
   pointer-events:none;
   background:var(--netscli-band-dark);
+  /* On the pseudo, not the card: this is the element that spans the full
+     viewport width, so the inner edge runs the whole band rather than
+     stopping at the reading column. */
+  box-shadow:var(--netscli-band-inset);
 }
 /* Above the band, and re-inked for it. The ink values are shared with the
    navy footer -- see the on-dark block in code-surface.css -- rather than
    copied, which is how the footer's copy and this one would have drifted. */
-.surface:nth-child(even)>*{position:relative;z-index:1}
-.surface:nth-child(even){
+.surface:nth-child(odd)>*{position:relative;z-index:1}
+.surface:nth-child(odd){
   /* The same colour on the element itself, not only on the ::before.
    *
    * The pseudo-element is what reaches the viewport edges; this covers the
@@ -134,7 +138,7 @@ const { surfaces, copy } = site;
  * reached 1.42:1 while costing contrast everywhere else. So the block is
  * delineated by its border instead, lifted from .08 to .18 on these cards,
  * and by its own dark fill against the lighter band around it. */
-.surface:nth-child(even) .codeblock{
+.surface:nth-child(odd) .codeblock{
   border-color:rgba(255,255,255,.18);
 }
 /* Grid children default to min-width:auto (content-based), which lets a

--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -131,11 +131,24 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
       color: var(--sl-color-white);
     }
 
-    /* Same separator as the landing bar -- see Nav.astro. */
+    /* Same separator as the landing bar -- see Nav.astro, including why it is
+       a short centred pseudo-element rather than a border: these links are the
+       full nav height, so a border ran floor to ceiling and split the bar. */
     .docs-nav-links a.nav-group-start {
+      position: relative;
       margin-inline-start: 0.35rem;
       padding-inline-start: 0.95rem;
-      border-inline-start: 1px solid rgba(var(--netscli-hairline-rgb), 0.28);
+    }
+
+    .docs-nav-links a.nav-group-start::before {
+      content: "";
+      position: absolute;
+      inset-inline-start: 0;
+      top: 50%;
+      width: 1px;
+      height: 18px;
+      margin-block-start: -9px;
+      background: rgba(var(--netscli-hairline-rgb), 0.28);
     }
 
     .docs-nav-links a[aria-current] {

--- a/site/src/data/site-content/hero.ts
+++ b/site/src/data/site-content/hero.ts
@@ -22,14 +22,28 @@ export const hero: Hero = {
     // find nothing. The capture-enabled CLI assets are real and published, so
     // the feature stays on the page; it just no longer implies the download
     // above it includes it.
-    // Traceroute is deliberately absent from this list. It used to be in it,
-    // and the sentence attributes every operation it names to all four
-    // interfaces -- but the MCP server has no traceroute tool at all (docs
-    // say so outright: /docs/interface-coverage/ "Trace route has no MCP
-    // tool"). The list was already illustrative rather than exhaustive; it
-    // omits ping, sweep, ARP and mDNS too. Dropping the one operation that
-    // does not hold for all four is cheaper than qualifying it.
-    'Discover LAN devices, scan TCP ports, query DNS, and inspect hosts from the desktop app, terminal UI, CLI, or MCP server — with packet capture in capture-enabled CLI builds. Each interface calls the same Rust core, so results stay consistent.',
+    // Two things are deliberately absent.
+    //
+    // TRACEROUTE. The sentence attributes every operation it names to all
+    // four interfaces, and the MCP server has no traceroute tool at all --
+    // /docs/interface-coverage/ says so outright. The list is illustrative
+    // rather than exhaustive (it omits ping, sweep, ARP and mDNS too), so
+    // dropping the one operation that does not hold for all four is cheaper
+    // than qualifying it.
+    //
+    // PACKET CAPTURE. This used to end "with packet capture in
+    // capture-enabled CLI builds", a clause added because an earlier version
+    // listed capture alongside the rest and so implied the desktop installer
+    // above it included capture, which no published one does. Saying nothing
+    // makes no claim at all, which is the same protection for a third of the
+    // length -- and capture is covered properly in the FAQ and the install
+    // guide, which is where someone looking for it will be.
+    //
+    // 242 characters and three lines before; the second sentence went with
+    // it. "All on one Rust core" carries the same point as "each interface
+    // calls the same Rust core, so results stay consistent" -- the reader who
+    // needs the longer version is already reading /docs/.
+    'Discover LAN devices, scan TCP ports, query DNS, and inspect hosts from the desktop app, terminal UI, CLI, or MCP server — all on one Rust core.',
   // `winget install netscli` leads, and the shell script follows.
   //
   // os-tabs.ts already swapped these per-OS at runtime -- Windows visitors

--- a/site/src/layouts/Page.astro
+++ b/site/src/layouts/Page.astro
@@ -123,6 +123,12 @@ const shouldNoindex = noindex || isPreviewBuild;
             ? 'light'
             : 'dark';
       document.documentElement.dataset.theme = theme;
+      // What the reader CHOSE, as distinct from what is applied: 'auto'
+      // resolves to light or dark above, and the theme control has to show
+      // which of the three is selected. Set here rather than by the control's
+      // own script so the right icon is correct on first paint.
+      document.documentElement.dataset.themeChoice =
+        stored === 'light' || stored === 'dark' ? stored : 'auto';
     } catch {
       // Private mode, or storage blocked. Falling through leaves the dark
       // default, which is what an unthemed page has always rendered.

--- a/site/src/scripts/theme-select.ts
+++ b/site/src/scripts/theme-select.ts
@@ -50,6 +50,10 @@ export function initThemeSelect(): void {
       // Storage blocked: the choice still applies to this page, it just will
       // not survive a navigation. Better than doing nothing.
     }
+    // The icon follows the CHOICE, not the applied theme: on "auto" the page
+    // may be dark while the control should still show the laptop. See the
+    // icon rules in styles/theme-control.css.
+    document.documentElement.dataset.themeChoice = choice;
     apply(choice === 'auto' ? systemTheme() : (choice as Theme));
   });
 

--- a/site/src/styles/code-surface.css
+++ b/site/src/styles/code-surface.css
@@ -111,7 +111,25 @@
   --netscli-band-inset:
     inset 0 11px 15px -11px rgba(0, 0, 0, 0.55),
     inset 0 -11px 15px -11px rgba(0, 0, 0, 0.55);
+
+  /* ---- Elevation -------------------------------------------------------
+   *
+   * The lift under a screenshot, a code sample or the hero shot. These were
+   * hand-written rgba(0,0,0,.32-.6) blacks, tuned when the only page was
+   * near-black: on #111 a hard black shadow reads as depth, on #fbfbfb it
+   * reads as a heavy grey halo, and the two big ones (.42 and .6) are the
+   * most dated-looking thing on the light page.
+   *
+   * Three steps because the three call sites want different weights -- a
+   * 900px hero shot needs more lift than an inline code sample -- and one
+   * scale so they stay in proportion to each other when either theme
+   * changes. The light values use the hairline channel rather than black,
+   * which is the same thing the nav's scroll shadow was corrected to. */
+  --netscli-lift-sm: 0 12px 28px rgba(0, 0, 0, 0.32);
+  --netscli-lift-md: 0 12px 40px rgba(0, 0, 0, 0.4);
+  --netscli-lift-lg: 0 32px 80px rgba(0, 0, 0, 0.6);
 }
+
 
 html[data-theme='light'] {
   /* Same surface and the same 1.52:1 edge as the .reco card, so a chip and a
@@ -123,6 +141,12 @@ html[data-theme='light'] {
   --netscli-chip-fg-muted: #596478;
   --netscli-chip-raised: #f2f5fa;
   --netscli-chip-lift-rgb: 17, 24, 39;
+
+  /* Elevation on a light page: the hairline channel, not black, and much
+     shallower. See the scale above. */
+  --netscli-lift-sm: 0 6px 16px rgba(17, 24, 39, 0.07);
+  --netscli-lift-md: 0 10px 28px rgba(17, 24, 39, 0.1);
+  --netscli-lift-lg: 0 22px 56px rgba(17, 24, 39, 0.14);
 }
 
 /* ─── INK ON THE DARK CODE SURFACE ───

--- a/site/src/styles/code-surface.css
+++ b/site/src/styles/code-surface.css
@@ -56,6 +56,41 @@
   --netscli-code-key: #7c9fc7;
   --netscli-code-string: #8fbc7f;
 
+  /* ---- Command chips ---------------------------------------------------
+   *
+   * A chip is a single command with a copy button: the two in the hero and
+   * every row in the install section. A code surface is something you read:
+   * the JSON and config samples, the terminal panel, the docs.
+   *
+   * The split exists because they are different objects. A chip sits next to
+   * the "Desktop app" button and behaves like it -- you click it -- so on a
+   * white page two solid #10151b bars beside an outlined button read as
+   * mismatched weights rather than as a set. A sample has no such neighbour
+   * and stays dark in both themes, which is the rule the rest of this file
+   * describes.
+   *
+   * Defaults are the code surface, so the dark theme is unchanged and the two
+   * kinds of thing look identical there -- on a dark page there is nothing to
+   * mismatch. Only the light theme pulls them apart. */
+  --netscli-chip-bg: var(--netscli-code-bg);
+  --netscli-chip-border: var(--netscli-code-border);
+  --netscli-chip-divider: var(--netscli-code-divider);
+  --netscli-chip-fg: var(--netscli-code-fg);
+  --netscli-chip-fg-muted: #9a9a9a;
+  --netscli-chip-raised: #20242b;
+  --netscli-chip-lift-rgb: 255, 255, 255;
+}
+
+html[data-theme='light'] {
+  /* Same surface and the same 1.52:1 edge as the .reco card, so a chip and a
+     card read as the same family of object. */
+  --netscli-chip-bg: #f2f5fa;
+  --netscli-chip-border: rgba(17, 24, 39, 0.2);
+  --netscli-chip-divider: rgba(17, 24, 39, 0.14);
+  --netscli-chip-fg: #44516a;
+  --netscli-chip-fg-muted: #596478;
+  --netscli-chip-raised: #f2f5fa;
+  --netscli-chip-lift-rgb: 17, 24, 39;
 }
 
 /* ─── INK ON THE DARK CODE SURFACE ───
@@ -76,11 +111,8 @@
  * lightened the label onto a light background. Same reason .reco and .try-cmd
  * are absent -- see Install.astro.
  */
-.cmd,
-.alt,
 .tryblock,
 .try,
-.hero-command,
 .codeblock,
 .faq-command code {
   --netscli-text: var(--netscli-code-fg);
@@ -103,4 +135,22 @@
    * on the chip, so it must keep the light surface. Only `.faq-command code`
    * is remapped, and that element has no button inside it. */
   --netscli-surface-raised: #20242b;
+}
+
+/* The same remap for chips, pointed at the chip tokens instead of the code
+ * ones. Identical in dark -- the chip tokens default to the code surface --
+ * and the light values in the block above take over on a light page.
+ *
+ * A token indirection rather than a light-theme rule restating the ramp: the
+ * navy footer already carries one copy of the light ink values and the .reco
+ * card another, and a third would be the point where they start to drift. */
+.cmd,
+.alt,
+.hero-command {
+  --netscli-text: var(--netscli-chip-fg);
+  --netscli-text-strong: var(--netscli-chip-fg);
+  --netscli-text-muted: var(--netscli-chip-fg-muted);
+  --netscli-surface-raised: var(--netscli-chip-raised);
+  --netscli-lift-rgb: var(--netscli-chip-lift-rgb);
+  color: var(--netscli-text);
 }

--- a/site/src/styles/code-surface.css
+++ b/site/src/styles/code-surface.css
@@ -99,6 +99,18 @@
      at 6.09:1. Not as dark as the code surface on purpose -- see the note on
      the card rule in Surfaces.astro for why that gap cannot do the work. */
   --netscli-band-dark: #1c2634;
+
+  /* The band's inner edge. A pair of inset shadows, top and bottom, with a
+     negative spread so each one stays a thin gradient at its own edge instead
+     of washing the whole band. Reads as the band being recessed into the page
+     rather than laid on top of it, and it gives the light/dark joins a soft
+     transition instead of a hard 1px switch.
+     One token because every band uses it -- the surface cards, the install
+     section and the footer -- and three hand-tuned copies is how they end up
+     with three different depths. */
+  --netscli-band-inset:
+    inset 0 11px 15px -11px rgba(0, 0, 0, 0.55),
+    inset 0 -11px 15px -11px rgba(0, 0, 0, 0.55);
 }
 
 html[data-theme='light'] {

--- a/site/src/styles/code-surface.css
+++ b/site/src/styles/code-surface.css
@@ -129,8 +129,8 @@
     0 6px 14px -6px rgba(17, 24, 39, 0.18);
 
   --netscli-band-inset:
-    inset 0 11px 15px -11px rgba(0, 0, 0, 0.55),
-    inset 0 -11px 15px -11px rgba(0, 0, 0, 0.55);
+    inset 0 14px 18px -10px rgba(0, 0, 0, 0.7),
+    inset 0 -14px 18px -10px rgba(0, 0, 0, 0.7);
 
   /* ---- Elevation -------------------------------------------------------
    *

--- a/site/src/styles/code-surface.css
+++ b/site/src/styles/code-surface.css
@@ -83,6 +83,13 @@
      neither a control nor a sample: on a white page a near-black chip mid-
      paragraph reads as a hole punched in the text. */
   --netscli-chip-code-fg: var(--netscli-code-inline-fg);
+  /* Accent INSIDE a chip. The install band re-points the accent to its
+     on-dark values, and a control sitting on a light chip on that band
+     inherited them -- the Download button's hover was #86efac on a light
+     row, 1.62:1. */
+  --netscli-chip-accent: var(--netscli-ondark-accent);
+  --netscli-chip-accent-rgb: var(--netscli-ondark-accent-rgb);
+  --netscli-chip-accent-bright: var(--netscli-ondark-accent-bright);
 
   /* ---- Ink on a dark surface -------------------------------------------
    *
@@ -157,6 +164,9 @@ html[data-theme='light'] {
   /* 8.66:1 on the light chip. The dark theme's #86efac is a light-on-dark
      green and measures 1.5:1 there, so it cannot simply carry over. */
   --netscli-chip-code-fg: #0e5122;
+  --netscli-chip-accent: #146b2e;
+  --netscli-chip-accent-rgb: 20, 107, 46;
+  --netscli-chip-accent-bright: #0e5122;
 
   /* Elevation on a light page: the hairline channel, not black, and much
      shallower. See the scale above. */
@@ -224,5 +234,11 @@ html[data-theme='light'] {
   --netscli-text-muted: var(--netscli-chip-fg-muted);
   --netscli-surface-raised: var(--netscli-chip-raised);
   --netscli-lift-rgb: var(--netscli-chip-lift-rgb);
+  /* The accent too, not just the ink. A control sitting on a chip -- the
+     install rows' Download button -- otherwise inherits the band's on-dark
+     accent and hovers to #86efac on a light row: measured 1.19:1. */
+  --netscli-accent: var(--netscli-chip-accent);
+  --netscli-accent-rgb: var(--netscli-chip-accent-rgb);
+  --netscli-accent-bright: var(--netscli-chip-accent-bright);
   color: var(--netscli-text);
 }

--- a/site/src/styles/code-surface.css
+++ b/site/src/styles/code-surface.css
@@ -79,6 +79,10 @@
   --netscli-chip-fg-muted: #9a9a9a;
   --netscli-chip-raised: #20242b;
   --netscli-chip-lift-rgb: 255, 255, 255;
+  /* Inline `code` in prose rides the chip too. A word inside a sentence is
+     neither a control nor a sample: on a white page a near-black chip mid-
+     paragraph reads as a hole punched in the text. */
+  --netscli-chip-code-fg: var(--netscli-code-inline-fg);
 
   /* ---- Ink on a dark surface -------------------------------------------
    *
@@ -141,6 +145,9 @@ html[data-theme='light'] {
   --netscli-chip-fg-muted: #596478;
   --netscli-chip-raised: #f2f5fa;
   --netscli-chip-lift-rgb: 17, 24, 39;
+  /* 8.66:1 on the light chip. The dark theme's #86efac is a light-on-dark
+     green and measures 1.5:1 there, so it cannot simply carry over. */
+  --netscli-chip-code-fg: #0e5122;
 
   /* Elevation on a light page: the hairline channel, not black, and much
      shallower. See the scale above. */

--- a/site/src/styles/code-surface.css
+++ b/site/src/styles/code-surface.css
@@ -79,6 +79,26 @@
   --netscli-chip-fg-muted: #9a9a9a;
   --netscli-chip-raised: #20242b;
   --netscli-chip-lift-rgb: 255, 255, 255;
+
+  /* ---- Ink on a dark surface -------------------------------------------
+   *
+   * Anything that paints itself dark on a light page has to re-point the
+   * text ramp, and there are three such places now: the navy footer, the
+   * alternating dark surface cards, and any future one. Each was carrying
+   * its own copy of these six values, which is exactly how two of them
+   * would eventually disagree. One definition, referenced. */
+  --netscli-ondark-text: #d7dce5;
+  --netscli-ondark-text-strong: #f4f4f4;
+  --netscli-ondark-text-muted: #9aa4b8;
+  --netscli-ondark-accent: #22c55e;
+  --netscli-ondark-accent-rgb: 34, 197, 94;
+  --netscli-ondark-accent-bright: #86efac;
+
+  /* The dark band behind every other surface card. Measured against the
+     light page at 14.75:1, and it carries body ink at 11.09:1 and muted ink
+     at 6.09:1. Not as dark as the code surface on purpose -- see the note on
+     the card rule in Surfaces.astro for why that gap cannot do the work. */
+  --netscli-band-dark: #1c2634;
 }
 
 html[data-theme='light'] {

--- a/site/src/styles/code-surface.css
+++ b/site/src/styles/code-surface.css
@@ -112,6 +112,15 @@
      One token because every band uses it -- the surface cards, the install
      section and the footer -- and three hand-tuned copies is how they end up
      with three different depths. */
+  /* Cast at the band's own edges, outward onto the page above and below.
+     The inset pair below darkens the band's inner lip; this is the other
+     half -- the page picking up a little shade where the dark section meets
+     it, so the two do not simply abut. Small on purpose: the join should
+     read as a seam, not as a floating panel. */
+  --netscli-band-edge-shadow:
+    0 -6px 14px -6px rgba(17, 24, 39, 0.18),
+    0 6px 14px -6px rgba(17, 24, 39, 0.18);
+
   --netscli-band-inset:
     inset 0 11px 15px -11px rgba(0, 0, 0, 0.55),
     inset 0 -11px 15px -11px rgba(0, 0, 0, 0.55);

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -123,12 +123,12 @@ section:nth-of-type(even){
     var(--netscli-surface);
   border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
 }
-/* No section-level band on a light page. The rhythm is inside the surfaces
- * section instead, where every other card gets a full-bleed dark band -- see
- * Surfaces.astro.
+/* No alternating band on a light page. Two dark moments carry the rhythm
+ * instead -- #install below and the footer -- and every other section is the
+ * page colour.
  *
- * Five treatments were built and measured getting here, and it is worth
- * knowing why each failed, because three of them failed for reasons a
+ * Six treatments were built and measured getting here, and it is worth
+ * knowing why each failed, because most of them failed for reasons a
  * screenshot does not show:
  *
  *   1.09:1  the original tint (--netscli-surface). Invisible; not a band.
@@ -145,12 +145,16 @@ section:nth-of-type(even){
  *  1.143:1  a quiet tint, alternating so no two banded sections touch. The
  *           structure was right and the colour was not: a pale blue-grey at
  *           that strength reads as washed out rather than as a band.
+ *  14.75:1  dark bands on alternating SURFACE CARDS. Correct per-band and
+ *           wrong as a page: it made the page invert seven times between the
+ *           hero and the footer. Gradient joins were tried to soften that and
+ *           were worse -- fading #1c2634 into #fbfbfb runs through a muddy
+ *           mid-grey. Spreading a 14.75:1 step does not shrink it.
  *
- * So the band went dark and moved down a level, to the thing it is actually
- * separating: the four surface cards. `.surfaces-section` is still listed
- * here because Surfaces.astro paints its own background in a component style
- * and the bare `section` selector does not reach it -- an earlier build
- * cleared one and not the other, which is invisible from either file alone. */
+ * So: two dark moments, not seven. `.surfaces-section` is still listed here
+ * because Surfaces.astro paints its own background in a component style and
+ * the bare `section` selector does not reach it -- an earlier build cleared
+ * one and not the other, which is invisible from either file alone. */
 html[data-theme='light'] section,
 html[data-theme='light'] .surfaces-section{
   background:var(--netscli-bg);
@@ -186,7 +190,7 @@ html[data-theme='light'] section:nth-of-type(even)::before{
  * device. */
 #install{
   background:var(--netscli-band-dark);
-  box-shadow:var(--netscli-band-inset);
+  box-shadow:var(--netscli-band-inset),var(--netscli-band-edge-shadow);
   color:var(--netscli-ondark-text);
   --netscli-text:var(--netscli-ondark-text);
   --netscli-text-strong:var(--netscli-ondark-text-strong);
@@ -226,7 +230,7 @@ html[data-theme='light'] #install .reco{
 html[data-theme='light'] footer{
   --netscli-band-navy:#141c2e;
   background:var(--netscli-band-navy);
-  box-shadow:var(--netscli-band-inset);
+  box-shadow:var(--netscli-band-inset),var(--netscli-band-edge-shadow);
   /* Explicit, not just the token. The element inherits `color` from <body>,
      where the token already resolved to the light ramp, so re-pointing the
      token alone leaves text that sets no colour of its own dark on navy.

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -120,34 +120,58 @@ section:nth-of-type(even){
     var(--netscli-surface);
   border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
 }
-/* Dark navy bands, light theme only.
+/* A band you can actually see, light theme only.
  *
- * The alternating band above is a tint, and on a light page it is barely a
- * band at all: measured page rgb(251,251,251) against band rgb(238,241,247)
- * is 1.09:1, which no one can see. The dark theme does not have this problem
- * -- 1.12:1 reads fine when the page is already dark -- so this is scoped to
- * light and dark mode is left exactly as it was.
+ * The tint above is drawn from --netscli-surface, and on a light page that is
+ * barely a band at all: page rgb(251,251,251) against band rgb(238,241,247)
+ * measures 1.09:1. The dark theme does not have this problem -- 1.12:1 reads
+ * fine when the page is already dark -- so this is scoped to light and dark
+ * mode is untouched.
  *
- * Install and the footer, not install and surfaces: two bands running back to
- * back read as one heavy slab, and the FAQ between these two gives the page a
- * rhythm instead. It also puts the weight at the bottom, which is where the
- * install commands are.
+ * A DEEPER TINT, not an inversion. Painting #install dark navy was tried
+ * first and measured worse where it counts: the .alt and .tryblock command
+ * blocks are #10151b, so on a light band they separate at 16.21:1 and on a
+ * navy one at 1.08:1. The commands a visitor came to copy disappeared into
+ * the band while the container shouted -- contrast moved from inside the
+ * section, where it was working, to around it, where it is decoration. It
+ * also broke the alternation: #surfaces and #install share this one rule, and
+ * inverting only one of them left two sections that look nothing alike.
  *
- * The ramp is re-pointed on the subtree rather than restated per element --
- * the same technique as the code surfaces in code-surface.css, and for the
- * same reason: the children already read these tokens, so one rule fixes all
- * of them and cannot miss one added later. The rgb CHANNELS have to invert
- * too, not just the ink: hairlines, borders and the accent wash on ::before
- * are all rgba() call sites, and in the light theme those channels are
- * near-black. */
-html[data-theme='light'] #install,
+ * #dae1ee is 1.27:1 against the page -- visible as a band, and the command
+ * blocks still clear 13.96:1 on it. It lifts the .reco card off the band as a
+ * side effect, from 1.03:1 to 1.20:1, so the recommended install finally
+ * reads as a card rather than as more band.
+ *
+ * A band-specific token rather than a deeper --netscli-surface: that token is
+ * also the hero's chips, the surface cards, the changelog fade and the
+ * lightbox, and none of those asked to get darker. */
+/* `.surfaces-section` is listed as well as the nth-of-type rule, and it has to
+   be: only #install is an even section here -- the hero is a div, so the
+   sections count surfaces(1), install(2), faq(3) -- and Surfaces.astro paints
+   its own band from --netscli-surface in a component style. Tinting one and
+   not the other is the mismatch this whole change exists to remove, and it is
+   invisible from either file alone. */
+html[data-theme='light'] section:nth-of-type(even),
+html[data-theme='light'] .surfaces-section{
+  --netscli-band-tint:#dae1ee;
+  background:
+    linear-gradient(180deg,rgba(var(--netscli-lift-rgb),.018),rgba(var(--netscli-lift-rgb),.006)),
+    var(--netscli-band-tint);
+}
+
+/* The footer is the one dark anchor, and it is dark because it has nothing to
+   swallow: no code panels, no cards, one line of text. The ramp is re-pointed
+   on the subtree rather than restated per element -- the same technique as the
+   code surfaces in code-surface.css. The rgb CHANNELS invert with it, not just
+   the ink: the top border and any hairline here are rgba() call sites, and
+   those channels are near-black in the light theme. */
 html[data-theme='light'] footer{
   --netscli-band-navy:#141c2e;
   background:var(--netscli-band-navy);
-  /* Explicit, not just the token. The section inherits `color` from <body>,
+  /* Explicit, not just the token. The element inherits `color` from <body>,
      where the token already resolved to the light ramp, so re-pointing the
-     token alone leaves any text that does not set its own colour dark on
-     navy. Measured: #install computed rgb(68,81,106) until this line. */
+     token alone leaves text that sets no colour of its own dark on navy.
+     Measured rgb(68,81,106) until this line. */
   color:var(--netscli-text);
   --netscli-text:#d7dce5;
   --netscli-text-strong:#f4f4f4;
@@ -157,23 +181,6 @@ html[data-theme='light'] footer{
   --netscli-accent-bright:#86efac;
   --netscli-hairline-rgb:255, 255, 255;
   --netscli-lift-rgb:255, 255, 255;
-}
-
-/* The recommended-install card stays a LIGHT card on the navy band, so the
-   ramp has to come back to the light values inside it. Without this the card
-   keeps its near-white surface and inherits the band's near-white ink -- the
-   same trap `.faq-command` hit when the code surfaces went dark, and the one
-   `.reco` was pulled out of the code-surface remap for. */
-html[data-theme='light'] #install .reco{
-  color:var(--netscli-text);
-  --netscli-text:#44516a;
-  --netscli-text-strong:#111827;
-  --netscli-text-muted:#596478;
-  --netscli-accent:#146b2e;
-  --netscli-accent-rgb:20, 107, 46;
-  --netscli-accent-bright:#0e5122;
-  --netscli-hairline-rgb:17, 24, 39;
-  --netscli-lift-rgb:17, 24, 39;
 }
 
 section:nth-of-type(even)::before{

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -127,29 +127,20 @@ section:nth-of-type(even){
  * instead -- #install below and the footer -- and every other section is the
  * page colour.
  *
- * Six treatments were built and measured getting here, and it is worth
- * knowing why each failed, because most of them failed for reasons a
- * screenshot does not show:
+ * Six treatments were measured getting here; most failed for reasons a
+ * screenshot does not show, so the numbers are kept:
  *
- *   1.09:1  the original tint (--netscli-surface). Invisible; not a band.
- *  16.43:1  #install inverted to dark navy. Worse where it counts -- the .alt
- *           and .tryblock command blocks were #10151b, so they went from
- *           16.21:1 on a light band to 1.08:1 on a navy one. The commands a
- *           visitor came to copy vanished into the band while the container
- *           shouted.
- *   1.27:1  a deeper tint on BOTH surfaces and install. Those two sections
- *           are adjacent, so it tinted 59.6% of the page in one run and read
- *           as a second background rather than as punctuation.
- *    1:1    no bands at all. Measurably the best for the content -- command
- *           blocks separate at 17.72:1 on the page -- and too flat.
- *  1.143:1  a quiet tint, alternating so no two banded sections touch. The
- *           structure was right and the colour was not: a pale blue-grey at
- *           that strength reads as washed out rather than as a band.
- *  14.75:1  dark bands on alternating SURFACE CARDS. Correct per-band and
- *           wrong as a page: it made the page invert seven times between the
- *           hero and the footer. Gradient joins were tried to soften that and
- *           were worse -- fading #1c2634 into #fbfbfb runs through a muddy
- *           mid-grey. Spreading a 14.75:1 step does not shrink it.
+ *   1.09:1  the original tint. Invisible; not a band.
+ *  16.43:1  #install inverted to navy. The .alt and .tryblock command blocks
+ *           are #10151b, so they went 16.21:1 -> 1.08:1: the commands a
+ *           visitor came to copy vanished into their own container.
+ *   1.27:1  a deeper tint on surfaces AND install -- adjacent sections, so it
+ *           tinted 59.6% of the page in one run and read as a background.
+ *    1:1    no bands. Best for the content (blocks at 17.72:1) and too flat.
+ *  1.143:1  a quiet alternating tint. Structure right, colour washed out.
+ *  14.75:1  dark bands on alternating CARDS -- seven inversions per page.
+ *           Gradient joins were tried and were worse: #1c2634 into #fbfbfb
+ *           runs through a muddy grey; spreading a step does not shrink it.
  *
  * So: two dark moments, not seven. `.surfaces-section` is still listed here
  * because Surfaces.astro paints its own background in a component style and

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -120,56 +120,36 @@ section:nth-of-type(even){
     var(--netscli-surface);
   border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
 }
-/* Alternating bands on the light page, ODD sections tinted.
+/* No section-level band on a light page. The rhythm is inside the surfaces
+ * section instead, where every other card gets a full-bleed dark band -- see
+ * Surfaces.astro.
  *
- * The hero is a div, so the sections count surfaces(1), install(2), faq(3):
- * odd tints surfaces and faq and leaves install white, and no two banded
- * sections ever touch. That adjacency is the thing that matters here -- four
- * treatments were built and measured before this one, and the two that failed
- * failed for different reasons:
+ * Five treatments were built and measured getting here, and it is worth
+ * knowing why each failed, because three of them failed for reasons a
+ * screenshot does not show:
  *
  *   1.09:1  the original tint (--netscli-surface). Invisible; not a band.
  *  16.43:1  #install inverted to dark navy. Worse where it counts -- the .alt
- *           and .tryblock command blocks are #10151b, so they went from
+ *           and .tryblock command blocks were #10151b, so they went from
  *           16.21:1 on a light band to 1.08:1 on a navy one. The commands a
  *           visitor came to copy vanished into the band while the container
- *           shouted. Contrast had moved from inside the section, where it was
- *           working, to around it, where it is decoration.
- *   1.27:1  a deeper tint, #dae1ee, on BOTH surfaces and install. Coherent
- *           and clearly visible, and rejected on looks: those two sections
- *           are adjacent, so it tinted 59.6% of the page in one continuous
- *           run and read as a second background rather than as punctuation.
+ *           shouted.
+ *   1.27:1  a deeper tint on BOTH surfaces and install. Those two sections
+ *           are adjacent, so it tinted 59.6% of the page in one run and read
+ *           as a second background rather than as punctuation.
  *    1:1    no bands at all. Measurably the best for the content -- command
- *           blocks separate at 17.72:1 on the page against 13.96:1 on the
- *           deeper tint -- and too flat to give the page structure.
+ *           blocks separate at 17.72:1 on the page -- and too flat.
+ *  1.143:1  a quiet tint, alternating so no two banded sections touch. The
+ *           structure was right and the colour was not: a pale blue-grey at
+ *           that strength reads as washed out rather than as a band.
  *
- * So the tint can be quiet, because alternation does the work the tint was
- * being asked to do alone: #e9ecf3 is 1.143:1 against the page, and every
- * banded section has a white one above and below it. Command blocks still
- * clear 15.5:1 on it.
- *
- * This was only possible once .reco got a real border (see Install.astro).
- * Before that, #install had to be tinted -- its cards are near-white and had
- * nothing else to sit on -- which forced surfaces and install to share a
- * treatment and made true alternation impossible.
- *
- * `.surfaces-section` is listed as well as the nth-of-type rule, and has to
- * be: Surfaces.astro paints its own band from --netscli-surface in a
- * component style, so the nth-of-type rule alone does not reach it. An
- * earlier build tinted one and not the other, which is invisible from either
- * file alone.
- *
- * NOTE: dark mode still bands the EVEN section (install) plus surfaces, so
- * the two themes currently mark different sections. Left that way because
- * only the light page was being reworked; making dark alternate is changing
- * `odd` in one more rule. */
-html[data-theme='light'] section:nth-of-type(odd),
+ * So the band went dark and moved down a level, to the thing it is actually
+ * separating: the four surface cards. `.surfaces-section` is still listed
+ * here because Surfaces.astro paints its own background in a component style
+ * and the bare `section` selector does not reach it -- an earlier build
+ * cleared one and not the other, which is invisible from either file alone. */
+html[data-theme='light'] section,
 html[data-theme='light'] .surfaces-section{
-  --netscli-band-tint:#e9ecf3;
-  background:var(--netscli-band-tint);
-}
-
-html[data-theme='light'] section:nth-of-type(even){
   background:var(--netscli-bg);
 }
 
@@ -195,12 +175,12 @@ html[data-theme='light'] footer{
      token alone leaves text that sets no colour of its own dark on navy.
      Measured rgb(68,81,106) until this line. */
   color:var(--netscli-text);
-  --netscli-text:#d7dce5;
-  --netscli-text-strong:#f4f4f4;
-  --netscli-text-muted:#9aa4b8;
-  --netscli-accent:#22c55e;
-  --netscli-accent-rgb:34, 197, 94;
-  --netscli-accent-bright:#86efac;
+  --netscli-text:var(--netscli-ondark-text);
+  --netscli-text-strong:var(--netscli-ondark-text-strong);
+  --netscli-text-muted:var(--netscli-ondark-text-muted);
+  --netscli-accent:var(--netscli-ondark-accent);
+  --netscli-accent-rgb:var(--netscli-ondark-accent-rgb);
+  --netscli-accent-bright:var(--netscli-ondark-accent-bright);
   --netscli-hairline-rgb:255, 255, 255;
   --netscli-lift-rgb:255, 255, 255;
 }

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -120,38 +120,56 @@ section:nth-of-type(even){
     var(--netscli-surface);
   border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
 }
-/* No alternating band on a light page. The sections are the page colour and
- * the structure comes from the content sitting on it.
+/* Alternating bands on the light page, ODD sections tinted.
  *
- * Three treatments were built and measured before this one:
+ * The hero is a div, so the sections count surfaces(1), install(2), faq(3):
+ * odd tints surfaces and faq and leaves install white, and no two banded
+ * sections ever touch. That adjacency is the thing that matters here -- four
+ * treatments were built and measured before this one, and the two that failed
+ * failed for different reasons:
  *
  *   1.09:1  the original tint (--netscli-surface). Invisible; not a band.
  *  16.43:1  #install inverted to dark navy. Worse where it counts -- the .alt
  *           and .tryblock command blocks are #10151b, so they went from
  *           16.21:1 on a light band to 1.08:1 on a navy one. The commands a
  *           visitor came to copy vanished into the band while the container
- *           shouted.
- *   1.27:1  a deeper tint, #dae1ee. Coherent and visible, and rejected on
- *           looks: with #surfaces and #install adjacent it tinted 59.6% of
- *           the page, which reads as a second background rather than as
- *           punctuation.
+ *           shouted. Contrast had moved from inside the section, where it was
+ *           working, to around it, where it is decoration.
+ *   1.27:1  a deeper tint, #dae1ee, on BOTH surfaces and install. Coherent
+ *           and clearly visible, and rejected on looks: those two sections
+ *           are adjacent, so it tinted 59.6% of the page in one continuous
+ *           run and read as a second background rather than as punctuation.
+ *    1:1    no bands at all. Measurably the best for the content -- command
+ *           blocks separate at 17.72:1 on the page against 13.96:1 on the
+ *           deeper tint -- and too flat to give the page structure.
  *
- * White wins on the measurement too, not just on taste: the command blocks
- * separate at 17.72:1 against the page, better than the 13.96:1 they managed
- * on the deeper tint. The one thing it costs is the .reco card, which needs a
- * real border to exist at all -- see Install.astro.
+ * So the tint can be quiet, because alternation does the work the tint was
+ * being asked to do alone: #e9ecf3 is 1.143:1 against the page, and every
+ * banded section has a white one above and below it. Command blocks still
+ * clear 15.5:1 on it.
+ *
+ * This was only possible once .reco got a real border (see Install.astro).
+ * Before that, #install had to be tinted -- its cards are near-white and had
+ * nothing else to sit on -- which forced surfaces and install to share a
+ * treatment and made true alternation impossible.
  *
  * `.surfaces-section` is listed as well as the nth-of-type rule, and has to
- * be: only #install is an even section -- the hero is a div, so the sections
- * count surfaces(1), install(2), faq(3) -- and Surfaces.astro paints its own
- * band from --netscli-surface in a component style. Clearing one and not the
- * other leaves two sections that should match looking nothing alike, and that
- * is invisible from either file alone.
+ * be: Surfaces.astro paints its own band from --netscli-surface in a
+ * component style, so the nth-of-type rule alone does not reach it. An
+ * earlier build tinted one and not the other, which is invisible from either
+ * file alone.
  *
- * Dark mode keeps its bands. 1.12:1 reads fine when the page is already dark,
- * and none of the above applies there. */
-html[data-theme='light'] section:nth-of-type(even),
+ * NOTE: dark mode still bands the EVEN section (install) plus surfaces, so
+ * the two themes currently mark different sections. Left that way because
+ * only the light page was being reworked; making dark alternate is changing
+ * `odd` in one more rule. */
+html[data-theme='light'] section:nth-of-type(odd),
 html[data-theme='light'] .surfaces-section{
+  --netscli-band-tint:#e9ecf3;
+  background:var(--netscli-band-tint);
+}
+
+html[data-theme='light'] section:nth-of-type(even){
   background:var(--netscli-bg);
 }
 

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -75,11 +75,14 @@ body.not-found-page .not-found{
   align-content:center;
 }
 a{color:inherit}
-/* Dark in both themes -- see the code-surface note in tokens.css. */
+/* Inline code follows the theme, like the command chips and unlike the block
+   samples. It was `--netscli-code-bg`, so a near-black chip landed mid-
+   sentence on a white page -- `netscli`, `--json`, `netscli serve` punching
+   holes through the surfaces prose. See the chip note in code-surface.css. */
 code{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.85em;
-  background:var(--netscli-code-bg);padding:2px 6px;border-radius:4px;
-  color:var(--netscli-code-inline-fg);
+  background:var(--netscli-chip-bg);padding:2px 6px;border-radius:4px;
+  color:var(--netscli-chip-code-fg);
 }
 
 /* layout */

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -167,9 +167,63 @@ html[data-theme='light'] section:nth-of-type(even)::before{
    code surfaces in code-surface.css. The rgb CHANNELS invert with it, not just
    the ink: the top border and any hairline here are rgba() call sites, and
    those channels are near-black in the light theme. */
+/* The install section is a band too, continuing the rhythm the surface cards
+ * start: Desktop app (band), Terminal UI, Command line (band), MCP server,
+ * Get started (band), FAQ, footer (band).
+ *
+ * This was built once before as dark navy and reverted, because the .alt and
+ * .cmd command blocks were #10151b and vanished into it at 1.08:1 -- the
+ * commands a visitor came to copy, lost in the container. That objection no
+ * longer holds: chips follow the theme now (see code-surface.css), so on a
+ * light page they are #f2f5fa and sit ON the band at high contrast rather
+ * than inside it. The band became possible because the chips changed, not
+ * because the earlier measurement was wrong.
+ *
+ * Both themes, like the surface cards, so the rhythm is not a light-mode-only
+ * device. */
+#install{
+  background:var(--netscli-band-dark);
+  box-shadow:var(--netscli-band-inset);
+  color:var(--netscli-ondark-text);
+  --netscli-text:var(--netscli-ondark-text);
+  --netscli-text-strong:var(--netscli-ondark-text-strong);
+  --netscli-text-muted:var(--netscli-ondark-text-muted);
+  --netscli-accent:var(--netscli-ondark-accent);
+  --netscli-accent-rgb:var(--netscli-ondark-accent-rgb);
+  --netscli-accent-bright:var(--netscli-ondark-accent-bright);
+  --netscli-hairline-rgb:255, 255, 255;
+  --netscli-lift-rgb:255, 255, 255;
+}
+
+/* The recommended-install card is a LIGHT card on the band in the light
+   theme, so the ink has to come back to the light ramp inside it. Not needed
+   in dark, where .reco is a dark card and the on-dark ramp above is already
+   right -- hence the theme scope. Same trap as .faq-command and the chips. */
+html[data-theme='light'] #install .reco{
+  color:var(--netscli-text);
+  --netscli-text:#44516a;
+  --netscli-text-strong:#111827;
+  --netscli-text-muted:#596478;
+  --netscli-accent:#146b2e;
+  --netscli-accent-rgb:20, 107, 46;
+  --netscli-accent-bright:#0e5122;
+  --netscli-hairline-rgb:17, 24, 39;
+  --netscli-lift-rgb:17, 24, 39;
+}
+
+/* The Try-it panel stays a dark code surface -- it is something you read, not
+   a chip you click -- so on the band it needs the same edge the surface cards
+   give their code samples: #10151b on #1c2634 is 1.20:1, and no fill fixes
+   that. */
+#install .tryblock,
+#install .try{
+  border-color:rgba(255,255,255,.18);
+}
+
 html[data-theme='light'] footer{
   --netscli-band-navy:#141c2e;
   background:var(--netscli-band-navy);
+  box-shadow:var(--netscli-band-inset);
   /* Explicit, not just the token. The element inherits `color` from <body>,
      where the token already resolved to the light ramp, so re-pointing the
      token alone leaves text that sets no colour of its own dark on navy.

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -120,43 +120,47 @@ section:nth-of-type(even){
     var(--netscli-surface);
   border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
 }
-/* A band you can actually see, light theme only.
+/* No alternating band on a light page. The sections are the page colour and
+ * the structure comes from the content sitting on it.
  *
- * The tint above is drawn from --netscli-surface, and on a light page that is
- * barely a band at all: page rgb(251,251,251) against band rgb(238,241,247)
- * measures 1.09:1. The dark theme does not have this problem -- 1.12:1 reads
- * fine when the page is already dark -- so this is scoped to light and dark
- * mode is untouched.
+ * Three treatments were built and measured before this one:
  *
- * A DEEPER TINT, not an inversion. Painting #install dark navy was tried
- * first and measured worse where it counts: the .alt and .tryblock command
- * blocks are #10151b, so on a light band they separate at 16.21:1 and on a
- * navy one at 1.08:1. The commands a visitor came to copy disappeared into
- * the band while the container shouted -- contrast moved from inside the
- * section, where it was working, to around it, where it is decoration. It
- * also broke the alternation: #surfaces and #install share this one rule, and
- * inverting only one of them left two sections that look nothing alike.
+ *   1.09:1  the original tint (--netscli-surface). Invisible; not a band.
+ *  16.43:1  #install inverted to dark navy. Worse where it counts -- the .alt
+ *           and .tryblock command blocks are #10151b, so they went from
+ *           16.21:1 on a light band to 1.08:1 on a navy one. The commands a
+ *           visitor came to copy vanished into the band while the container
+ *           shouted.
+ *   1.27:1  a deeper tint, #dae1ee. Coherent and visible, and rejected on
+ *           looks: with #surfaces and #install adjacent it tinted 59.6% of
+ *           the page, which reads as a second background rather than as
+ *           punctuation.
  *
- * #dae1ee is 1.27:1 against the page -- visible as a band, and the command
- * blocks still clear 13.96:1 on it. It lifts the .reco card off the band as a
- * side effect, from 1.03:1 to 1.20:1, so the recommended install finally
- * reads as a card rather than as more band.
+ * White wins on the measurement too, not just on taste: the command blocks
+ * separate at 17.72:1 against the page, better than the 13.96:1 they managed
+ * on the deeper tint. The one thing it costs is the .reco card, which needs a
+ * real border to exist at all -- see Install.astro.
  *
- * A band-specific token rather than a deeper --netscli-surface: that token is
- * also the hero's chips, the surface cards, the changelog fade and the
- * lightbox, and none of those asked to get darker. */
-/* `.surfaces-section` is listed as well as the nth-of-type rule, and it has to
-   be: only #install is an even section here -- the hero is a div, so the
-   sections count surfaces(1), install(2), faq(3) -- and Surfaces.astro paints
-   its own band from --netscli-surface in a component style. Tinting one and
-   not the other is the mismatch this whole change exists to remove, and it is
-   invisible from either file alone. */
+ * `.surfaces-section` is listed as well as the nth-of-type rule, and has to
+ * be: only #install is an even section -- the hero is a div, so the sections
+ * count surfaces(1), install(2), faq(3) -- and Surfaces.astro paints its own
+ * band from --netscli-surface in a component style. Clearing one and not the
+ * other leaves two sections that should match looking nothing alike, and that
+ * is invisible from either file alone.
+ *
+ * Dark mode keeps its bands. 1.12:1 reads fine when the page is already dark,
+ * and none of the above applies there. */
 html[data-theme='light'] section:nth-of-type(even),
 html[data-theme='light'] .surfaces-section{
-  --netscli-band-tint:#dae1ee;
-  background:
-    linear-gradient(180deg,rgba(var(--netscli-lift-rgb),.018),rgba(var(--netscli-lift-rgb),.006)),
-    var(--netscli-band-tint);
+  background:var(--netscli-bg);
+}
+
+/* The accent wash went with the band it belonged to. It is a radial
+   rgba(accent,.055) in the corner of every even section -- part of the band
+   treatment, and on a white page with no band under it, a green smudge at
+   1.08:1 rather than depth. */
+html[data-theme='light'] section:nth-of-type(even)::before{
+  content:none;
 }
 
 /* The footer is the one dark anchor, and it is dark because it has nothing to

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -120,6 +120,62 @@ section:nth-of-type(even){
     var(--netscli-surface);
   border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
 }
+/* Dark navy bands, light theme only.
+ *
+ * The alternating band above is a tint, and on a light page it is barely a
+ * band at all: measured page rgb(251,251,251) against band rgb(238,241,247)
+ * is 1.09:1, which no one can see. The dark theme does not have this problem
+ * -- 1.12:1 reads fine when the page is already dark -- so this is scoped to
+ * light and dark mode is left exactly as it was.
+ *
+ * Install and the footer, not install and surfaces: two bands running back to
+ * back read as one heavy slab, and the FAQ between these two gives the page a
+ * rhythm instead. It also puts the weight at the bottom, which is where the
+ * install commands are.
+ *
+ * The ramp is re-pointed on the subtree rather than restated per element --
+ * the same technique as the code surfaces in code-surface.css, and for the
+ * same reason: the children already read these tokens, so one rule fixes all
+ * of them and cannot miss one added later. The rgb CHANNELS have to invert
+ * too, not just the ink: hairlines, borders and the accent wash on ::before
+ * are all rgba() call sites, and in the light theme those channels are
+ * near-black. */
+html[data-theme='light'] #install,
+html[data-theme='light'] footer{
+  --netscli-band-navy:#141c2e;
+  background:var(--netscli-band-navy);
+  /* Explicit, not just the token. The section inherits `color` from <body>,
+     where the token already resolved to the light ramp, so re-pointing the
+     token alone leaves any text that does not set its own colour dark on
+     navy. Measured: #install computed rgb(68,81,106) until this line. */
+  color:var(--netscli-text);
+  --netscli-text:#d7dce5;
+  --netscli-text-strong:#f4f4f4;
+  --netscli-text-muted:#9aa4b8;
+  --netscli-accent:#22c55e;
+  --netscli-accent-rgb:34, 197, 94;
+  --netscli-accent-bright:#86efac;
+  --netscli-hairline-rgb:255, 255, 255;
+  --netscli-lift-rgb:255, 255, 255;
+}
+
+/* The recommended-install card stays a LIGHT card on the navy band, so the
+   ramp has to come back to the light values inside it. Without this the card
+   keeps its near-white surface and inherits the band's near-white ink -- the
+   same trap `.faq-command` hit when the code surfaces went dark, and the one
+   `.reco` was pulled out of the code-surface remap for. */
+html[data-theme='light'] #install .reco{
+  color:var(--netscli-text);
+  --netscli-text:#44516a;
+  --netscli-text-strong:#111827;
+  --netscli-text-muted:#596478;
+  --netscli-accent:#146b2e;
+  --netscli-accent-rgb:20, 107, 46;
+  --netscli-accent-bright:#0e5122;
+  --netscli-hairline-rgb:17, 24, 39;
+  --netscli-lift-rgb:17, 24, 39;
+}
+
 section:nth-of-type(even)::before{
   content:"";
   position:absolute;inset:0;

--- a/site/src/styles/starlight/01-tokens-and-header.css
+++ b/site/src/styles/starlight/01-tokens-and-header.css
@@ -174,8 +174,14 @@ html[data-theme='light'][data-docs-scrolled='true'] header.header {
     0 1px 0 rgba(var(--netscli-accent-rgb), 0.12) !important;
 }
 
+/* One layer on a light page, not two. Same change as the landing bar's
+   `::after` -- see the note in components/Nav.astro. The bar already casts a
+   30px blurred box-shadow above; this 28px hard gradient stacked on top of it
+   and took the page from rgb(251,251,251) to rgb(200,202,205) in a band
+   directly under the bar. The gradient earns its place in the dark theme at
+   rgba(0,0,0,.34); on white the blur alone is the whole effect. */
 html[data-theme='light'][data-docs-scrolled='true'] header.header::after {
-  background: linear-gradient(180deg, rgba(var(--netscli-hairline-rgb), 0.12), rgba(var(--netscli-hairline-rgb), 0));
+  opacity: 0;
 }
 
 header.header > .header {

--- a/site/src/styles/theme-control.css
+++ b/site/src/styles/theme-control.css
@@ -200,3 +200,28 @@ html[data-theme='light'] .netscli-theme-select label:hover,
 html[data-theme='light'] .netscli-theme-select label:focus-within {
   border-color: rgba(var(--netscli-accent-rgb), 0.34);
 }
+
+/* The landing bar's theme icon, one of three.
+ *
+ * The docs bar gets this from Starlight's ThemeProvider, which clones the
+ * matching glyph out of a `<template id="theme-icons">` and only looks for
+ * `starlight-theme-select`. Neither the template nor that element exists on
+ * the landing page, so its control sat on the laptop glyph no matter what was
+ * selected.
+ *
+ * Driven by data-theme-choice on <html>, which the pre-paint script in
+ * Page.astro sets before anything renders -- so the correct icon is right on
+ * first paint rather than swapped in afterwards. The :not() fallback covers
+ * the case where that script did not run at all (storage blocked and it threw
+ * before the assignment): auto is the honest default there, because auto is
+ * what an unset preference means. */
+.netscli-theme-select .label-icon {
+  display: none;
+}
+
+html:not([data-theme-choice]) .netscli-theme-select .label-icon[data-icon='auto'],
+html[data-theme-choice='auto'] .netscli-theme-select .label-icon[data-icon='auto'],
+html[data-theme-choice='light'] .netscli-theme-select .label-icon[data-icon='light'],
+html[data-theme-choice='dark'] .netscli-theme-select .label-icon[data-icon='dark'] {
+  display: block;
+}


### PR DESCRIPTION
A light-theme and landing-page pass. It began as "soften the nav shadow, add a navy band" and grew as each change was looked at and rejected; the commits are kept individually because several of them record a treatment that was built, measured and thrown away, and those are the expensive things to rediscover.

## The band, six times

The page structure was the hard part. Every version below was actually built and measured:

| treatment | measured | why it went |
|---|---|---|
| original tint | **1.09:1** vs page | invisible; not a band |
| `#install` inverted to navy | 16.43:1 | the `#10151b` command blocks went from **16.21:1** on a light band to **1.08:1** on a navy one — the commands a visitor came to copy vanished into their own container |
| deeper tint on surfaces + install | 1.27:1 | those two sections are adjacent, so it tinted **59.6% of the page** in one run and read as a second background |
| no bands at all | 1:1 | measurably best for the content — command blocks at **17.72:1** — and too flat |
| quiet tint, alternating | 1.143:1 | structure right, colour wrong: a pale blue-grey at that strength reads as washed out |
| dark bands on alternating cards | 14.75:1 | correct per band, wrong as a page: **seven inversions** between hero and footer. Gradient joins were tried to soften it and were worse — fading `#1c2634` into `#fbfbfb` runs through a muddy mid-grey, and spreading a 14.75:1 step does not shrink it |

**Landed: two dark moments** — the install section and the footer. Three edges instead of seven, each carrying a small inset *and* outward shadow so the join reads as a seam.

The navy install band only became viable because of the chip change below. The earlier measurement that killed it was right; the thing it measured changed.

## Chips, samples and inline code

One rule became three, because they were three different objects wearing the same clothes:

- **Chips** — a single command with a copy button (hero, install rows) — follow the theme. Light: `#f2f5fa`, text at 7.3:1, same 1.52:1 edge as the cards.
- **Inline `code`** — a word in a sentence — follows the theme too. It was a near-black chip punching holes through light prose.
- **Block samples** — things you read — stay dark in both themes, unchanged.

Dark mode is byte-identical for all three; the chip tokens default to the code surface.

## Everything else

- **Nav shadow** was two stacking layers, not one. #328 softened the blur and left the heavier `::after` gradient, which took the page to `rgb(200,202,205)` — a **1.59:1 step** under the bar. The docs header had the identical defect and got the same fix.
- **Wordmark** darkened on light pages: its cyan half measured **1.79:1** on white. WCAG exempts logotypes, so no gate caught it.
- **Surface cards centred** — every text block is 118px against 218–296px visuals, so `align-items: start` left 100–178px of dead column each, ~560px in a 1608px section.
- **Shadows on a scale** — four hand-written blacks (`.32`–`.6`) replaced by `--netscli-lift-sm/md/lg`, light values on the hairline channel.
- **FAQ grouped** — 40px between groups against 8px within, strong-ink titles with a hairline. It was 13 identical pills over a quarter of the page.
- **Hero**: download cue moved inside the button, one 44px control height across the CTA, social proof lifted from 12px/5.77:1 to 13px/7.71:1.
- **Nav group separator** shortened from a 59px floor-to-ceiling border to an 18px centred rule.
- **Recommended card** lifted off the band; it and the chip inside it had been identical fills with identical borders.
- **Theme icon swap** landed — it was written but sitting uncommitted, so the control was stuck on the laptop glyph.

## Bugs found by measuring rather than looking

- A **5px horizontal scrollbar** at every width, from `100vw` counting the scrollbar while the layout box doesn't. My first check missed it by comparing `scrollWidth > innerWidth` instead of `clientWidth`.
- The contrast sweep caught a **2.42:1** failure when a band was a pseudo-element only — it composites real ancestor backgrounds and can't see a `::before`, which is correct: if the pseudo stops painting, that's what a reader gets.
- Making inline code theme-following exposed `.faq .answer code` still pinned to the dark-theme green — **1.28:1** on the new light chip.
- Fixing the dark card exposed that `#install .reco` (id) outranked the light-theme rule, painting the light card dark at **1.65:1**.

## Checks

Contrast sweep clean across 14 routes in both themes, axe clean in both themes, 196 token pairs ≥ 4.5:1, dead CSS 14/14, `astro check` clean, no horizontal overflow at 1280/1440/1600.
