### PR TITLE
ci: skip the site preview for Dependabot PRs

### DIFF
--- a/.github/workflows/site-preview.yml
+++ b/.github/workflows/site-preview.yml
@@ -58,9 +58,15 @@ jobs:
     # A push to main is always same-repo, and `github.event.pull_request` is
     # null there -- so without the first clause this guard is false and the
     # main preview never runs.
+    #
+    # Dependabot PRs are same-repo but run with Dependabot's own secret
+    # store, not the repository's, so CLOUDFLARE_API_TOKEN is empty there
+    # too and "Check configuration" failed on all eleven of them (#311-#319,
+    # #334, #335). A dependency bump does not need a preview.
     if: >-
-      github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name == 'push' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
Dependabot runs use Dependabot's own secret store, not the repository's, so `CLOUDFLARE_API_TOKEN` is empty and the **Check configuration** step failed on all eleven Dependabot PRs merged today (#311–#319, #334, #335). It was not a required check, so they merged, but every future bump would show a red X.

A dependency bump does not need a preview deploy. The job is now skipped for `dependabot[bot]` the same way it is for fork PRs.