### PR TITLE
site: drop the await on the synchronous preview cleanup

### DIFF
--- a/site/scripts/css-equivalence.mjs
+++ b/site/scripts/css-equivalence.mjs
@@ -215,5 +215,5 @@ async function captureSearch() {
       writeFileSync(join(CAPTURE_DIR, 'docs-search', 'index.html'), html);
       console.log(`Saved the open search dialog (${n} results) to .css-equivalence/docs-search/index.html`);
     } finally { await driver.quit(); }
-  } finally { await cleanup(); }
+  } finally { cleanup(); }
 }


### PR DESCRIPTION
One-line follow-up to the equivalence checker: the preview server's cleanup is synchronous, and astro check flagged the await. Already applied in the template copy.