### PR TITLE
site: move the hero installers and the docs sidebar into site-content

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,5 +1,11 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import {
+  docsDescription,
+  docsLogo,
+  docsSidebar,
+  docsTitle,
+} from './src/data/site-content/docs';
 
 // Canonical site URL. Used by Astro for absolute URL generation in
 // sitemap/RSS integrations if we add them later, and surfaces in the
@@ -30,15 +36,13 @@ export default defineConfig({
           ? [{ tag: 'meta', attrs: { name: 'robots', content: 'noindex, nofollow' } }]
           : []),
       ],
-      title: 'NetsCLI docs',
-      // "network scanner", not "network scanner and diagnostics toolkit" --
-      // one name for the product, matching the title, H1 and description on
-      // the landing page.
-      description:
-        'Technical documentation for NetsCLI, a Rust-based network scanner with a desktop app, terminal UI, CLI, MCP server, and shared core library.',
+      // Title, description, logo and sidebar come from
+      // src/data/site-content/docs.ts with the rest of the site's content.
+      title: docsTitle,
+      description: docsDescription,
       disable404Route: true,
       logo: {
-        src: './public/assets/netscli-wordmark.png',
+        src: docsLogo,
         replacesTitle: true,
       },
       components: {
@@ -85,39 +89,7 @@ export default defineConfig({
           href: 'https://github.com/fstubner/netscli',
         },
       ],
-      sidebar: [
-        {
-          label: 'Start',
-          items: [
-            { label: 'Overview', link: '/docs/' },
-            { label: 'Installation', link: '/docs/install/' },
-            { label: 'Interface coverage', link: '/docs/interface-coverage/' },
-          ],
-        },
-        {
-          label: 'Interfaces',
-          items: [
-            { label: 'Desktop app', link: '/docs/desktop/' },
-            { label: 'Terminal UI', link: '/docs/tui/' },
-            { label: 'CLI', link: '/docs/cli/' },
-            { label: 'MCP server', link: '/docs/mcp/' },
-          ],
-        },
-        {
-          label: 'Operations',
-          items: [
-            { label: 'Operation guide', link: '/docs/operations/' },
-            { label: 'Packet capture', link: '/docs/packet-capture/' },
-          ],
-        },
-        {
-          label: 'Reference',
-          items: [
-            { label: 'Core library and crates', link: '/docs/core-library/' },
-            { label: 'Result model', link: '/docs/result-model/' },
-          ],
-        },
-      ],
+      sidebar: docsSidebar,
     }),
   ],
   build: {

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,6 +1,10 @@
 ---
 import { site } from '../data/site';
-const { hero, social } = site;
+const { hero, heroDownloads, social } = site;
+// What the button points at before any script runs, and what a crawler
+// reads. The list's first entry, so the markup can never name a file the
+// content file does not list.
+const defaultDownload = heroDownloads[0];
 ---
 <div class="hero">
   <p class="badge">{hero.badge}</p>
@@ -35,78 +39,52 @@ const { hero, social } = site;
 
   <div class="hero-cta">
     <div class="hero-cta-main">
-      <div class="hero-primary-wrap">
-        <a
-          class="hero-primary"
-          id="hero-desktop-download"
-          href="https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-windows-x86_64.msi"
-        >
-          <span class="hero-primary-label">Desktop app</span>
-          {/* What the button will download, said out loud, and inside the
-              button rather than under it.
-              Clicking starts a download immediately and nothing else on the
-              page names the file or the platform first, so the only way to
-              find out what you were getting was to get it. It used to sit
-              below as a sibling, which put it in row 2 column 1 of the CTA
-              grid -- hanging off the left column while the command chip
-              beside it had nothing underneath. Inside the button it is
-              attached to the thing it describes and the row is even again.
-              Server-rendered with the Windows default so it matches the href
-              before any script runs; scripts/landing/os-tabs.ts rewrites the
-              text and the href together. */}
-          <span class="hero-primary-cue" id="hero-desktop-cue">Windows &middot; .msi installer</span>
-        </a>
-        <button
-          class="hero-primary-menu"
-          id="hero-desktop-menu-button"
-          type="button"
-          aria-label="Choose desktop installer"
-          aria-expanded="false"
-          aria-controls="hero-desktop-menu"
-        ></button>
-        <div class="hero-desktop-menu" id="hero-desktop-menu" hidden>
-          <a href="https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-windows-x86_64.msi">
-            <span class="platform-mark platform-windows" aria-hidden="true"><span></span><span></span><span></span><span></span></span>
-            <span class="installer-copy">
-              <span class="installer-name">Windows</span>
-              <span class="installer-meta">AMD64</span>
-            </span>
-            <span class="installer-ext">msi</span>
+      {heroDownloads.length > 0 && (
+        <div class="hero-primary-wrap">
+          <a class="hero-primary" id="hero-desktop-download" href={defaultDownload.href}>
+            <span class="hero-primary-label">{hero.downloadLabel}</span>
+            {/* What the button will download, said out loud, and inside the
+                button rather than under it.
+                Clicking starts a download immediately and nothing else on the
+                page names the file or the platform first, so the only way to
+                find out what you were getting was to get it. It used to sit
+                below as a sibling, which put it in row 2 column 1 of the CTA
+                grid -- hanging off the left column while the command chip
+                beside it had nothing underneath. Inside the button it is
+                attached to the thing it describes and the row is even again.
+                Server-rendered with the first entry so it matches the href
+                before any script runs; scripts/landing/os-tabs.ts rewrites the
+                text and the href together. */}
+            <span class="hero-primary-cue" id="hero-desktop-cue">{defaultDownload.cue}</span>
           </a>
-          <a href="https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-macos-aarch64.dmg">
-            <span class="platform-mark platform-macos" aria-hidden="true"></span>
-            <span class="installer-copy">
-              <span class="installer-name">macOS</span>
-              <span class="installer-meta">Apple silicon</span>
-            </span>
-            <span class="installer-ext">dmg</span>
-          </a>
-          <a href="https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-macos-x86_64.dmg">
-            <span class="platform-mark platform-macos" aria-hidden="true"></span>
-            <span class="installer-copy">
-              <span class="installer-name">macOS</span>
-              <span class="installer-meta">Intel x86_64</span>
-            </span>
-            <span class="installer-ext">dmg</span>
-          </a>
-          <a href="https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-linux-x86_64.AppImage">
-            <span class="platform-mark platform-linux" aria-hidden="true"></span>
-            <span class="installer-copy">
-              <span class="installer-name">Linux</span>
-              <span class="installer-meta">x86_64 portable</span>
-            </span>
-            <span class="installer-ext">AppImage</span>
-          </a>
-          <a href="https://github.com/fstubner/netscli/releases/latest/download/netscli-gui-linux-x86_64.deb">
-            <span class="platform-mark platform-linux" aria-hidden="true"></span>
-            <span class="installer-copy">
-              <span class="installer-name">Debian / Ubuntu</span>
-              <span class="installer-meta">AMD64</span>
-            </span>
-            <span class="installer-ext">deb</span>
-          </a>
+          <button
+            class="hero-primary-menu"
+            id="hero-desktop-menu-button"
+            type="button"
+            aria-label={hero.downloadMenuLabel}
+            aria-expanded="false"
+            aria-controls="hero-desktop-menu"
+          ></button>
+          <div class="hero-desktop-menu" id="hero-desktop-menu" hidden>
+            {heroDownloads.map((download) => (
+              <a href={download.href}>
+                <span class={`platform-mark platform-${download.os}`} aria-hidden="true">
+                  {/* The Windows glyph is four panes; the other two are a
+                      single shape drawn in CSS. */}
+                  {download.os === 'windows' && (
+                    <Fragment><span></span><span></span><span></span><span></span></Fragment>
+                  )}
+                </span>
+                <span class="installer-copy">
+                  <span class="installer-name">{download.name}</span>
+                  <span class="installer-meta">{download.meta}</span>
+                </span>
+                <span class="installer-ext">{download.ext}</span>
+              </a>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
       {/* The SCRIPT one-liner sits here, in the wide slot beside the button,
           and the package-manager command goes in the narrower row below.
 

--- a/site/src/data/site-content/docs.ts
+++ b/site/src/data/site-content/docs.ts
@@ -1,0 +1,52 @@
+import type { DocsSection } from './types';
+
+// The docs section's own copy and structure. Starlight reads these from
+// astro.config.mjs; they live here because a product's docs are content, and
+// retargeting the site should not mean editing build config.
+//
+// Nothing checks that a `link` resolves: Starlight builds an entry pointing
+// at a page that does not exist without complaining, so an entry left behind
+// after deleting its page becomes a dead link in the sidebar of every page.
+export const docsTitle = 'NetsCLI docs';
+
+// "network scanner", not "network scanner and diagnostics toolkit" -- one
+// name for the product, matching the title, H1 and description on the
+// landing page.
+export const docsDescription =
+  'Technical documentation for NetsCLI, a Rust-based network scanner with a desktop app, terminal UI, CLI, MCP server, and shared core library.';
+
+export const docsLogo = './public/assets/netscli-wordmark.png';
+
+export const docsSidebar: DocsSection[] = [
+  {
+    label: 'Start',
+    items: [
+      { label: 'Overview', link: '/docs/' },
+      { label: 'Installation', link: '/docs/install/' },
+      { label: 'Interface coverage', link: '/docs/interface-coverage/' },
+    ],
+  },
+  {
+    label: 'Interfaces',
+    items: [
+      { label: 'Desktop app', link: '/docs/desktop/' },
+      { label: 'Terminal UI', link: '/docs/tui/' },
+      { label: 'CLI', link: '/docs/cli/' },
+      { label: 'MCP server', link: '/docs/mcp/' },
+    ],
+  },
+  {
+    label: 'Operations',
+    items: [
+      { label: 'Operation guide', link: '/docs/operations/' },
+      { label: 'Packet capture', link: '/docs/packet-capture/' },
+    ],
+  },
+  {
+    label: 'Reference',
+    items: [
+      { label: 'Core library and crates', link: '/docs/core-library/' },
+      { label: 'Result model', link: '/docs/result-model/' },
+    ],
+  },
+];

--- a/site/src/data/site-content/hero.ts
+++ b/site/src/data/site-content/hero.ts
@@ -1,4 +1,4 @@
-import type { Hero } from './types';
+import type { Hero, HeroDownload } from './types';
 import { INSTALL_SH_COMMAND } from './install-urls';
 
 export const hero: Hero = {
@@ -65,4 +65,64 @@ export const hero: Hero = {
   heroImageWidth: 1640,
   heroImageHeight: 930,
   sourceUrl: 'https://github.com/fstubner/netscli',
+  downloadLabel: 'Desktop app',
+  downloadMenuLabel: 'Choose desktop installer',
 };
+
+const RELEASE_DOWNLOAD = 'https://github.com/fstubner/netscli/releases/latest/download';
+
+// The desktop installers, in menu order. The first entry is also what the
+// server renders into the button before any script runs, so it has to be a
+// file that exists rather than a placeholder.
+//
+// macOS ships two .dmgs and they are NOT interchangeable. The Intel build is
+// `preferred` because Rosetta 2 runs it on Apple silicon too -- an asymmetry
+// worth exploiting, since the wrong guess in that direction still works and
+// the reverse does not. `appleSilicon` upgrades to the native build only when
+// the browser will actually say so.
+export const heroDownloads: HeroDownload[] = [
+  {
+    os: 'windows',
+    name: 'Windows',
+    meta: 'AMD64',
+    ext: 'msi',
+    href: `${RELEASE_DOWNLOAD}/netscli-gui-windows-x86_64.msi`,
+    cue: 'Windows · .msi installer',
+    preferred: true,
+  },
+  {
+    os: 'macos',
+    name: 'macOS',
+    meta: 'Apple silicon',
+    ext: 'dmg',
+    href: `${RELEASE_DOWNLOAD}/netscli-gui-macos-aarch64.dmg`,
+    cue: 'macOS · Apple silicon .dmg',
+    appleSilicon: true,
+  },
+  {
+    os: 'macos',
+    name: 'macOS',
+    meta: 'Intel x86_64',
+    ext: 'dmg',
+    href: `${RELEASE_DOWNLOAD}/netscli-gui-macos-x86_64.dmg`,
+    cue: 'macOS · Intel .dmg',
+    preferred: true,
+  },
+  {
+    os: 'linux',
+    name: 'Linux',
+    meta: 'x86_64 portable',
+    ext: 'AppImage',
+    href: `${RELEASE_DOWNLOAD}/netscli-gui-linux-x86_64.AppImage`,
+    cue: 'Linux · .AppImage',
+    preferred: true,
+  },
+  {
+    os: 'linux',
+    name: 'Debian / Ubuntu',
+    meta: 'AMD64',
+    ext: 'deb',
+    href: `${RELEASE_DOWNLOAD}/netscli-gui-linux-x86_64.deb`,
+    cue: 'Linux · .deb package',
+  },
+];

--- a/site/src/data/site-content/types.ts
+++ b/site/src/data/site-content/types.ts
@@ -35,6 +35,37 @@ export interface Branding {
   fg: string;
 }
 
+/** One installer in the hero's Desktop app menu.
+ *
+ *  The list is content, not markup: a product with no desktop build leaves
+ *  `heroDownloads` empty and the button, its caption and the menu are not
+ *  rendered at all. */
+export interface HeroDownload {
+  /** Which platform this installer is for. Drives both the platform glyph
+   *  and which entry a visitor on that platform is offered by default. */
+  os: Platform;
+  /** Platform name as shown in the menu ("Windows", "Debian / Ubuntu"). */
+  name: string;
+  /** Architecture or variant line under the name ("Apple silicon"). */
+  meta: string;
+  /** File extension badge on the right of the row ("msi", "AppImage"). */
+  ext: string;
+  href: string;
+  /** Caption inside the main button when this entry is the chosen one.
+   *  Says the platform and the file out loud, e.g. "Windows · .msi
+   *  installer" — a caption naming a different file from the one the
+   *  button fetches is worse than no caption, so the two move together. */
+  cue: string;
+  /** The entry offered to a visitor detected on this `os`. Exactly one
+   *  entry per os that appears in the list should set it; the first entry
+   *  for that os is used if none does. */
+  preferred?: boolean;
+  /** Offered instead of `preferred` when the browser reports an arm64
+   *  machine. macOS only in practice: the Intel build runs everywhere via
+   *  Rosetta, so it stays the default and this is an upgrade. */
+  appleSilicon?: boolean;
+}
+
 export interface Hero {
   /** Small uppercase strip above the headline. */
   badge: string;
@@ -59,6 +90,11 @@ export interface Hero {
   heroImageWebp?: string;
   /** Link to the source repo for the "View source" pill. */
   sourceUrl: string;
+  /** Label on the desktop-download button. Only rendered when
+   *  `heroDownloads` has entries. */
+  downloadLabel: string;
+  /** Accessible name of the button that opens the installer menu. */
+  downloadMenuLabel: string;
 }
 
 export interface SurfaceCard {
@@ -160,10 +196,19 @@ export interface SectionCopy {
   leadHtml: string;
 }
 
+/** One group in the docs sidebar, as Starlight expects it. */
+export interface DocsSection {
+  label: string;
+  items: { label: string; link: string }[];
+}
+
 export interface SiteData {
   meta: Meta;
   branding: Branding;
   hero: Hero;
+  /** Desktop installers offered in the hero. Empty for a product that
+   *  ships no desktop build. */
+  heroDownloads: HeroDownload[];
   /** Visible headings + leads for each main section. */
   copy: {
     surfaces: SectionCopy;

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -3,7 +3,7 @@
 // product. Every component reads the assembled `site` export from here.
 
 import { branding, meta } from './site-content/meta';
-import { hero } from './site-content/hero';
+import { hero, heroDownloads } from './site-content/hero';
 import { surfaces, surfacesCopy } from './site-content/surfaces';
 import {
   installBinariesNote,
@@ -22,6 +22,7 @@ export type {
   BuiltWithEntry,
   FaqItem,
   Hero,
+  HeroDownload,
   InstallEntry,
   Meta,
   Platform,
@@ -37,6 +38,7 @@ export const site: SiteData = {
   meta,
   branding,
   hero,
+  heroDownloads,
   copy: {
     surfaces: surfacesCopy,
     install: installCopy,

--- a/site/src/scripts/landing/os-tabs.ts
+++ b/site/src/scripts/landing/os-tabs.ts
@@ -9,6 +9,7 @@
  */
 import type { NavigatorWithUserAgentData, OperatingSystem } from './os-types';
 import { INSTALL_PS1_COMMAND, INSTALL_SH_COMMAND } from '../../data/site-content/install-urls';
+import { heroDownloads } from '../../data/site-content/hero';
 
 export function initOsTabs(): void {
   // OS tab swap. Keep visual state and ARIA state aligned so package
@@ -158,51 +159,35 @@ export function initOsTabs(): void {
 
     const desktopDownload = document.querySelector<HTMLAnchorElement>("#hero-desktop-download");
     if (desktopDownload) {
-      const base = "https://github.com/fstubner/netscli/releases/latest/download";
-      // macOS ships two .dmgs and they are NOT interchangeable. This
-      // button used to hand every Mac visitor the Apple Silicon build,
-      // so Intel users downloaded something that would not run.
-      //
-      // Default to the Intel build, because Rosetta 2 runs it on Apple
-      // Silicon too — an asymmetry worth exploiting, since the wrong
-      // guess in that direction still works and the reverse does not.
-      // Then upgrade to the native arm64 build if the browser will
-      // actually tell us the architecture.
-      const desktopUrls: Record<OperatingSystem, string> = {
-        windows: `${base}/netscli-gui-windows-x86_64.msi`,
-        macos: `${base}/netscli-gui-macos-x86_64.dmg`,
-        linux: `${base}/netscli-gui-linux-x86_64.AppImage`,
-      };
-      desktopDownload.href = desktopUrls[detected];
-
+      // Which installer a visitor on this OS is offered. The content file
+      // marks one entry per OS `preferred`; the first entry for that OS is
+      // the fallback, so a list that forgets the flag still offers something
+      // for the right platform rather than nothing.
+      const forOs = heroDownloads.filter((d) => d.os === detected);
+      const chosen = forOs.find((d) => d.preferred) ?? forOs[0];
+      const cue = document.getElementById("hero-desktop-cue");
       // Keep the caption and the href saying the same thing. They are set
       // together on purpose: a cue that describes a different file from the
       // one the button fetches is worse than no cue.
-      const cueText: Record<OperatingSystem, string> = {
-        windows: 'Windows · .msi installer',
-        macos: 'macOS · Intel .dmg',
-        linux: 'Linux · .AppImage',
+      const offer = (download: (typeof heroDownloads)[number]) => {
+        desktopDownload.href = download.href;
+        if (cue) cue.textContent = download.cue;
       };
-      const cue = document.getElementById('hero-desktop-cue');
-      if (cue) cue.textContent = cueText[detected];
+      if (chosen) offer(chosen);
 
-      if (detected === "macos") {
+      const armBuild = forOs.find((d) => d.appleSilicon);
+      if (armBuild) {
         // High-entropy hints are async and Chromium-only; Safari never
-        // resolves this, which is exactly why the default above has to
-        // be the one that runs everywhere.
+        // resolves this, which is why the entry chosen above has to be one
+        // that runs everywhere -- on macOS that is the Intel build, which
+        // Rosetta 2 also runs on Apple silicon.
         navigatorWithUaData.userAgentData
           ?.getHighEntropyValues?.(["architecture"])
           .then(({ architecture }) => {
-            if (architecture === "arm") {
-              desktopDownload.href = `${base}/netscli-gui-macos-aarch64.dmg`;
-              // The caption moves with the href. Without this the button
-              // would fetch the Apple Silicon build while the line under it
-              // still read "Intel .dmg".
-              if (cue) cue.textContent = 'macOS · Apple silicon .dmg';
-            }
+            if (architecture === "arm") offer(armBuild);
           })
           .catch(() => {
-            /* keep the Intel default */
+            /* keep the entry chosen above */
           });
       }
     }


### PR DESCRIPTION
The last two things a fork had to edit outside `src/data/site-content/`.

- The hero's installer menu, its server-rendered default and the per-OS swap in `os-tabs.ts` now read one list in `site-content/hero.ts`. An empty list renders no desktop button at all.
- Starlight's title, description, logo and sidebar come from a new `site-content/docs.ts`.

Found by the trial instantiation of the site template. No visual change: all 240 screenshot captures match the baseline.