### PR TITLE
site: commit the cascade equivalence checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ NEXT_GEN_NETWORKING_PLAN.md
 site/.visual-baseline/
 site/.visual-current/
 site/.visual-diff/
+# Captured runtime DOM for scripts/css-equivalence.mjs (capture-search).
+site/.css-equivalence/

--- a/site/package.json
+++ b/site/package.json
@@ -14,6 +14,7 @@
     "check:changelog": "node ./scripts/changelog-dates.mjs",
     "check:css": "node ./scripts/css-shadowing.mjs --max 0",
     "check:regions": "node ./scripts/css-regions.mjs",
+    "css:equivalence": "node ./scripts/css-equivalence.mjs",
     "check:wordmark": "node ./scripts/wordmark-inset.mjs",
     "test:a11y": "npm run build && node ./scripts/a11y.mjs",
     "check:contrast": "node ./scripts/contrast-sweep.mjs",

--- a/site/scripts/css-equivalence.mjs
+++ b/site/scripts/css-equivalence.mjs
@@ -1,0 +1,206 @@
+/**
+ * Does a CSS change render the same? A static cascade comparison.
+ *
+ * For every element in the built pages, every longhand property, every
+ * capture width and every state, this works out which declaration wins
+ * under the stylesheets at a git ref and under the working tree, and lists
+ * the cells where the two disagree. It is what the screenshot check
+ * (visual-snapshot.mjs) cannot see: hover and focus states, the light
+ * theme's rules on something only the dark capture shows, a rule that only
+ * applies at 815px.
+ *
+ *   node scripts/css-equivalence.mjs [--old <ref>] [--stack docs|landing]
+ *   node scripts/css-equivalence.mjs capture-search
+ *
+ * --old defaults to origin/main. --stack picks which stylesheet list to
+ * compare: `docs` is astro.config.mjs's customCss (checked against the
+ * Starlight pages), `landing` is what layouts/Page.astro imports (checked
+ * against the rest). Both need a current `dist/`; run `npm run build`.
+ *
+ * `capture-search` opens the docs search dialog in Chrome with a query and
+ * saves the resulting DOM under .css-equivalence/, because Pagefind
+ * renders the whole panel at runtime and the static pages never contain
+ * it. Run it once after a build; the comparison picks the file up.
+ *
+ * What it does not model, each of which has produced a false "identical":
+ *   - inline `style` attributes (Expressive Code's token colours; only
+ *     !important beats them) -- the screenshots caught this;
+ *   - component-scoped <style> blocks in .astro files, which the build
+ *     rewrites with a per-component attribute -- covered by screenshots;
+ *   - runtime state not in STATE_DIMS (lib/css-cascade.mjs) -- add the
+ *     state there when a captured DOM carries it, or the check will assume
+ *     it is always on.
+ * It is a second check, not the only one.
+ */
+
+import { readFileSync, readdirSync, statSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import process from 'node:process';
+import postcss from 'postcss';
+import { parseHTML } from 'linkedom';
+import { specificity, expandAlternatives, mediaMatches, contexts, applies, contextKey, structural, pseudoElement, longhands, recoverBraces, winner } from './lib/css-cascade.mjs';
+
+const root = process.cwd();
+const args = process.argv.slice(2);
+const opt = (name, dflt) => { const i = args.indexOf(name); return i === -1 ? dflt : args[i + 1]; };
+const OLD_REF = opt('--old', 'origin/main');
+const STACK = opt('--stack', 'docs');
+const WIDTHS = [1800, 1600, 1250, 1100, 900, 815, 760, 640];
+const CAPTURE_DIR = join(root, '.css-equivalence');
+
+if (args[0] === 'capture-search') { await captureSearch(); process.exit(0); }
+
+/* ---- Stylesheet lists --------------------------------------------------- */
+function sheetsFromConfig(source) {
+  return [...source.matchAll(/'\.\/src\/styles\/([^']+)'/g)].map((m) => `src/styles/${m[1]}`);
+}
+function sheetsFromLayout(source) {
+  return [...source.matchAll(/import '\.\.\/styles\/([^']+)'/g)].map((m) => `src/styles/${m[1]}`);
+}
+const listFile = STACK === 'landing' ? 'src/layouts/Page.astro' : 'astro.config.mjs';
+const pick = STACK === 'landing' ? sheetsFromLayout : sheetsFromConfig;
+const oldFiles = pick(execSync(`git show ${OLD_REF}:site/${listFile}`, { encoding: 'utf8' }));
+const newFiles = pick(readFileSync(join(root, listFile), 'utf8'));
+const oldStack = oldFiles.map((f) => execSync(`git show ${OLD_REF}:site/${f}`, { encoding: 'utf8', maxBuffer: 1 << 24 }));
+const newStack = newFiles.map((f) => readFileSync(join(root, f), 'utf8'));
+
+/* ---- Pages ---------------------------------------------------------------- */
+const pages = [];
+const walkHtml = (d) => { if (!existsSync(d)) return; for (const n of readdirSync(d)) { const f = join(d, n); if (statSync(f).isDirectory()) walkHtml(f); else if (n.endsWith('.html')) pages.push(f); } };
+walkHtml(join(root, 'dist'));
+walkHtml(CAPTURE_DIR);
+if (!pages.length) { console.error('No dist/ found. Run `npm run build` first.'); process.exit(1); }
+// Starlight pages carry its header's search element; Page.astro pages (index, 404, changelog) do not.
+const isDocs = (html) => html.includes('<site-search');
+const docs = pages
+  .map((f) => ({ f, html: readFileSync(f, 'utf8') }))
+  .filter(({ html }) => (STACK === 'landing' ? !isDocs(html) : isDocs(html)))
+  .map(({ f, html }) => ({ f, document: parseHTML(html).document }));
+
+// Replay what src/scripts/docs-tables.ts does at runtime, so the wrapper
+// and the marker classes exist for matching.
+for (const { document } of docs) {
+  const content = document.querySelector('.sl-markdown-content');
+  if (!content) continue;
+  const opts = { 'netscli-table: row-headers': 'table-row-headers', 'netscli-table: plain-first-column': 'table-plain-first-column' };
+  const walk = (node) => {
+    for (const n of node.childNodes) {
+      if (n.nodeType === 8) {
+        const cls = opts[(n.nodeValue || '').trim().toLowerCase()];
+        if (cls) { let sib = n.nextSibling; while (sib) { if (sib.nodeType === 1) { if (sib.tagName === 'TABLE') sib.classList.add(cls); break; } sib = sib.nextSibling; } }
+      } else if (n.nodeType === 1) walk(n);
+    }
+  };
+  walk(content);
+  for (const table of content.querySelectorAll('table')) {
+    if (table.parentElement && table.parentElement.classList.contains('netscli-table-scroll')) continue;
+    const w = document.createElement('div'); w.className = 'netscli-table-scroll'; table.before(w); w.append(table);
+  }
+}
+
+let elSeq = 0;
+const elemCache = new Map();
+function elems(sel) {
+  const q0 = structural(sel);
+  if (elemCache.has(q0)) return elemCache.get(q0);
+  const set = new Set();
+  for (const q of expandAlternatives(q0)) for (const { document } of docs) {
+    let list = [];
+    try { list = document.querySelectorAll(q || 'html'); } catch { elemCache.set(q0, null); return null; }
+    for (const el of list) { if (!el.__id) el.__id = `e${elSeq++}`; set.add(el.__id); }
+  }
+  elemCache.set(q0, set);
+  return set;
+}
+const subject = (sel) => sel.trim().split(/[\s>+~]+/).pop().replace(/\[[^\]]*\]/g, '').replace(/::?[a-z-]+(\([^)]*\))?/g, '');
+// Selectors for DOM that only exists at runtime fall back to a name bucket.
+const RUNTIME = /pagefind|dialog|site-search|feedback|aria-hidden|isMobile|sl-sidebar-state|search-offline|data-search-modal|::backdrop|data-copied|\.show|netscli-table-scroll/;
+
+/* ---- Index a stack ------------------------------------------------------- */
+function index(sources) {
+  const byKey = new Map();
+  let order = 0;
+  const ast = postcss.parse(recoverBraces(sources.join('\n')));
+  ast.walkRules((rule) => {
+    const chain = [];
+    let p = rule.parent;
+    while (p && p.type === 'atrule') { chain.unshift(`@${p.name} ${p.params.replace(/\s+/g, ' ')}`); p = p.parent; }
+    const media = chain.join(' { ');
+    const sels = rule.selectors.map((s) => s.replace(/\s+/g, ' ').replace(/^html (?=[^\[])/, ''));
+    rule.walkDecls((d) => {
+      order++;
+      for (const sel of sels) {
+        const els = elems(sel);
+        if (els && els.size === 0 && !RUNTIME.test(sel)) continue;
+        const ids = els && els.size ? [...els] : ['~' + subject(sel)];
+        const pe = pseudoElement(sel);
+        const base = { media, sel, prop: d.prop, value: d.value.replace(/\s+/g, ' ').trim(), important: !!d.important, order, s: specificity(sel) };
+        for (const [key, val] of longhands(d.prop, base.value)) {
+          for (const id of ids) { const k = `${id}${pe}|${key}`; (byKey.get(k) || byKey.set(k, []).get(k)).push({ ...base, val }); }
+        }
+      }
+    });
+  });
+  return byKey;
+}
+
+/* ---- Compare -------------------------------------------------------------- */
+const I1 = index(oldStack), I2 = index(newStack);
+console.log(`${STACK}: ${oldFiles.length} sheets at ${OLD_REF} vs ${newFiles.length} in the working tree, over ${docs.length} page(s)`);
+const norm = (v) => v.replace(/\s+/g, ' ').replace(/(^|[^\d.])0\.(\d)/g, '$1.$2').replace(/, /g, ',').replace(/"/g, "'").trim();
+const diffs = new Map();
+let cells = 0;
+for (const k of new Set([...I1.keys(), ...I2.keys()])) {
+  const l1 = I1.get(k) || [], l2 = I2.get(k) || [];
+  const ctxs = contexts([...l1, ...l2].map((x) => x.sel));
+  for (const w of WIDTHS) {
+    const m1 = l1.filter((x) => mediaMatches(x.media, w)), m2 = l2.filter((x) => mediaMatches(x.media, w));
+    if (!m1.length && !m2.length) continue;
+    for (const ctx of ctxs) {
+      const a = winner(m1.filter((x) => applies(x.sel, ctx))), b = winner(m2.filter((x) => applies(x.sel, ctx)));
+      const va = a ? norm(a.val) : '(none)', vb = b ? norm(b.val) : '(none)';
+      if (va === vb) continue;
+      cells++;
+      const id = `${k.split('|')[1]}|${a ? a.sel : ''}|${va}|${b ? b.sel : ''}|${vb}`;
+      if (!diffs.has(id)) diffs.set(id, { key: k.split('|')[1], w, ctx: contextKey(ctx), a, b, n: 0 });
+      diffs.get(id).n++;
+    }
+  }
+}
+const fmt = (x) => (x ? `${x.sel} {${x.prop}: ${x.value}${x.important ? ' !important' : ''}} @${x.media || 'all'}` : '(nothing)');
+for (const { key, w, ctx, a, b, n } of diffs.values()) console.log(`${key} @${w}px [${ctx}] x${n}\n  OLD: ${fmt(a)}\n  NEW: ${fmt(b)}`);
+if (diffs.size) { console.log(`\n${diffs.size} distinct difference(s), ${cells} cells. Each is a place the new stylesheets render differently -- or a state this model cannot see; say which.`); process.exit(1); }
+console.log('Identical: the same declaration wins everywhere the model can see.');
+
+/* ---- capture-search ------------------------------------------------------- */
+async function captureSearch() {
+  const { Builder } = await import('selenium-webdriver');
+  const chrome = await import('selenium-webdriver/chrome.js');
+  const { startPreview, resolveChromedriverPath } = await import('./lib/preview-server.mjs');
+  const port = 4329, host = '127.0.0.1', baseUrl = `http://${host}:${port}`;
+  const { cleanup } = await startPreview({ baseUrl, host, port, astroCli: join(root, 'node_modules/astro/bin/astro.mjs'), allowReuse: false, reuseHint: 'CSS_EQUIVALENCE_REUSE' });
+  try {
+    const options = new chrome.Options();
+    options.addArguments('--headless=new', '--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE 127.0.0.1', '--disable-gpu');
+    const driverPath = resolveChromedriverPath(process.env.VISUAL_CHROMEDRIVER_PATH);
+    const builder = new Builder().forBrowser('chrome').setChromeOptions(options);
+    if (driverPath) builder.setChromeService(new chrome.ServiceBuilder(driverPath));
+    const driver = await builder.build();
+    try {
+      await driver.manage().window().setRect({ width: 1600, height: 900 });
+      await driver.get(`${baseUrl}/docs/`);
+      await driver.executeScript(`document.querySelector('site-search button[data-open-modal]')?.click();`);
+      const deadline = Date.now() + 10000;
+      const until = async (js) => { let r; while (Date.now() < deadline && !(r = await driver.executeScript(js))) await new Promise((res) => setTimeout(res, 100)); return r; };
+      if (!(await until(`return !!document.querySelector('site-search dialog[open] .pagefind-ui__search-input')`))) throw new Error('search dialog did not open');
+      await driver.executeScript(`const i = document.querySelector('site-search dialog[open] .pagefind-ui__search-input'); i.focus(); i.value = 'scan'; i.dispatchEvent(new Event('input', { bubbles: true }));`);
+      const n = await until(`return document.querySelectorAll('site-search dialog[open] .pagefind-ui__result').length`);
+      if (!n) throw new Error('search returned no results');
+      const html = await driver.executeScript('return document.documentElement.outerHTML');
+      mkdirSync(join(CAPTURE_DIR, 'docs-search'), { recursive: true });
+      writeFileSync(join(CAPTURE_DIR, 'docs-search', 'index.html'), html);
+      console.log(`Saved the open search dialog (${n} results) to .css-equivalence/docs-search/index.html`);
+    } finally { await driver.quit(); }
+  } finally { await cleanup(); }
+}

--- a/site/scripts/lib/css-cascade.mjs
+++ b/site/scripts/lib/css-cascade.mjs
@@ -1,0 +1,193 @@
+/* The pieces of the CSS cascade that css-equivalence.mjs needs to decide,
+ * for one element and one property, which declaration wins.
+ *
+ * This is a model, not a browser. What it covers: specificity (including
+ * :is/:not/:has/:where), !important, source order, width media queries,
+ * shorthands against their longhands, and the states a selector can
+ * depend on (theme, hover, focus, aria-current, open, and a few of this
+ * site's runtime classes). What it does not: inline `style` attributes,
+ * cascade layers, inheritance, or any state not listed in STATE_DIMS. Each
+ * of those has produced a false "identical" once; see the notes in
+ * css-equivalence.mjs.
+ */
+
+/** Specificity packed as a*10000 + b*100 + c. */
+export function specificity(sel) {
+  let a = 0, b = 0, c = 0, rest = sel;
+  const fn = /:(is|not|has|where)\(/g;
+  let m;
+  while ((m = fn.exec(rest))) {
+    let depth = 1, i = m.index + m[0].length;
+    const start = i;
+    while (i < rest.length && depth) { if (rest[i] === '(') depth++; else if (rest[i] === ')') depth--; i++; }
+    const inner = rest.slice(start, i - 1);
+    if (m[1] !== 'where') {
+      const best = Math.max(...splitTop(inner).map(specificity));
+      a += Math.floor(best / 10000); b += Math.floor(best / 100) % 100; c += best % 100;
+    }
+    rest = rest.slice(0, m.index) + ' ' + rest.slice(i);
+    fn.lastIndex = m.index;
+  }
+  rest = rest.replace(/::?[a-z-]+(\([^)]*\))?/g, (x) => { if (/^::|^:(before|after)/.test(x)) c++; else b++; return ' '; });
+  a += (rest.match(/#[\w-]+/g) || []).length;
+  b += (rest.match(/\.[\w-]+|\[[^\]]*\]/g) || []).length;
+  c += (rest.replace(/#[\w-]+|\.[\w-]+|\[[^\]]*\]/g, ' ').match(/(^|[\s>+~])[a-z][\w-]*/gi) || []).length;
+  return a * 10000 + b * 100 + c;
+}
+
+/** Split on top-level commas only. */
+export function splitTop(s) {
+  const out = []; let d = 0, cur = '';
+  for (const ch of s) { if (ch === '(') d++; if (ch === ')') d--; if (ch === ',' && !d) { out.push(cur); cur = ''; } else cur += ch; }
+  out.push(cur);
+  return out.map((x) => x.trim()).filter(Boolean);
+}
+
+/** Expand :is(a, b) / :where(a, b) into plain alternatives. */
+export function expandAlternatives(q) {
+  const m = /:(is|where)\(/.exec(q);
+  if (!m) return [q];
+  let depth = 1, i = m.index + m[0].length;
+  const start = i;
+  while (i < q.length && depth) { if (q[i] === '(') depth++; else if (q[i] === ')') depth--; i++; }
+  const inner = q.slice(start, i - 1), before = q.slice(0, m.index), after = q.slice(i);
+  return splitTop(inner).flatMap((p) => expandAlternatives(before + p + after));
+}
+
+/** Does a chain of @media params apply at a viewport `w` px wide? */
+export function mediaMatches(media, w) {
+  if (!media) return true;
+  for (const q of media.split(' { ')) {
+    if (/prefers-reduced-motion/.test(q)) return false;
+    for (const m of q.matchAll(/\((min|max)-width:\s*([\d.]+)(px|rem|em)\)/g)) {
+      const v = parseFloat(m[2]) * (m[3] === 'px' ? 1 : 16);
+      if (m[1] === 'min' && w < v) return false;
+      if (m[1] === 'max' && w > v) return false;
+    }
+  }
+  return true;
+}
+
+/* ---- States ------------------------------------------------------------
+ * A selector "applies" in a context only if every state it names is on.
+ * Each dimension: the regex that means a selector depends on it, and the
+ * test for whether it applies in a given context value. */
+export const STATE_DIMS = [
+  { key: 'theme', values: ['light', 'dark'], mentions: /data-theme=/, applies: (sel, v) => !(/data-theme='light'/.test(sel) && v !== 'light') && !(/data-theme='dark'/.test(sel) && v !== 'dark') },
+  { key: 'scrolled', values: [false, true], mentions: /data-docs-scrolled/, applies: (sel, v) => !(/\[data-docs-scrolled='true'\]/.test(sel) && !/:not\(\[data-docs-scrolled/.test(sel) && !v) && !(/:not\(\[data-docs-scrolled='true'\]\)/.test(sel) && v) },
+  { key: 'state', values: ['none', 'hover', 'focus-visible'], mentions: /:hover|:focus/, applies: (sel, v) => !(/:hover/.test(sel) && v !== 'hover') && !(/:focus-visible|:focus-within|:focus(?!-)/.test(sel) && v !== 'focus-visible') },
+  { key: 'current', values: [false, true], mentions: /aria-current/, applies: (sel, v) => !(/\[aria-current/.test(sel) && !v) },
+  { key: 'expanded', values: [false, true], mentions: /aria-expanded|\[open\]/, applies: (sel, v) => !(/\[aria-expanded='true'\]|\[open\]/.test(sel) && !v) },
+  { key: 'copied', values: [false, true], mentions: /data-copied|feedback\.show/, applies: (sel, v) => !(/\[data-copied\]|feedback\.show/.test(sel) && !v) },
+  { key: 'overflow', values: [false, true], mentions: /netscli-search-overflow/, applies: (sel, v) => !(/netscli-search-overflow/.test(sel) && !v) },
+];
+
+/** Every combination of the dimensions some selector in `sels` depends on. */
+export function contexts(sels) {
+  const joined = sels.join('\n');
+  let out = [{}];
+  for (const dim of STATE_DIMS) {
+    const values = dim.mentions.test(joined) ? dim.values : [dim.values[0]];
+    out = out.flatMap((ctx) => values.map((v) => ({ ...ctx, [dim.key]: v })));
+  }
+  return out;
+}
+
+export const applies = (sel, ctx) => expandAlternatives(sel).some((v) => STATE_DIMS.every((d) => d.applies(v, ctx[d.key])));
+export const contextKey = (ctx) => STATE_DIMS.map((d) => `${ctx[d.key]}`).join('|');
+
+/** The selector with state and scope stripped, for matching it statically. */
+export function structural(sel) {
+  return sel
+    .replace(/^html(\[[^\]]*\]|:[a-z-]+(\([^)]*\))?)*\s+/, '')
+    .replace(/:(hover|focus-visible|focus-within|focus|active|visited|target)(?![a-z-])/g, '')
+    .replace(/::?(before|after|placeholder|backdrop|marker|selection|-webkit-[a-z-]+)(?![a-z-])/g, '')
+    .replace(/\[aria-current(=[^\]]*)?\]|\[aria-expanded=[^\]]*\]|\[open\]|\[data-search-modal-open\]|\[data-copied\]/g, '')
+    .replace(/:has\(\.feedback\.show\)/g, '')
+    .replace(/\.netscli-search-overflow-(top|bottom)/g, '')
+    .replace(/^html(\[[^\]]*\])*$/, 'html')
+    .trim();
+}
+
+export const pseudoElement = (sel) => (sel.match(/::[a-z-]+|:(before|after|placeholder|backdrop|marker)(?![a-z-])/g) || []).join('');
+
+/* ---- Longhands ---------------------------------------------------------
+ * Shorthands collide with their longhands in the cascade, so every
+ * declaration is compared on physical (LTR) longhand keys. */
+const SIDES = ['top', 'right', 'bottom', 'left'];
+const split = (v) => v.trim().split(/\s+(?![^(]*\))/);
+const box = (v) => { const [t, r = t, b = t, l = r] = split(v); return [t, r, b, l]; };
+const two = (v) => { const p = split(v); return [p[0], p[1] === undefined ? p[0] : p[1]]; };
+function borderParts(v) {
+  let w = 'medium', st = 'none', c = 'currentcolor';
+  const toks = split(v);
+  for (const t of toks) {
+    if (/^(\d|\.\d|-\d|thin$|medium$|thick$)/.test(t)) w = t;
+    else if (/^(none|solid|dashed|dotted|double|hidden|groove|ridge|inset|outset)$/.test(t)) st = t;
+    else c = t;
+  }
+  if (toks.length === 1 && toks[0] === '0') { w = '0'; st = 'none'; }
+  return { w, st, c };
+}
+const bside = (x, v) => { const { w, st, c } = borderParts(v); return [[`border-${x}-width`, w], [`border-${x}-style`, st], [`border-${x}-color`, c]]; };
+
+export function longhands(prop, value) {
+  switch (prop) {
+    case 'padding': case 'margin': { const v = box(value); return SIDES.map((s, i) => [`${prop}-${s}`, v[i]]); }
+    case 'inset': { const v = box(value); return SIDES.map((s, i) => [s, v[i]]); }
+    case 'padding-inline': case 'margin-inline': { const [a, b] = two(value); const n = prop.replace('-inline', ''); return [[`${n}-left`, a], [`${n}-right`, b]]; }
+    case 'inset-inline': { const [a, b] = two(value); return [['left', a], ['right', b]]; }
+    case 'padding-block': case 'margin-block': { const [a, b] = two(value); const n = prop.replace('-block', ''); return [[`${n}-top`, a], [`${n}-bottom`, b]]; }
+    case 'inset-block': { const [a, b] = two(value); return [['top', a], ['bottom', b]]; }
+    case 'padding-inline-start': case 'margin-inline-start': return [[prop.replace('-inline-start', '-left'), value]];
+    case 'padding-inline-end': case 'margin-inline-end': return [[prop.replace('-inline-end', '-right'), value]];
+    case 'padding-block-start': case 'margin-block-start': return [[prop.replace('-block-start', '-top'), value]];
+    case 'padding-block-end': case 'margin-block-end': return [[prop.replace('-block-end', '-bottom'), value]];
+    case 'inset-inline-start': return [['left', value]];
+    case 'inset-inline-end': return [['right', value]];
+    case 'inset-block-start': return [['top', value]];
+    case 'inset-block-end': return [['bottom', value]];
+    case 'border': return SIDES.flatMap((s) => bside(s, value));
+    case 'border-inline': return ['left', 'right'].flatMap((s) => bside(s, value));
+    case 'border-block': return ['top', 'bottom'].flatMap((s) => bside(s, value));
+    case 'border-inline-start': return bside('left', value);
+    case 'border-inline-end': return bside('right', value);
+    case 'border-inline-start-color': return [['border-left-color', value]];
+    case 'border-inline-end-color': return [['border-right-color', value]];
+    case 'border-inline-start-width': return [['border-left-width', value]];
+    case 'border-color': return SIDES.map((s) => [`border-${s}-color`, value]);
+    case 'border-width': return SIDES.map((s) => [`border-${s}-width`, value]);
+    case 'border-radius': return ['top-left', 'top-right', 'bottom-right', 'bottom-left'].map((c) => [`border-${c}-radius`, value]);
+    case 'background': return [['background-color', value], ['background-image', value]];
+    case 'overflow': return [['overflow-x', value], ['overflow-y', value]];
+    case 'gap': return [['row-gap', value], ['column-gap', value]];
+    case 'flex': return [['flex-grow', value], ['flex-shrink', value], ['flex-basis', value]];
+    case 'outline': { const { w, st, c } = borderParts(value); return [['outline-width', w], ['outline-style', st], ['outline-color', c]]; }
+    default:
+      for (const s of SIDES) if (prop === `border-${s}`) return bside(s, value);
+      return [[prop, value]];
+  }
+}
+
+/** Browser-style recovery for a concatenated stack: drop stray `}`, close what is open. */
+export function recoverBraces(css) {
+  let depth = 0, out = '', inComment = false;
+  for (let i = 0; i < css.length; i++) {
+    const ch = css[i];
+    if (inComment) { out += ch; if (ch === '/' && css[i - 1] === '*') inComment = false; continue; }
+    if (ch === '/' && css[i + 1] === '*') { inComment = true; out += ch; continue; }
+    if (ch === '{') depth++;
+    if (ch === '}') { if (depth === 0) continue; depth--; }
+    out += ch;
+  }
+  return out + '}'.repeat(depth);
+}
+
+/** Pick the winning declaration: !important, then specificity, then order. */
+export function winner(list) {
+  let best = null;
+  for (const x of list) {
+    if (!best || x.important - best.important > 0 || (x.important === best.important && (x.s - best.s > 0 || (x.s === best.s && x.order > best.order)))) best = x;
+  }
+  return best;
+}

--- a/site/src/styles/docs/README.md
+++ b/site/src/styles/docs/README.md
@@ -46,7 +46,12 @@ are in `../code-surface.css` for the same reason.
    `.visual-baseline/`. Record a baseline from `main` first if you do not
    have one. A change you intended shows up as a diff pair in
    `.visual-diff/`; re-run `record` to accept it.
-3. `npm run check:css`, `npm run check:regions`, `npm run check:contrast`
+3. `node scripts/css-equivalence.mjs --old origin/main` compares, for every
+   element, property, width and state, which declaration wins under
+   `main`'s stylesheets and under yours. It sees hover, focus and the light
+   theme where a screenshot cannot; run `capture-search` once first so the
+   search dialog's DOM exists. Its header lists what it cannot model.
+4. `npm run check:css`, `npm run check:regions`, `npm run check:contrast`
    and `npm run test:a11y` are what CI runs.
 
 Hover, focus and the search dialog's empty and no-results states are not in


### PR DESCRIPTION
The static check that ran alongside the screenshots for the four region migrations, cleaned up and committed: `scripts/css-equivalence.mjs` plus `scripts/lib/css-cascade.mjs`. For every element × longhand × width × state it says which declaration wins at a git ref and in the working tree, and lists the disagreements. `capture-search` records the open search dialog's DOM so Pagefind's runtime markup can be matched.

Its header lists what it cannot model (inline styles, component-scoped styles, states not in `STATE_DIMS`); each produced a false "identical" once. Sanity-checked: identical against HEAD~1 for both stacks, and a deliberate colour change is reported.

Not a CI check (needs a git ref and a built `dist/`); documented in `src/styles/docs/README.md` as the step before the screenshot check.