### PR TITLE
site: rename the shell's style prefix from netscli- to ui-

### DIFF
--- a/scripts/design-tokens.mjs
+++ b/scripts/design-tokens.mjs
@@ -58,7 +58,7 @@ const TARGETS = [
   {
     name: 'site',
     // tokens.css carries the brand accent under `:root`; the Starlight file
-    // reaches it with `--sl-color-accent: var(--netscli-accent)`, which is why
+    // reaches it with `--sl-color-accent: var(--ui-accent)`, which is why
     // values are resolved through one level of var() before use.
     // docs/theme.css holds the per-theme palette and the docs layout tokens;
     // both files are read because a value can resolve across them.
@@ -72,7 +72,7 @@ const TARGETS = [
     // Starlight inverts its own naming in the light theme -- `--sl-color-white`
     // is #111827 there -- so white/gray-1..3 are the text ramp in both themes
     // and black/bg/gray-6 are the surfaces in both.
-    // netscli-text-* are the landing page's ramp and share values with the
+    // ui-text-* are the landing page's ramp and share values with the
     // sl-color-* entries beside them. Listed anyway: they are what the landing
     // stack actually names, and a future change to one of them has to be
     // checked here rather than rely on a reader noticing the values match.
@@ -83,24 +83,24 @@ const TARGETS = [
       'sl-color-gray-2',
       'sl-color-gray-3',
       'sl-color-accent',
-      'netscli-text-strong',
-      'netscli-text',
-      'netscli-text-muted',
+      'ui-text-strong',
+      'ui-text',
+      'ui-text-muted',
       // The accent as ink, and the four code-sample colours.
       //
-      // Added after the light theme shipped with --netscli-accent left at the
+      // Added after the light theme shipped with --ui-accent left at the
       // dark #22c55e -- 2.0:1 on a white page, across every accent-coloured
       // link on the landing page and the changelog -- and the code samples
       // still carrying a palette picked for a near-black background. Neither
       // was reachable from this list, so the gate reported a pass on both.
-      // --netscli-accent is the one to watch: only its -rgb twin was
+      // --ui-accent is the one to watch: only its -rgb twin was
       // overridden per theme, and channels are invisible to a contrast check.
-      'netscli-accent',
-      'netscli-accent-bright',
-      'netscli-accent-high',
+      'ui-accent',
+      'ui-accent-bright',
+      'ui-accent-high',
       // The four code-sample colours are deliberately NOT here.
       //
-      // They sit on --netscli-code-bg, which is dark in both themes, and this
+      // They sit on --ui-code-bg, which is dark in both themes, and this
       // gate compares every foreground against every PAGE surface -- so it
       // measured them against white and reported failures for a pairing that
       // never renders. Adding the code background to `surfaces` instead would
@@ -120,9 +120,9 @@ const TARGETS = [
       // 1.59:1 on the light one -- one end of the word near-invisible in each
       // theme, for as long as the button has existed. Nothing else can see
       // these: a running browser reports the fill, not the paint.
-      'netscli-brand-gradient-from',
-      'netscli-brand-gradient-via',
-      'netscli-brand-gradient-to',
+      'ui-brand-gradient-from',
+      'ui-brand-gradient-via',
+      'ui-brand-gradient-to',
     ],
     surfaces: ['sl-color-bg', 'sl-color-bg-sidebar', 'sl-color-black', 'sl-color-gray-6'],
     keys: {

--- a/site/scripts/css-equivalence.mjs
+++ b/site/scripts/css-equivalence.mjs
@@ -83,7 +83,7 @@ const docs = pages
 for (const { document } of docs) {
   const content = document.querySelector('.sl-markdown-content');
   if (!content) continue;
-  const opts = { 'netscli-table: row-headers': 'table-row-headers', 'netscli-table: plain-first-column': 'table-plain-first-column' };
+  const opts = { 'ui-table: row-headers': 'table-row-headers', 'ui-table: plain-first-column': 'table-plain-first-column' };
   const walk = (node) => {
     for (const n of node.childNodes) {
       if (n.nodeType === 8) {
@@ -94,8 +94,8 @@ for (const { document } of docs) {
   };
   walk(content);
   for (const table of content.querySelectorAll('table')) {
-    if (table.parentElement && table.parentElement.classList.contains('netscli-table-scroll')) continue;
-    const w = document.createElement('div'); w.className = 'netscli-table-scroll'; table.before(w); w.append(table);
+    if (table.parentElement && table.parentElement.classList.contains('ui-table-scroll')) continue;
+    const w = document.createElement('div'); w.className = 'ui-table-scroll'; table.before(w); w.append(table);
   }
 }
 
@@ -115,7 +115,7 @@ function elems(sel) {
 }
 const subject = (sel) => sel.trim().split(/[\s>+~]+/).pop().replace(/\[[^\]]*\]/g, '').replace(/::?[a-z-]+(\([^)]*\))?/g, '');
 // Selectors for DOM that only exists at runtime fall back to a name bucket.
-const RUNTIME = /pagefind|dialog|site-search|feedback|aria-hidden|isMobile|sl-sidebar-state|search-offline|data-search-modal|::backdrop|data-copied|\.show|netscli-table-scroll/;
+const RUNTIME = /pagefind|dialog|site-search|feedback|aria-hidden|isMobile|sl-sidebar-state|search-offline|data-search-modal|::backdrop|data-copied|\.show|ui-table-scroll/;
 
 /* ---- Index a stack ------------------------------------------------------- */
 function index(sources) {

--- a/site/scripts/lib/css-cascade.mjs
+++ b/site/scripts/lib/css-cascade.mjs
@@ -79,7 +79,7 @@ export const STATE_DIMS = [
   { key: 'current', values: [false, true], mentions: /aria-current/, applies: (sel, v) => !(/\[aria-current/.test(sel) && !v) },
   { key: 'expanded', values: [false, true], mentions: /aria-expanded|\[open\]/, applies: (sel, v) => !(/\[aria-expanded='true'\]|\[open\]/.test(sel) && !v) },
   { key: 'copied', values: [false, true], mentions: /data-copied|feedback\.show/, applies: (sel, v) => !(/\[data-copied\]|feedback\.show/.test(sel) && !v) },
-  { key: 'overflow', values: [false, true], mentions: /netscli-search-overflow/, applies: (sel, v) => !(/netscli-search-overflow/.test(sel) && !v) },
+  { key: 'overflow', values: [false, true], mentions: /ui-search-overflow/, applies: (sel, v) => !(/ui-search-overflow/.test(sel) && !v) },
 ];
 
 /** Every combination of the dimensions some selector in `sels` depends on. */
@@ -104,7 +104,7 @@ export function structural(sel) {
     .replace(/::?(before|after|placeholder|backdrop|marker|selection|-webkit-[a-z-]+)(?![a-z-])/g, '')
     .replace(/\[aria-current(=[^\]]*)?\]|\[aria-expanded=[^\]]*\]|\[open\]|\[data-search-modal-open\]|\[data-copied\]/g, '')
     .replace(/:has\(\.feedback\.show\)/g, '')
-    .replace(/\.netscli-search-overflow-(top|bottom)/g, '')
+    .replace(/\.ui-search-overflow-(top|bottom)/g, '')
     .replace(/^html(\[[^\]]*\])*$/, 'html')
     .trim();
 }

--- a/site/scripts/wordmark-inset.mjs
+++ b/site/scripts/wordmark-inset.mjs
@@ -1,4 +1,4 @@
-// Does --netscli-mark-inset-ratio still match the wordmark asset?
+// Does --ui-mark-inset-ratio still match the wordmark asset?
 //
 // netscli-wordmark.png carries transparent columns down its left edge, so a
 // bar that renders it flush against the gutter shows the logo indented while
@@ -110,10 +110,10 @@ while (left < width) {
 const measured = left / width;
 
 const css = fs.readFileSync(tokens, 'utf8');
-const declared = css.match(/--netscli-mark-inset-ratio:\s*([\d.]+)\s*;/);
+const declared = css.match(/--ui-mark-inset-ratio:\s*([\d.]+)\s*;/);
 if (!declared) {
   console.error(
-    `No --netscli-mark-inset-ratio declaration in ${path.relative(siteRoot, tokens)}.\n` +
+    `No --ui-mark-inset-ratio declaration in ${path.relative(siteRoot, tokens)}.\n` +
       `The wordmark's own left margin is ${measured.toFixed(4)} of its width ` +
       `(${left} of ${width} columns); declare that.`
   );
@@ -126,7 +126,7 @@ const drift = Math.abs(ratio - measured);
 if (drift > TOLERANCE) {
   console.error(
     'Wordmark inset has drifted from the asset.\n' +
-      `  declared  --netscli-mark-inset-ratio: ${ratio}\n` +
+      `  declared  --ui-mark-inset-ratio: ${ratio}\n` +
       `  measured  ${measured.toFixed(4)} (${left} transparent columns of ${width})\n` +
       `  drift     ${(drift * 160).toFixed(2)}px at a 160px wordmark, tolerance 0.50px\n` +
       `Set the token to ${measured.toFixed(4)} in ${path.relative(siteRoot, tokens)}, ` +

--- a/site/src/components/Faq.astro
+++ b/site/src/components/Faq.astro
@@ -62,33 +62,33 @@ const faqGroups = grouped.sort(
 .faq-section-title{
   margin:0 0 6px;
   padding-bottom:8px;
-  border-bottom:1px solid rgba(var(--netscli-hairline-rgb),.16);
-  color:var(--netscli-text-strong);
+  border-bottom:1px solid rgba(var(--ui-hairline-rgb),.16);
+  color:var(--ui-text-strong);
   font-size:.78rem;
   font-weight:700;
   letter-spacing:.08em;
   text-transform:uppercase;
 }
 .faq details{
-  background:rgba(var(--netscli-lift-rgb),.025);
-  border:1px solid rgba(var(--netscli-lift-rgb),.08);
+  background:rgba(var(--ui-lift-rgb),.025);
+  border:1px solid rgba(var(--ui-lift-rgb),.08);
   border-radius:10px;padding:14px 18px;
   transition:background 150ms,border-color 150ms;
 }
-.faq details[open]{background:rgba(var(--netscli-lift-rgb),.04);border-color:rgba(var(--netscli-lift-rgb),.14)}
+.faq details[open]{background:rgba(var(--ui-lift-rgb),.04);border-color:rgba(var(--ui-lift-rgb),.14)}
 .faq summary{
-  cursor:pointer;font-size:.9375rem;font-weight:600;color:var(--netscli-text);
+  cursor:pointer;font-size:.9375rem;font-weight:600;color:var(--ui-text);
   list-style:none;display:flex;align-items:center;gap:10px;
 }
 .faq summary::-webkit-details-marker{display:none}
 .faq summary::before{
   content:"+";font-family:ui-monospace,"SF Mono",Menlo,monospace;
-  color:var(--netscli-accent);font-weight:700;width:14px;flex-shrink:0;
+  color:var(--ui-accent);font-weight:700;width:14px;flex-shrink:0;
   transition:transform 150ms;
 }
 .faq details[open] summary::before{content:"−"}
 .faq .answer{
-  color:var(--netscli-text-muted);font-size:.875rem;line-height:1.65;margin-top:12px;
+  color:var(--ui-text-muted);font-size:.875rem;line-height:1.65;margin-top:12px;
   padding-left:24px;
   /* Long URLs inside <code> spans don't break by default and force the
      details card wider than the viewport. Allow breaks at any char so
@@ -107,7 +107,7 @@ const faqGroups = grouped.sort(
   position:relative;
 }
 .faq-command span{
-  color:var(--netscli-text-muted);
+  color:var(--ui-text-muted);
   font-size:.78rem;
   line-height:1.7;
 }
@@ -120,34 +120,34 @@ const faqGroups = grouped.sort(
      pinned dark in both themes, which left black bars running down a light
      FAQ answer once everything around them had gone light. The LABEL beside
      it sits on the card either way. */
-  border:1px solid var(--netscli-chip-border);
+  border:1px solid var(--ui-chip-border);
   border-radius:5px;
-  background:var(--netscli-chip-bg);
-  color:var(--netscli-chip-fg);
+  background:var(--ui-chip-bg);
+  color:var(--ui-chip-fg);
   white-space:pre;
   overflow-x:auto;
 }
 .faq .answer code{
   font-size:.8125rem;
   /* The chip follows the theme now, so the ink has to as well. This was
-     pinned to --netscli-code-inline-fg back when the chip was dark in both
+     pinned to --ui-code-inline-fg back when the chip was dark in both
      themes; left pinned, that light-on-dark green landed on the new light
-     chip at 1.28:1. --netscli-chip-code-fg is the pair that moves with the
+     chip at 1.28:1. --ui-chip-code-fg is the pair that moves with the
      surface: 13.06:1 dark, 8.66:1 light. */
-  color:var(--netscli-chip-code-fg);
+  color:var(--ui-chip-code-fg);
   white-space:nowrap;
   overflow-wrap:normal;
   word-break:normal;
 }
 .faq .answer .faq-command code{
-  color:var(--netscli-chip-fg);
+  color:var(--ui-chip-fg);
   white-space:pre;
   overflow-x:auto;
   overflow-wrap:normal;
   word-break:normal;
 }
-.faq .answer a{color:var(--netscli-accent);text-decoration:underline;text-underline-offset:3px;overflow-wrap:anywhere}
-.faq .answer a:hover{color:var(--netscli-accent-bright)}
+.faq .answer a{color:var(--ui-accent);text-decoration:underline;text-underline-offset:3px;overflow-wrap:anywhere}
+.faq .answer a:hover{color:var(--ui-accent-bright)}
 
 
 @media(max-width:600px){

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -27,14 +27,14 @@ const { meta, hero, builtWith } = site;
 
 <style is:global>
 footer{
-  border-top:1px solid rgba(var(--netscli-lift-rgb),.06);padding:0;
+  border-top:1px solid rgba(var(--ui-lift-rgb),.06);padding:0;
 }
 .footer-inner{
   max-width:1060px;margin:0 auto;padding:28px 24px;
   display:flex;justify-content:space-between;align-items:center;
-  flex-wrap:wrap;gap:12px;font-size:.75rem;color:var(--netscli-text-muted);
+  flex-wrap:wrap;gap:12px;font-size:.75rem;color:var(--ui-text-muted);
 }
-footer a{color:var(--netscli-text-muted);text-decoration:none}
-footer a:hover{color:var(--netscli-text)}
+footer a{color:var(--ui-text-muted);text-decoration:none}
+footer a:hover{color:var(--ui-text)}
 .flinks{display:flex;gap:16px}
 </style>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -135,17 +135,17 @@ const defaultDownload = heroDownloads[0];
 .hero{padding:72px 24px 0;text-align:center}
 .hero .badge{
   display:inline-block;font-size:.6875rem;font-weight:600;
-  letter-spacing:.06em;text-transform:uppercase;color:var(--netscli-text-muted);margin-bottom:16px;
+  letter-spacing:.06em;text-transform:uppercase;color:var(--ui-text-muted);margin-bottom:16px;
 }
 .hero h1{
-  font-size:clamp(1.75rem,4vw,2.75rem);font-weight:700;color:var(--netscli-text-strong);
+  font-size:clamp(1.75rem,4vw,2.75rem);font-weight:700;color:var(--ui-text-strong);
   letter-spacing:-.02em;margin:0 auto;line-height:1.2;
   /* Sized for the current heading, which is 62 characters. At the old 15ch
      -- set when the heading was "A modern network scanner" -- it broke into
      four lines and pushed the install buttons off the first screen. */
   max-width:34ch;
 }
-.hero .sub{font-size:1.0625rem;color:var(--netscli-text-muted);max-width:640px;margin:14px auto 0}
+.hero .sub{font-size:1.0625rem;color:var(--ui-text-muted);max-width:640px;margin:14px auto 0}
 /* .8125rem and the body ink, not .75rem and the muted step.
  *
  * The line was 12px at rgb(89,100,120) -- 5.77:1, so legible, but it read as
@@ -158,7 +158,7 @@ const defaultDownload = heroDownloads[0];
  * separators keep the muted colour below, so the line still reads as one
  * group rather than four competing items. */
 .hero .social-proof{
-  margin:12px auto 0;font-size:.8125rem;color:var(--netscli-text);
+  margin:12px auto 0;font-size:.8125rem;color:var(--ui-text);
   display:flex;justify-content:center;align-items:center;gap:10px;
   font-variant-numeric:tabular-nums;min-height:1em;
 }
@@ -166,7 +166,7 @@ const defaultDownload = heroDownloads[0];
   display:inline-flex;align-items:center;gap:3px;
 }
 .hero .social-proof a{color:inherit;text-decoration:none}
-.hero .social-proof a:hover{color:var(--netscli-text)}
+.hero .social-proof a:hover{color:var(--ui-text)}
 .hero .social-proof a[data-total-downloads]{
   position:relative;
   outline-offset:4px;
@@ -185,9 +185,9 @@ const defaultDownload = heroDownloads[0];
   padding:.42rem .58rem;
   border:1px solid rgba(106,240,208,.2);
   border-radius:6px;
-  background:var(--netscli-surface);
-  color:var(--netscli-text);
-  box-shadow:var(--netscli-lift-sm);
+  background:var(--ui-surface);
+  color:var(--ui-text);
+  box-shadow:var(--ui-lift-sm);
   font-size:.72rem;
   line-height:1.25;
   pointer-events:none;
@@ -205,7 +205,7 @@ const defaultDownload = heroDownloads[0];
   height:.45rem;
   border-right:1px solid rgba(106,240,208,.2);
   border-bottom:1px solid rgba(106,240,208,.2);
-  background:var(--netscli-surface);
+  background:var(--ui-surface);
   pointer-events:none;
   opacity:0;
   transform:translate(-50%,.25rem) rotate(45deg);
@@ -232,7 +232,7 @@ const defaultDownload = heroDownloads[0];
    light theme had no say over, and the one thing on this line that did not
    move when the rest of it did. It is the separator's job to sit behind the
    items it separates, so it takes the muted token they just left. */
-.hero .social-proof .sep{color:var(--netscli-text-muted)}
+.hero .social-proof .sep{color:var(--ui-text-muted)}
 .hero-cta{
   /* 610, not 560, and sized off the viewport rather than a vw fraction.
      At 560 the wide command slot was 351px against 397px of text, so
@@ -273,9 +273,9 @@ const defaultDownload = heroDownloads[0];
      surface; the border gradient ended on the dark theme's bright cyan for the
      same reason. Both follow the theme now. */
   background:
-    linear-gradient(var(--netscli-surface),var(--netscli-surface)) padding-box,
-    linear-gradient(90deg,var(--netscli-accent) 0%,var(--netscli-accent) 62%,var(--netscli-brand-gradient-to) 100%) border-box;
-  box-shadow:0 0 12px rgba(var(--netscli-accent-rgb),.08);
+    linear-gradient(var(--ui-surface),var(--ui-surface)) padding-box,
+    linear-gradient(90deg,var(--ui-accent) 0%,var(--ui-accent) 62%,var(--ui-brand-gradient-to) 100%) border-box;
+  box-shadow:0 0 12px rgba(var(--ui-accent-rgb),.08);
   overflow:visible;
 }
 /* One control height for the whole CTA block.
@@ -290,14 +290,14 @@ const defaultDownload = heroDownloads[0];
  * box-sizing is border-box globally, so the number is the outer height on
  * both -- borders included, which is where the button's extra 2px lived. */
 .hero-cta{
-  --netscli-cta-height:44px;
+  --ui-cta-height:44px;
 }
 .hero-primary-wrap{
-  min-height:var(--netscli-cta-height);
+  min-height:var(--ui-cta-height);
 }
 .hero-primary,
 .hero-primary-menu{
-  min-height:calc(var(--netscli-cta-height) - 2px);
+  min-height:calc(var(--ui-cta-height) - 2px);
   display:inline-flex;align-items:center;justify-content:center;
   background:transparent;
   background-image:none;
@@ -317,19 +317,19 @@ const defaultDownload = heroDownloads[0];
   text-decoration:none;font-size:.82rem;font-weight:760;
   letter-spacing:.005em;
   font-family:Inter,system-ui,-apple-system,Segoe UI,sans-serif;
-  color:var(--netscli-accent);
+  color:var(--ui-accent);
 }
 .hero-primary-label{
   transform:translateX(8px);
   background-image:linear-gradient(90deg,
-    var(--netscli-brand-gradient-from),
-    var(--netscli-brand-gradient-via),
-    var(--netscli-brand-gradient-to));
+    var(--ui-brand-gradient-from),
+    var(--ui-brand-gradient-via),
+    var(--ui-brand-gradient-to));
   -webkit-background-clip:text;background-clip:text;
   -webkit-text-fill-color:transparent;
 }
 .hero-primary-menu{
-  border-radius:0;color:var(--netscli-text);
+  border-radius:0;color:var(--ui-text);
   cursor:pointer;font:inherit;padding:0;
 }
 .hero-primary-menu::before{
@@ -354,44 +354,44 @@ const defaultDownload = heroDownloads[0];
 .hero-primary-wrap:focus-within,
 .hero-primary-wrap:hover{
   background:
-    linear-gradient(var(--netscli-surface-raised),var(--netscli-surface-raised)) padding-box,
-    linear-gradient(90deg,var(--netscli-accent) 0%,var(--netscli-accent) 62%,var(--netscli-brand-gradient-to) 100%) border-box;
-  box-shadow:0 0 0 1px rgba(var(--netscli-accent-rgb),.16),0 0 12px rgba(var(--netscli-accent-rgb),.08);
+    linear-gradient(var(--ui-surface-raised),var(--ui-surface-raised)) padding-box,
+    linear-gradient(90deg,var(--ui-accent) 0%,var(--ui-accent) 62%,var(--ui-brand-gradient-to) 100%) border-box;
+  box-shadow:0 0 0 1px rgba(var(--ui-accent-rgb),.16),0 0 12px rgba(var(--ui-accent-rgb),.08);
 }
-.hero-primary-menu:hover{color:var(--netscli-text-strong)}
+.hero-primary-menu:hover{color:var(--ui-text-strong)}
 .hero-desktop-menu{
   position:absolute;top:calc(100% + 6px);left:0;z-index:20;
   width:min(260px,calc(100vw - 48px));min-width:0;box-sizing:border-box;
   /* See the wrapped-layout rule below, which widens this to the trigger. */
   padding:5px;border-radius:8px;
-  background:var(--netscli-surface);border:1px solid rgba(var(--netscli-lift-rgb),.12);
-  box-shadow:var(--netscli-lift-md);
+  background:var(--ui-surface);border:1px solid rgba(var(--ui-lift-rgb),.12);
+  box-shadow:var(--ui-lift-md);
 }
 .hero-desktop-menu a{
   display:grid;grid-template-columns:16px minmax(0,1fr) auto;
   align-items:center;gap:8px;
   padding:8px 10px;border-radius:6px;text-align:left;
-  color:var(--netscli-text);text-decoration:none;font-size:.8rem;font-weight:700;
+  color:var(--ui-text);text-decoration:none;font-size:.8rem;font-weight:700;
 }
 .hero-desktop-menu .platform-mark{
   position:relative;
   width:16px;height:16px;
   display:inline-flex;justify-content:center;align-items:center;
-  flex:none;color:var(--netscli-text-muted);
+  flex:none;color:var(--ui-text-muted);
 }
 .hero-desktop-menu .installer-copy{
   display:grid;gap:1px;min-width:0;
 }
 .hero-desktop-menu .installer-name{
-  min-width:0;color:var(--netscli-text);font-weight:720;line-height:1.18;
+  min-width:0;color:var(--ui-text);font-weight:720;line-height:1.18;
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
 }
 .hero-desktop-menu .installer-meta{
-  min-width:0;color:var(--netscli-text-muted);font-size:.67rem;font-weight:560;line-height:1.15;
+  min-width:0;color:var(--ui-text-muted);font-size:.67rem;font-weight:560;line-height:1.15;
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
 }
 .hero-desktop-menu .installer-ext{
-  justify-self:end;align-self:center;color:var(--netscli-text-muted);font-size:.68rem;font-weight:680;
+  justify-self:end;align-self:center;color:var(--ui-text-muted);font-size:.68rem;font-weight:680;
 }
 .hero-desktop-menu a .platform-mark{font-weight:700}
 .hero-desktop-menu .platform-windows{
@@ -430,21 +430,21 @@ const defaultDownload = heroDownloads[0];
   color:currentColor;font-size:8px;line-height:1;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
 }
-.hero-desktop-menu a:hover{background:rgba(var(--netscli-accent-rgb),.12);color:#1ec88c}
+.hero-desktop-menu a:hover{background:rgba(var(--ui-accent-rgb),.12);color:#1ec88c}
 .hero-command{
   position:relative;display:grid;grid-template-columns:minmax(0,1fr);
-  align-items:center;gap:10px;min-height:var(--netscli-cta-height);
+  align-items:center;gap:10px;min-height:var(--ui-cta-height);
   padding:8px 58px 8px 14px;border-radius:9px;
   /* A chip, not a code surface: dark in the dark theme, light in the light
      one, so it carries the same weight as the Desktop app button beside it.
      See the chip note in landing/tokens.css. */
-  background:var(--netscli-chip-bg);border:1px solid var(--netscli-chip-border);
-  box-shadow:0 0 0 1px rgba(var(--netscli-accent-rgb),.26),0 0 14px rgba(var(--netscli-accent-rgb),.08);
+  background:var(--ui-chip-bg);border:1px solid var(--ui-chip-border);
+  box-shadow:0 0 0 1px rgba(var(--ui-accent-rgb),.26),0 0 14px rgba(var(--ui-accent-rgb),.08);
 }
 .hero-command.hero-copy .copy-btn{opacity:1}
 .hero-command code{
   min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
-  color:var(--netscli-text);font-family:ui-monospace,"SF Mono",Menlo,monospace;
+  color:var(--ui-text);font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:.78rem;background:transparent;border:0;padding:0;
 }
 /* The button's second line. Stacked under the label inside the anchor, so it
@@ -463,7 +463,7 @@ const defaultDownload = heroDownloads[0];
   font-size:.66rem;
   font-weight:500;
   line-height:1.25;
-  color:var(--netscli-text-muted);
+  color:var(--ui-text-muted);
   -webkit-text-fill-color:currentColor;
   text-align:center;
   white-space:nowrap;
@@ -471,18 +471,18 @@ const defaultDownload = heroDownloads[0];
 .hero-install-link{
   justify-self:end;
   display:inline-flex;align-items:center;
-  color:var(--netscli-text);text-decoration:none;font-size:.76rem;white-space:nowrap;
+  color:var(--ui-text);text-decoration:none;font-size:.76rem;white-space:nowrap;
   border-bottom:1px dotted rgba(255,255,255,.22);
   padding-bottom:2px;
 }
-.hero-install-link:hover{color:var(--netscli-text-strong);border-bottom-color:rgba(255,255,255,.5)}
+.hero-install-link:hover{color:var(--ui-text-strong);border-bottom-color:rgba(255,255,255,.5)}
 .hero .links{display:flex;gap:16px;justify-content:center;margin-top:14px;flex-wrap:wrap}
 .hero .links a{
-  font-size:.8125rem;color:var(--netscli-text-muted);text-decoration:none;
+  font-size:.8125rem;color:var(--ui-text-muted);text-decoration:none;
   border-bottom:1px dotted rgba(255,255,255,.22);padding-bottom:1px;
   display:inline-flex;align-items:center;gap:4px;
 }
-.hero .links a:hover{color:var(--netscli-text);border-bottom-color:rgba(255,255,255,.5)}
+.hero .links a:hover{color:var(--ui-text);border-bottom-color:rgba(255,255,255,.5)}
 .hero .links a.plain{border-bottom:0}
 .hero .links a.plain:hover{border-bottom:0}
 @media(max-width:820px){
@@ -561,8 +561,8 @@ const defaultDownload = heroDownloads[0];
 .bigshot{
   margin:48px auto 78px;max-width:980px;
   border-radius:10px;overflow:hidden;
-  border:1px solid rgba(var(--netscli-lift-rgb),.08);
-  box-shadow:var(--netscli-lift-lg);
+  border:1px solid rgba(var(--ui-lift-rgb),.08);
+  box-shadow:var(--ui-lift-lg);
 }
 .bigshot img{width:100%;height:auto;display:block}
 .bigshot img{cursor:zoom-in}

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -108,33 +108,33 @@ const groups = [
 @media(max-width:860px){.install-grid{grid-template-columns:1fr}}
 .install-card{margin-bottom:16px;overflow:hidden}
 .install-card:last-child{margin-bottom:0}
-.install-label{font-size:.8125rem;font-weight:600;color:var(--netscli-text);margin:0 0 6px}
-.install-hint{font-size:.6875rem;color:var(--netscli-text-muted);margin:4px 0 0}
+.install-label{font-size:.8125rem;font-weight:600;color:var(--ui-text);margin:0 0 6px}
+.install-hint{font-size:.6875rem;color:var(--ui-text-muted);margin:4px 0 0}
 .cmd{
   /* A chip, not a code surface: dark in the dark theme, light in the light
      one. See the chip note in landing/tokens.css. */
-  background:var(--netscli-chip-bg);border:1px solid var(--netscli-chip-border);
+  background:var(--ui-chip-bg);border:1px solid var(--ui-chip-border);
   border-radius:8px;padding:12px 16px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:clamp(.6875rem,1.4vw,.8125rem);
-  overflow-x:auto;white-space:pre;color:var(--netscli-text);
-  scrollbar-width:thin;scrollbar-color:rgba(var(--netscli-lift-rgb),.15) transparent;
+  overflow-x:auto;white-space:pre;color:var(--ui-text);
+  scrollbar-width:thin;scrollbar-color:rgba(var(--ui-lift-rgb),.15) transparent;
   position:relative;
 }
 .tryblock{
   /* Dark in both themes -- see the code-surface note in tokens.css. */
-  background:var(--netscli-code-bg);border:1px solid var(--netscli-code-border);
+  background:var(--ui-code-bg);border:1px solid var(--ui-code-border);
   border-radius:10px;padding:16px 20px;height:100%;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:clamp(.6875rem,1.4vw,.8125rem);
-  line-height:1.9;white-space:pre;overflow-x:auto;color:var(--netscli-text);
+  line-height:1.9;white-space:pre;overflow-x:auto;color:var(--ui-text);
   position:relative;
 }
-.tryblock .c{color:var(--netscli-text-muted)}
+.tryblock .c{color:var(--ui-text-muted)}
 
 /* ─── TRY BLOCK TITLE ─── */
 .try-title{
-  font-size:.9375rem;font-weight:600;color:var(--netscli-text);margin:0 0 8px;
+  font-size:.9375rem;font-weight:600;color:var(--ui-text);margin:0 0 8px;
 }
 .try-title + .tryblock{margin-top:0}
 
@@ -147,31 +147,31 @@ const groups = [
 .os-tabs{
   grid-column:1;grid-row:1;display:flex;gap:0;
   /* A hairline on the band, not a near-white bar.
-     --netscli-surface-raised is a PAGE surface: on a light page it resolves
+     --ui-surface-raised is a PAGE surface: on a light page it resolves
      to #f2f5fa, so against the navy band this drew a solid near-white 1px
      line under the tabs -- brighter than the 2px accent underline it sits
      level with, and a different kind of mark from every other divider in the
      section. The hairline channel inverts with the band's ink, so this is a
      faint light rule on navy and a faint dark one anywhere light. */
-  border-bottom:1px solid rgba(var(--netscli-hairline-rgb),.18);margin-bottom:20px;
+  border-bottom:1px solid rgba(var(--ui-hairline-rgb),.18);margin-bottom:20px;
 }
 .install-content{grid-column:1;grid-row:2}
 .try{grid-column:2;grid-row:2}
 .os-tab{
-  padding:12px 22px;color:var(--netscli-text-muted);font-size:.9rem;cursor:pointer;user-select:none;
+  padding:12px 22px;color:var(--ui-text-muted);font-size:.9rem;cursor:pointer;user-select:none;
   border:none;background:transparent;font-family:inherit;
   border-bottom:2px solid transparent;margin-bottom:-1px;transition:color .15s;
 }
-.os-tab:hover{color:var(--netscli-text)}
-.os-tab.active{color:var(--netscli-text-strong);border-bottom-color:var(--netscli-accent);font-weight:500}
+.os-tab:hover{color:var(--ui-text)}
+.os-tab.active{color:var(--ui-text-strong);border-bottom-color:var(--ui-accent);font-weight:500}
 .os-panel{display:none}
 .os-panel.active{display:block}
 .reco{
-  background:var(--netscli-surface-raised);border:1px solid rgba(var(--netscli-lift-rgb),.08);border-radius:10px;
+  background:var(--ui-surface-raised);border:1px solid rgba(var(--ui-lift-rgb),.08);border-radius:10px;
   padding:14px 18px;margin-bottom:16px;
 }
 /* A step above the band in the dark theme, not level with it.
-   --netscli-surface-raised is #20242b and the band is #1c2634: 1.02:1, so
+   --ui-surface-raised is #20242b and the band is #1c2634: 1.02:1, so
    once #install became a band the card stopped reading as a card at all in
    dark. This is the same relationship the light theme gets from white on
    navy, at the only strength a dark page allows. */
@@ -206,10 +206,10 @@ const groups = [
    measured at 1.65:1 before this line was matched to it. */
 html[data-theme='light'] #install .reco{
   background:#ffffff;
-  border-color:rgba(var(--netscli-lift-rgb),.14);
-  box-shadow:var(--netscli-lift-sm);
+  border-color:rgba(var(--ui-lift-rgb),.14);
+  box-shadow:var(--ui-lift-sm);
 }
-.reco-meta{font-size:.85rem;font-weight:500;color:var(--netscli-text);margin-bottom:8px}
+.reco-meta{font-size:.85rem;font-weight:500;color:var(--ui-text);margin-bottom:8px}
 .cmd.big{font-size:1.05rem;padding-right:74px}
 /* The container is the divider: the rows sit on it with a 1px gap, so its
    background shows through as the hairline between them. Chip tokens, so the
@@ -217,26 +217,26 @@ html[data-theme='light'] #install .reco{
    one. */
 .alts{
   display:flex;flex-direction:column;gap:1px;
-  background:var(--netscli-chip-divider);border:1px solid var(--netscli-chip-divider);border-radius:8px;overflow:hidden;
+  background:var(--ui-chip-divider);border:1px solid var(--ui-chip-divider);border-radius:8px;overflow:hidden;
 }
 .alt{
   display:grid;grid-template-columns:140px 1fr;gap:16px;align-items:center;
-  padding:11px 16px;background:var(--netscli-chip-bg);transition:background .15s;position:relative;
+  padding:11px 16px;background:var(--ui-chip-bg);transition:background .15s;position:relative;
 }
-.alt:hover{background:var(--netscli-chip-bg)}
-.alt-label{font-size:.85rem;color:var(--netscli-text)}
+.alt:hover{background:var(--ui-chip-bg)}
+.alt-label{font-size:.85rem;color:var(--ui-text)}
 .alt-cmd{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.82rem;
-  color:var(--netscli-text);overflow-wrap:anywhere;word-break:normal;padding-right:50px;
+  color:var(--ui-text);overflow-wrap:anywhere;word-break:normal;padding-right:50px;
 }
 /* Two groups per OS panel: desktop app, then CLI. */
 .install-group + .install-group{margin-top:26px}
 .install-group-title{
-  font-size:.8125rem;font-weight:600;color:var(--netscli-text-muted);margin:0 0 10px;
+  font-size:.8125rem;font-weight:600;color:var(--ui-text-muted);margin:0 0 10px;
   text-transform:uppercase;letter-spacing:.06em;
 }
-.install-hint{font-size:.7rem;color:var(--netscli-text-muted);margin:8px 0 0}
-.alt-hint{display:block;font-size:.7rem;color:var(--netscli-text-muted);margin-top:2px;line-height:1.35}
+.install-hint{font-size:.7rem;color:var(--ui-text-muted);margin:8px 0 0}
+.alt-hint{display:block;font-size:.7rem;color:var(--ui-text-muted);margin-top:2px;line-height:1.35}
 /* Direct-download rows sit in the same column as the commands, but this is
    an action, not something to type.
    It used to be a bare monospace link with `display:block`, so it filled the
@@ -262,23 +262,23 @@ a.install-download{
   font-size:.8125rem;
   font-weight:500;
   line-height:1;
-  color:var(--netscli-text);
+  color:var(--ui-text);
   text-decoration:none;
   padding:8px 14px;
-  border:1px solid rgba(var(--netscli-lift-rgb),.08);
+  border:1px solid rgba(var(--ui-lift-rgb),.08);
   border-radius:7px;
-  background:rgba(var(--netscli-lift-rgb),.04);
+  background:rgba(var(--ui-lift-rgb),.04);
   transition:background 140ms ease,border-color 140ms ease,color 140ms ease;
 }
 a.install-download:hover,
 a.install-download:focus-visible{
-  color:var(--netscli-accent-bright);
-  border-color:rgba(var(--netscli-accent-rgb),.48);
-  background:rgba(var(--netscli-accent-rgb),.10);
+  color:var(--ui-accent-bright);
+  border-color:rgba(var(--ui-accent-rgb),.48);
+  background:rgba(var(--ui-accent-rgb),.10);
 }
-.footer-note{margin-top:14px;font-size:.8125rem;color:var(--netscli-text-muted)}
-.footer-note a{color:var(--netscli-accent);text-decoration:underline;text-underline-offset:3px}
-.footer-note a:hover{color:var(--netscli-accent-bright)}
+.footer-note{margin-top:14px;font-size:.8125rem;color:var(--ui-text-muted)}
+.footer-note a{color:var(--ui-accent);text-decoration:underline;text-underline-offset:3px}
+.footer-note a:hover{color:var(--ui-accent-bright)}
 
 /* Try it sidebar — one row per command, each row gets .has-copy so the
    existing copy-button JS auto-attaches a button. */
@@ -286,7 +286,7 @@ a.install-download:focus-visible{
   /* Dark in both themes: this panel is entirely commands and their comments,
      unlike .reco, which is a card wrapping one command bar plus prose. See
      the code-surface note in tokens.css. */
-  background:var(--netscli-code-bg);border:1px solid var(--netscli-code-border);border-radius:10px;
+  background:var(--ui-code-bg);border:1px solid var(--ui-code-border);border-radius:10px;
   padding:18px;
 }
 .try .try-title{margin:0 0 12px}
@@ -294,14 +294,14 @@ a.install-download:focus-visible{
   display:flex;flex-direction:column;align-items:stretch;gap:3px;
   padding:9px 48px 9px 10px;border-radius:5px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.83rem;
-  color:var(--netscli-text);transition:background .15s;position:relative;
+  color:var(--ui-text);transition:background .15s;position:relative;
 }
-.try-cmd:hover{background:var(--netscli-code-bg)}
+.try-cmd:hover{background:var(--ui-code-bg)}
 .try-comment{
-  color:var(--netscli-text-muted);font-size:.74rem;line-height:1.35;
+  color:var(--ui-text-muted);font-size:.74rem;line-height:1.35;
 }
 .try-line{display:flex;align-items:center;gap:8px;min-width:0}
-.try-cmd .p{color:var(--netscli-text-muted);user-select:none;flex:none}
+.try-cmd .p{color:var(--ui-text-muted);user-select:none;flex:none}
 .try-cmd .t{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1}
 
 /* Always-visible Copy variant used where controls should be discoverable
@@ -311,8 +311,8 @@ a.install-download:focus-visible{
   opacity:1;
 }
 .has-copy.always-show .copy-btn:hover{
-  background:var(--netscli-surface-raised);
-  border-color:rgba(var(--netscli-lift-rgb),.18);
+  background:var(--ui-surface-raised);
+  border-color:rgba(var(--ui-lift-rgb),.18);
   color:rgba(255,255,255,.58);
 }
 
@@ -350,20 +350,20 @@ a.install-download:focus-visible{
 .surface-download-btn{
   display:inline-flex;flex-direction:column;align-items:flex-start;gap:2px;
   padding:9px 14px;border-radius:8px;
-  background:rgba(var(--netscli-accent-rgb),.10);border:1px solid rgba(var(--netscli-accent-rgb),.45);
-  color:var(--netscli-accent);font-size:.85rem;font-weight:500;text-decoration:none;
+  background:rgba(var(--ui-accent-rgb),.10);border:1px solid rgba(var(--ui-accent-rgb),.45);
+  color:var(--ui-accent);font-size:.85rem;font-weight:500;text-decoration:none;
   transition:background .15s,color .15s,border-color .15s;
 }
 .surface-download-btn:hover{
-  background:rgba(var(--netscli-accent-rgb),.20);
-  border-color:rgba(var(--netscli-accent-rgb),.6);
+  background:rgba(var(--ui-accent-rgb),.20);
+  border-color:rgba(var(--ui-accent-rgb),.6);
   color:#1ec88c;
 }
 .surface-download-btn .dl-label{font-size:.85rem;line-height:1.2}
 .surface-download-btn .dl-hint{
-  font-size:.7rem;color:var(--netscli-text-muted);font-weight:400;line-height:1.2;
+  font-size:.7rem;color:var(--ui-text-muted);font-weight:400;line-height:1.2;
 }
-.surface-download-btn:hover .dl-hint{color:var(--netscli-text-muted)}
+.surface-download-btn:hover .dl-hint{color:var(--ui-text-muted)}
 
 /* Narrow screens: truncate long commands, do not scroll them sideways.
  *

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -57,7 +57,7 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
         labels match upstream too, so the list reads identically in both
         bars.
       */}
-      <div class="netscli-theme-select">
+      <div class="ui-theme-select">
         <label>
           <span class="sr-only">Select theme</span>
           {/* All three icons, one shown at a time.
@@ -131,9 +131,9 @@ nav[data-site-nav]{
      header sets the same value the same way. Sizing it from the inner box
      plus a border instead left the landing bar 0.2px shorter, because a 1px
      border renders as 0.8 at this device pixel ratio. */
-  min-height:var(--netscli-nav-height);
-  background:rgba(var(--netscli-bg-rgb), .85);backdrop-filter:blur(12px);
-  border-bottom:1px solid rgba(var(--netscli-lift-rgb),.06);
+  min-height:var(--ui-nav-height);
+  background:rgba(var(--ui-bg-rgb), .85);backdrop-filter:blur(12px);
+  border-bottom:1px solid rgba(var(--ui-lift-rgb),.06);
   box-shadow:none;
   transition:box-shadow 160ms ease,border-color 160ms ease;
 }
@@ -157,10 +157,10 @@ nav[data-site-nav]::after{
   transition:opacity 160ms ease;
 }
 body.nav-scrolled nav[data-site-nav]{
-  border-bottom-color:rgba(var(--netscli-accent-rgb),.12);
+  border-bottom-color:rgba(var(--ui-accent-rgb),.12);
   box-shadow:
     0 12px 28px rgba(0,0,0,.28),
-    0 1px 0 rgba(var(--netscli-accent-rgb),.08) !important;
+    0 1px 0 rgba(var(--ui-accent-rgb),.08) !important;
 }
 body.nav-scrolled nav[data-site-nav]::after{
   opacity:1;
@@ -175,8 +175,8 @@ body.nav-scrolled nav[data-site-nav]::after{
  * shadow. */
 html[data-theme='light'] body.nav-scrolled nav[data-site-nav]{
   box-shadow:
-    0 12px 26px rgba(var(--netscli-hairline-rgb),.11),
-    0 1px 0 rgba(var(--netscli-accent-rgb),.12) !important;
+    0 12px 26px rgba(var(--ui-hairline-rgb),.11),
+    0 1px 0 rgba(var(--ui-accent-rgb),.12) !important;
 }
 /* No second layer on a light page.
  *
@@ -200,12 +200,12 @@ html[data-theme='light'] nav[data-site-nav]::after{
      time you crossed between the landing page and the docs. The border is
      on the parent, hence the -1px. Still a min, so the mobile wrapped state
      grows past it as before. */
-  min-height:calc(var(--netscli-nav-height) - 1px);
+  min-height:calc(var(--ui-nav-height) - 1px);
   /* No block padding: the links are the full bar height so their underline
      reaches the bottom border, and padding here would push them past it.
      min-height holds the bar open instead. The narrow-screen rule below
      restores padding, where the links go back to auto height. */
-  max-width:var(--netscli-shell-width);margin:0 auto;padding:0 var(--netscli-shell-gutter);
+  max-width:var(--ui-shell-width);margin:0 auto;padding:0 var(--ui-shell-gutter);
   display:flex;align-items:center;justify-content:space-between;gap:18px;
   flex-wrap:wrap;
   position:relative;
@@ -217,13 +217,13 @@ html[data-theme='light'] nav[data-site-nav]::after{
      200ms transition had nothing to animate between. Left as they were, the
      hover rule would now undo the light theme's darkening the moment the
      pointer touched the logo. */
-  filter:var(--netscli-mark-filter);
+  filter:var(--ui-mark-filter);
   /* Cancels the wordmark asset's own transparent left margin, so the glyph
      starts on the gutter the nav links start on. See tokens.css. */
-  transform:translateX(calc(var(--netscli-mark-width) * var(--netscli-mark-inset-ratio) * -1));
+  transform:translateX(calc(var(--ui-mark-width) * var(--ui-mark-inset-ratio) * -1));
 }
 .mark img{
-  display:block;width:var(--netscli-mark-width);height:auto;image-rendering:auto;
+  display:block;width:var(--ui-mark-width);height:auto;image-rendering:auto;
 }
 
 .nav-menu-toggle{
@@ -234,10 +234,10 @@ html[data-theme='light'] nav[data-site-nav]::after{
   justify-content:center;
   flex-direction:column;
   gap:4px;
-  border:1px solid rgba(var(--netscli-lift-rgb),.1);
+  border:1px solid rgba(var(--ui-lift-rgb),.1);
   border-radius:7px;
-  color:var(--netscli-text);
-  background:rgba(var(--netscli-lift-rgb),.035);
+  color:var(--ui-text);
+  background:rgba(var(--ui-lift-rgb),.035);
   cursor:pointer;
 }
 .nav-menu-toggle span{
@@ -248,13 +248,13 @@ html[data-theme='light'] nav[data-site-nav]::after{
 }
 .nav-menu-toggle:hover,
 .nav-menu-toggle:focus-visible{
-  color:var(--netscli-text-strong);
-  border-color:rgba(var(--netscli-accent-rgb),.35);
+  color:var(--ui-text-strong);
+  border-color:rgba(var(--ui-accent-rgb),.35);
   outline:none;
 }
 .nlinks{display:flex;gap:20px;font-size:.8125rem;flex-wrap:wrap;justify-content:flex-end}
 .nlinks a{
-  color:var(--netscli-text-muted);text-decoration:none;
+  color:var(--ui-text-muted);text-decoration:none;
   display:inline-flex;align-items:center;
   border-bottom:2px solid transparent;
   /* Full bar height, so the underline lands on the bar's bottom edge the way
@@ -263,9 +263,9 @@ html[data-theme='light'] nav[data-site-nav]::after{
      percentage had nothing to resolve against and the link collapsed to its
      32px content box. The underline then floated 14px above the bar's
      border. Minus 1px for the border on <nav>. */
-  height:calc(var(--netscli-nav-height) - 1px);
+  height:calc(var(--ui-nav-height) - 1px);
 }
-.nlinks a:hover{color:var(--netscli-text)}
+.nlinks a:hover{color:var(--ui-text)}
 /* Separates the links that scroll from the links that navigate.
    A rule, not a gap alone: at this size a gap on its own reads as an
    accident. Purely decorative, so it is drawn rather than announced --
@@ -289,7 +289,7 @@ html[data-theme='light'] nav[data-site-nav]::after{
   width:1px;
   height:18px;
   margin-block-start:-9px;
-  background:rgba(var(--netscli-hairline-rgb),.28);
+  background:rgba(var(--ui-hairline-rgb),.28);
 }
 
 /* Theme control.
@@ -311,7 +311,7 @@ html[data-theme='light'] nav[data-site-nav]::after{
  * already dark while this one was drawn white over a near-black bar. That is
  * as far as it is worth going: a bespoke listbox for three options would have
  * to re-implement the keyboard and screen reader behaviour this gets free. */
-.netscli-theme-select{display:inline-flex;align-items:center;height:calc(var(--netscli-nav-height) - 1px)}
+.ui-theme-select{display:inline-flex;align-items:center;height:calc(var(--ui-nav-height) - 1px)}
 
 /* Visually hidden, still announced. The control needs a name and the bar has
    no room for a visible one. */
@@ -332,8 +332,8 @@ html[data-theme='light'] nav[data-site-nav]::after{
    contains it, `location` the scroll-spy section on the landing page --
    all three should look current. */
 .nlinks a[aria-current]{
-  color:var(--netscli-text);
-  border-bottom-color:var(--netscli-accent);
+  color:var(--ui-text);
+  border-bottom-color:var(--ui-accent);
 }
 .external-link{
   display:inline-flex;
@@ -345,7 +345,7 @@ html[data-theme='light'] nav[data-site-nav]::after{
 .external-link::after{
   content:"↗";
   flex:0 0 auto;
-  color:var(--netscli-accent);
+  color:var(--ui-accent);
   font-size:.92em;
   font-weight:700;
   line-height:1;
@@ -353,7 +353,7 @@ html[data-theme='light'] nav[data-site-nav]::after{
   text-decoration:none;
 }
 .external-link:hover::after{
-  color:var(--netscli-accent-bright);
+  color:var(--ui-accent-bright);
   opacity:1;
 }
 @media(max-width:600px){
@@ -378,8 +378,8 @@ html[data-theme='light'] nav[data-site-nav]::after{
     justify-content:flex-start;
     gap:2px;
     padding:8px;
-    background:rgba(var(--netscli-bg-rgb), .98);
-    border:1px solid rgba(var(--netscli-lift-rgb),.1);
+    background:rgba(var(--ui-bg-rgb), .98);
+    border:1px solid rgba(var(--ui-lift-rgb),.1);
     border-radius:8px;
     box-shadow:0 14px 34px rgba(0,0,0,.36);
     backdrop-filter:blur(12px);
@@ -406,7 +406,7 @@ html[data-theme='light'] nav[data-site-nav]::after{
     border-inline-start:2px solid transparent;
     margin-block-start:6px;
     padding-block-start:6px;
-    border-block-start:1px solid rgba(var(--netscli-hairline-rgb),.28);
+    border-block-start:1px solid rgba(var(--ui-hairline-rgb),.28);
   }
   /* The stacked menu divides the two groups with the horizontal rule above,
      so the vertical one has nothing to do here. */
@@ -415,9 +415,9 @@ html[data-theme='light'] nav[data-site-nav]::after{
   }
   .nlinks a:hover,
   .nlinks a[aria-current]{
-    border-left-color:var(--netscli-accent);
+    border-left-color:var(--ui-accent);
     border-bottom-color:transparent;
-    background:rgba(var(--netscli-accent-rgb),.1);
+    background:rgba(var(--ui-accent-rgb),.1);
   }
 }
 

--- a/site/src/components/Surfaces.astro
+++ b/site/src/components/Surfaces.astro
@@ -57,8 +57,8 @@ const { surfaces, copy } = site;
 <style is:global>
 /* ─── SURFACE CARDS ─── */
 .surfaces-section{
-  background:var(--netscli-surface);
-  border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
+  background:var(--ui-surface);
+  border-block:1px solid rgba(var(--ui-lift-rgb),.045);
 }
 .surfaces-section::before{
   content:none;
@@ -103,8 +103,8 @@ const { surfaces, copy } = site;
 .surface.flip{direction:rtl}
 .surface.flip>*{direction:ltr;min-width:0}
 .surface-text{padding-top:0}
-.surface-text h3{font-size:1.125rem;font-weight:700;color:var(--netscli-text-strong);margin:0 0 22px}
-.surface-text p{font-size:.875rem;color:var(--netscli-text-muted);margin:0;line-height:1.6}
+.surface-text h3{font-size:1.125rem;font-weight:700;color:var(--ui-text-strong);margin:0 0 22px}
+.surface-text p{font-size:.875rem;color:var(--ui-text-muted);margin:0;line-height:1.6}
 .surface-text code{font-size:.75rem}
 .surface-visual picture{
   display:block;
@@ -113,8 +113,8 @@ const { surfaces, copy } = site;
 .surface-visual img{
   display:block;
   width:100%;height:auto;border-radius:10px;
-  border:1px solid rgba(var(--netscli-lift-rgb),.08);
-  box-shadow:var(--netscli-lift-md);
+  border:1px solid rgba(var(--ui-lift-rgb),.08);
+  box-shadow:var(--ui-lift-md);
   /* zoom-in: the lightbox opens it. Was in Hero.astro, which does not own
      this class; every component's styles are global, so each keeps to its
      own markup. */
@@ -127,11 +127,11 @@ const { surfaces, copy } = site;
 }
 .surface-visual .codeblock{
   /* Dark in both themes -- see the code-surface note in tokens.css. */
-  background:var(--netscli-code-bg);border:1px solid var(--netscli-code-border);
+  background:var(--ui-code-bg);border:1px solid var(--ui-code-border);
   border-radius:10px;padding:16px 58px 16px 20px;
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
-  font-size:.75rem;line-height:1.7;white-space:pre;overflow-x:auto;color:var(--netscli-text);
-  box-shadow:var(--netscli-lift-md);
+  font-size:.75rem;line-height:1.7;white-space:pre;overflow-x:auto;color:var(--ui-text);
+  box-shadow:var(--ui-lift-md);
   position:relative;
 }
 @media(max-width:720px){

--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -67,8 +67,8 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
       height: var(--sl-nav-height);
       min-height: var(--sl-nav-height);
       width: min(
-        calc(100vw - (var(--netscli-docs-shell-gutter, 1.5rem) * 2)),
-        var(--netscli-docs-frame-width, 1120px)
+        calc(100vw - (var(--ui-docs-shell-gutter, 1.5rem) * 2)),
+        var(--ui-docs-frame-width, 1120px)
       );
       max-width: calc(100vw - 2rem);
       margin-inline: auto;
@@ -90,16 +90,16 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
          flat -18px against a 12.4px margin, so the docs logo hung 5.5px
          further left than the identical logo on the landing bar. See
          tokens.css. */
-      transform: translateX(calc(var(--netscli-mark-width) * var(--netscli-mark-inset-ratio) * -1));
+      transform: translateX(calc(var(--ui-mark-width) * var(--ui-mark-inset-ratio) * -1));
     }
 
     .docs-mark img {
       display: block;
-      width: var(--netscli-mark-width);
+      width: var(--ui-mark-width);
       height: auto;
       /* Same token as the landing bar's `.mark`, so both bars darken the
          wordmark by the same amount on a light page. See tokens.css. */
-      filter: var(--netscli-mark-filter);
+      filter: var(--ui-mark-filter);
     }
 
     .docs-nav-links {
@@ -148,11 +148,11 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
       width: 1px;
       height: 18px;
       margin-block-start: -9px;
-      background: rgba(var(--netscli-hairline-rgb), 0.28);
+      background: rgba(var(--ui-hairline-rgb), 0.28);
     }
 
     .docs-nav-links a[aria-current] {
-      border-bottom-color: var(--netscli-accent);
+      border-bottom-color: var(--ui-accent);
     }
 
     .docs-header-search {

--- a/site/src/components/starlight/MobileMenuFooter.astro
+++ b/site/src/components/starlight/MobileMenuFooter.astro
@@ -86,8 +86,8 @@ const projectLinks = navLinks.filter((link) => link.mobileGroup === 'project');
     .docs-mobile-site-nav a:hover,
     .docs-mobile-site-nav a:focus-visible,
     .docs-mobile-site-nav a[aria-current] {
-      background: rgba(var(--netscli-accent-rgb), 0.12);
-      border-inline-start-color: var(--netscli-accent);
+      background: rgba(var(--ui-accent-rgb), 0.12);
+      border-inline-start-color: var(--ui-accent);
       color: var(--sl-color-white);
     }
 

--- a/site/src/components/starlight/PageSidebar.astro
+++ b/site/src/components/starlight/PageSidebar.astro
@@ -25,7 +25,7 @@ const { toc } = Astro.locals.starlightRoute;
   page marked.
 
   Its styles are gone from 17, 18, 20, 21, 22, 23 and 28 with it, along with a
-  `--netscli-mobile-docs-nav-height` token that only existed to offset the
+  `--ui-mobile-docs-nav-height` token that only existed to offset the
   contents bar below it, and a half-built hide-on-scroll-down treatment: 17
   declared `transform: translateY(0)` with a 140ms transition, 21 forced
   `transform: none !important` in both scroll states, and nothing ever set the
@@ -47,7 +47,7 @@ const { toc } = Astro.locals.starlightRoute;
         </div>
       </div>
       {/* Narrow screens keep the collapsed dropdown. */}
-      <div class="netscli-mobile-toc-wrapper lg:sl-hidden">
+      <div class="ui-mobile-toc-wrapper lg:sl-hidden">
         <MobileTableOfContents />
       </div>
     </>

--- a/site/src/content/docs/docs/interface-coverage.md
+++ b/site/src/content/docs/docs/interface-coverage.md
@@ -20,7 +20,7 @@ server does not expose it as a tool.
 
 ## Coverage matrix
 
-<div data-netscli-table="row-headers"></div>
+<div data-ui-table="row-headers"></div>
 
 | Capability | Desktop app | CLI | TUI | MCP |
 | --- | --- | --- | --- | --- |

--- a/site/src/content/docs/docs/operations.md
+++ b/site/src/content/docs/docs/operations.md
@@ -42,7 +42,7 @@ netscli scan 192.168.1.1 -p 22,80,443
 
 Port statuses are:
 
-<div data-netscli-table="row-headers"></div>
+<div data-ui-table="row-headers"></div>
 
 | Status | Meaning |
 | --- | --- |

--- a/site/src/content/docs/docs/packet-capture.md
+++ b/site/src/content/docs/docs/packet-capture.md
@@ -13,7 +13,7 @@ Run `netscli doctor` to check which build you have. It works on every build, unl
 
 ## Requirements
 
-<div data-netscli-table="row-headers"></div>
+<div data-ui-table="row-headers"></div>
 
 | Platform | Runtime requirement |
 | --- | --- |
@@ -45,7 +45,7 @@ netscli pcap --read capture.pcap --max-packets 100
 
 Important options:
 
-<div data-netscli-table="row-headers"></div>
+<div data-ui-table="row-headers"></div>
 
 | Option | Purpose |
 | --- | --- |

--- a/site/src/content/docs/docs/result-model.md
+++ b/site/src/content/docs/docs/result-model.md
@@ -18,7 +18,7 @@ Structured output is designed to be additive:
 
 Port scans include the existing compatibility fields plus richer status data.
 
-<div data-netscli-table="row-headers"></div>
+<div data-ui-table="row-headers"></div>
 
 | Field | Meaning |
 | --- | --- |
@@ -41,7 +41,7 @@ Banner, HTTP, TLS, and raw preview data are probe results. They are useful diagn
 
 Discovery and sweep results describe hosts.
 
-<div data-netscli-table="row-headers"></div>
+<div data-ui-table="row-headers"></div>
 
 | Field | Meaning |
 | --- | --- |
@@ -58,7 +58,7 @@ Discovery prioritizes inventory. Sweep adds exposed-service data by scanning sel
 
 DNS records expose type and value first, then additive metadata when the resolver provides it.
 
-<div data-netscli-table="row-headers"></div>
+<div data-ui-table="row-headers"></div>
 
 | Field | Meaning |
 | --- | --- |
@@ -74,7 +74,7 @@ When `ALL` records are requested, some record families can fail while others suc
 
 Inspect is a host profile. It combines host-level data with optional port scan data.
 
-<div data-netscli-table="row-headers"></div>
+<div data-ui-table="row-headers"></div>
 
 | Field | Meaning |
 | --- | --- |
@@ -89,7 +89,7 @@ Inspect is a host profile. It combines host-level data with optional port scan d
 
 mDNS/DNS-SD returns service announcements rather than generic host rows. A single device can announce multiple services.
 
-<div data-netscli-table="row-headers"></div>
+<div data-ui-table="row-headers"></div>
 
 | Field | Meaning |
 | --- | --- |
@@ -104,7 +104,7 @@ mDNS/DNS-SD returns service announcements rather than generic host rows. A singl
 
 Interface rows describe local network interfaces. ARP rows describe the local neighbor cache.
 
-<div data-netscli-table="row-headers"></div>
+<div data-ui-table="row-headers"></div>
 
 | Field | Meaning |
 | --- | --- |
@@ -121,7 +121,7 @@ ARP is not full discovery. It reports entries already known to the operating sys
 
 Packet capture results are available only in builds compiled with packet-capture support.
 
-<div data-netscli-table="row-headers"></div>
+<div data-ui-table="row-headers"></div>
 
 | Field | Meaning |
 | --- | --- |

--- a/site/src/data/site-content/surfaces.ts
+++ b/site/src/data/site-content/surfaces.ts
@@ -43,30 +43,30 @@ export const surfaces: SurfaceCard[] = [
     // discover.rs guards the reverse-lookup pass on it), so without it this
     // sample's own output would be three nulls rather than the three names
     // shown below it.
-    codeHtml: `<span style="color:var(--netscli-code-comment)">$</span> netscli scan demo.local -p 80,443 --json
-<span style="color:var(--netscli-code-punct)">[</span>
-  <span style="color:var(--netscli-code-punct)">{</span> <span style="color:var(--netscli-code-key)">"port"</span>: 80,  <span style="color:var(--netscli-code-key)">"open"</span>: true, <span style="color:var(--netscli-code-key)">"service"</span>: <span style="color:var(--netscli-code-string)">"http"</span>  <span style="color:var(--netscli-code-punct)">}</span>,
-  <span style="color:var(--netscli-code-punct)">{</span> <span style="color:var(--netscli-code-key)">"port"</span>: 443, <span style="color:var(--netscli-code-key)">"open"</span>: true, <span style="color:var(--netscli-code-key)">"service"</span>: <span style="color:var(--netscli-code-string)">"https"</span> <span style="color:var(--netscli-code-punct)">}</span>
-<span style="color:var(--netscli-code-punct)">]</span>
+    codeHtml: `<span style="color:var(--ui-code-comment)">$</span> netscli scan demo.local -p 80,443 --json
+<span style="color:var(--ui-code-punct)">[</span>
+  <span style="color:var(--ui-code-punct)">{</span> <span style="color:var(--ui-code-key)">"port"</span>: 80,  <span style="color:var(--ui-code-key)">"open"</span>: true, <span style="color:var(--ui-code-key)">"service"</span>: <span style="color:var(--ui-code-string)">"http"</span>  <span style="color:var(--ui-code-punct)">}</span>,
+  <span style="color:var(--ui-code-punct)">{</span> <span style="color:var(--ui-code-key)">"port"</span>: 443, <span style="color:var(--ui-code-key)">"open"</span>: true, <span style="color:var(--ui-code-key)">"service"</span>: <span style="color:var(--ui-code-string)">"https"</span> <span style="color:var(--ui-code-punct)">}</span>
+<span style="color:var(--ui-code-punct)">]</span>
 
-<span style="color:var(--netscli-code-comment)">$</span> netscli discover --resolve --json | jq '.[].hostname'
-<span style="color:var(--netscli-code-string)">"workstation.local"</span>
-<span style="color:var(--netscli-code-string)">"phone.local"</span>
-<span style="color:var(--netscli-code-string)">"pi.local"</span>`,
+<span style="color:var(--ui-code-comment)">$</span> netscli discover --resolve --json | jq '.[].hostname'
+<span style="color:var(--ui-code-string)">"workstation.local"</span>
+<span style="color:var(--ui-code-string)">"phone.local"</span>
+<span style="color:var(--ui-code-string)">"pi.local"</span>`,
   },
   {
     title: 'MCP server',
     body:
       'Run <code>netscli serve</code> when an MCP client needs local network tools. Discovery, scanning, ping, DNS, ARP and interfaces are all exposed as structured tools, so an agent gets the same results you would, in a shape it can parse.',
-    codeHtml: `<span style="color:var(--netscli-code-comment)">// claude_desktop_config.json</span>
-<span style="color:var(--netscli-code-punct)">{</span>
-  <span style="color:var(--netscli-code-key)">"mcpServers"</span>: <span style="color:var(--netscli-code-punct)">{</span>
-    <span style="color:var(--netscli-code-key)">"netscli"</span>: <span style="color:var(--netscli-code-punct)">{</span>
-      <span style="color:var(--netscli-code-key)">"command"</span>: <span style="color:var(--netscli-code-string)">"netscli"</span>,
-      <span style="color:var(--netscli-code-key)">"args"</span>: [<span style="color:var(--netscli-code-string)">"serve"</span>]
-    <span style="color:var(--netscli-code-punct)">}</span>
-  <span style="color:var(--netscli-code-punct)">}</span>
-<span style="color:var(--netscli-code-punct)">}</span>`,
+    codeHtml: `<span style="color:var(--ui-code-comment)">// claude_desktop_config.json</span>
+<span style="color:var(--ui-code-punct)">{</span>
+  <span style="color:var(--ui-code-key)">"mcpServers"</span>: <span style="color:var(--ui-code-punct)">{</span>
+    <span style="color:var(--ui-code-key)">"netscli"</span>: <span style="color:var(--ui-code-punct)">{</span>
+      <span style="color:var(--ui-code-key)">"command"</span>: <span style="color:var(--ui-code-string)">"netscli"</span>,
+      <span style="color:var(--ui-code-key)">"args"</span>: [<span style="color:var(--ui-code-string)">"serve"</span>]
+    <span style="color:var(--ui-code-punct)">}</span>
+  <span style="color:var(--ui-code-punct)">}</span>
+<span style="color:var(--ui-code-punct)">}</span>`,
     flip: true,
   },
 ];

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -43,8 +43,8 @@ import Footer from '../components/Footer.astro';
      never matched. In the light theme this painted the whole 404 page
      near-black under light-theme text -- the heading measured 1.06:1. */
   background:
-    linear-gradient(180deg,rgba(var(--netscli-accent-rgb),.045),transparent 20rem),
-    var(--netscli-bg);
+    linear-gradient(180deg,rgba(var(--ui-accent-rgb),.045),transparent 20rem),
+    var(--ui-bg);
 }
 .not-found-shell{
   width:min(720px,100%);
@@ -66,7 +66,7 @@ import Footer from '../components/Footer.astro';
 }
 .not-found .eyebrow{
   margin:0 0 12px;
-  color:var(--netscli-accent);
+  color:var(--ui-accent);
   font-size:.75rem;
   font-weight:800;
   letter-spacing:.14em;
@@ -74,7 +74,7 @@ import Footer from '../components/Footer.astro';
 }
 .not-found h1{
   margin:0;
-  color:var(--netscli-text-strong);
+  color:var(--ui-text-strong);
   font-size:clamp(2.4rem,6vw,5rem);
   line-height:1.05;
   letter-spacing:-.035em;
@@ -82,7 +82,7 @@ import Footer from '../components/Footer.astro';
 .not-found p{
   margin:20px 0 0;
   max-width:43rem;
-  color:var(--netscli-text);
+  color:var(--ui-text);
   font-size:clamp(1rem,1.6vw,1.18rem);
 }
 .not-found-actions{
@@ -97,29 +97,29 @@ import Footer from '../components/Footer.astro';
   align-items:center;
   justify-content:center;
   padding:9px 17px;
-  border:1px solid rgba(var(--netscli-accent-rgb),.35);
+  border:1px solid rgba(var(--ui-accent-rgb),.35);
   border-radius:7px;
-  color:var(--netscli-text);
+  color:var(--ui-text);
   text-decoration:none;
-  background:rgba(var(--netscli-lift-rgb),.025);
+  background:rgba(var(--ui-lift-rgb),.025);
   font-weight:700;
 }
 .not-found-actions a.primary{
-  color:var(--netscli-on-accent);
-  border-color:var(--netscli-accent);
-  background:var(--netscli-accent);
+  color:var(--ui-on-accent);
+  border-color:var(--ui-accent);
+  background:var(--ui-accent);
 }
 .not-found-actions a:hover,
 .not-found-actions a:focus-visible{
   outline:0;
   border-color:rgba(30,220,255,.62);
-  color:var(--netscli-text-strong);
+  color:var(--ui-text-strong);
 }
 .not-found-actions a.primary:hover,
 .not-found-actions a.primary:focus-visible{
-  color:var(--netscli-on-accent);
-  background:var(--netscli-accent-bright);
-  border-color:var(--netscli-accent-bright);
+  color:var(--ui-on-accent);
+  background:var(--ui-accent-bright);
+  border-color:var(--ui-accent-bright);
 }
 @media(max-width:820px){
   .not-found{

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -120,22 +120,22 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
 <style is:global>
 /* ─── CHANGELOG ─── */
 .changelog-shell{
-  max-width:var(--netscli-shell-width);margin:0 auto;padding:64px var(--netscli-shell-gutter) 86px;
+  max-width:var(--ui-shell-width);margin:0 auto;padding:64px var(--ui-shell-gutter) 86px;
 }
 .changelog-hero{
-  border-bottom:1px solid rgba(var(--netscli-lift-rgb),.08);
+  border-bottom:1px solid rgba(var(--ui-lift-rgb),.08);
   padding-bottom:28px;margin-bottom:28px;
 }
 .changelog-kicker{
-  margin:0 0 8px;color:var(--netscli-accent);font-size:.75rem;font-weight:700;
+  margin:0 0 8px;color:var(--ui-accent);font-size:.75rem;font-weight:700;
   text-transform:uppercase;letter-spacing:.08em;
 }
 .changelog-hero h1{
-  margin:0;color:var(--netscli-text-strong);font-size:clamp(2rem,4vw,3rem);
+  margin:0;color:var(--ui-text-strong);font-size:clamp(2rem,4vw,3rem);
   line-height:1.1;letter-spacing:-.02em;
 }
 .changelog-hero p{
-  margin:12px 0 0;color:var(--netscli-text-muted);font-size:.95rem;max-width:680px;
+  margin:12px 0 0;color:var(--ui-text-muted);font-size:.95rem;max-width:680px;
 }
 /* A text link, not a button. Two bordered pills sat under the intro as if
    they were the page's primary actions; the only one worth keeping is a
@@ -146,11 +146,11 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   font-size:.875rem;
 }
 .changelog-actions a{
-  color:var(--netscli-accent);
+  color:var(--ui-accent);
   text-decoration:underline;
   text-underline-offset:3px;
 }
-.changelog-actions a:hover{color:var(--netscli-accent-bright)}
+.changelog-actions a:hover{color:var(--ui-accent-bright)}
 .changelog-content{
   display:grid;
   grid-template-columns:minmax(0,1fr) 8.5rem;
@@ -162,10 +162,10 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
 .release-unreleased{
   margin-left:10px;
   padding:2px 8px;
-  border:1px solid rgba(var(--netscli-accent-rgb),.32);
+  border:1px solid rgba(var(--ui-accent-rgb),.32);
   border-radius:999px;
-  background:rgba(var(--netscli-accent-rgb),.06);
-  color:var(--netscli-accent);
+  background:rgba(var(--ui-accent-rgb),.06);
+  color:var(--ui-accent);
   font-size:.6875rem;
   font-weight:600;
   letter-spacing:.02em;
@@ -176,11 +176,11 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   position:sticky;
   top:calc(var(--nav-height, 72px) + 22px);
   padding-left:18px;
-  border-left:1px solid rgba(var(--netscli-lift-rgb),.08);
+  border-left:1px solid rgba(var(--ui-lift-rgb),.08);
 }
 .release-timeline p{
   margin:0 0 11px;
-  color:var(--netscli-text-muted);
+  color:var(--ui-text-muted);
   font-size:.72rem;
   font-weight:700;
   letter-spacing:.08em;
@@ -196,7 +196,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   gap:5px;
 }
 .release-timeline-year{
-  color:var(--netscli-text-strong);
+  color:var(--ui-text-strong);
   font-size:.82rem;
   line-height:1.2;
 }
@@ -208,7 +208,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   gap:10px;
   min-height:24px;
   padding:3px 0 3px 10px;
-  color:var(--netscli-text-muted);
+  color:var(--ui-text-muted);
   font-size:.78rem;
   line-height:1.2;
   text-decoration:none;
@@ -225,27 +225,27 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   transform:translateY(-50%);
 }
 .release-timeline-link small{
-  color:var(--netscli-text-muted);
+  color:var(--ui-text-muted);
   font-size:.68rem;
 }
 .release-timeline-link:hover,
 .release-timeline-link:focus-visible,
 .release-timeline-link.active{
-  color:var(--netscli-accent-bright);
+  color:var(--ui-accent-bright);
   outline:0;
 }
 .release-timeline-link:hover::before,
 .release-timeline-link:focus-visible::before,
 .release-timeline-link.active::before{
-  background:var(--netscli-accent);
+  background:var(--ui-accent);
 }
 .release-timeline-empty{
-  color:var(--netscli-text-muted);
+  color:var(--ui-text-muted);
   font-size:.78rem;
 }
 .release-item{
-  background:rgba(var(--netscli-lift-rgb),.028);
-  border:1px solid rgba(var(--netscli-lift-rgb),.085);
+  background:rgba(var(--ui-lift-rgb),.028);
+  border:1px solid rgba(var(--ui-lift-rgb),.085);
   border-radius:8px;overflow:hidden;
   max-width:100%;
   min-width:0;
@@ -254,20 +254,20 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
 }
 .release-head{
   display:flex;align-items:center;justify-content:space-between;gap:16px;
-  padding:10px 20px;border-bottom:1px solid rgba(var(--netscli-lift-rgb),.07);
-  background:rgba(var(--netscli-lift-rgb),.018);
+  padding:10px 20px;border-bottom:1px solid rgba(var(--ui-lift-rgb),.07);
+  background:rgba(var(--ui-lift-rgb),.018);
 }
 .release-title-group{min-width:0}
-.release-item h2{margin:0;font-size:1.08rem;color:var(--netscli-text-strong);line-height:1.35;min-width:0;overflow-wrap:anywhere}
+.release-item h2{margin:0;font-size:1.08rem;color:var(--ui-text-strong);line-height:1.35;min-width:0;overflow-wrap:anywhere}
 .release-item h2 a{color:inherit;text-decoration:none;min-width:0;overflow-wrap:anywhere}
 .release-item h2 a:hover .external-link-label{text-decoration:underline;text-underline-offset:3px}
 .release-meta{
-  flex:0 0 auto;margin:0;color:var(--netscli-text-muted);font-size:.76rem;
+  flex:0 0 auto;margin:0;color:var(--ui-text-muted);font-size:.76rem;
   line-height:1.4;white-space:nowrap;text-align:right;
 }
 .release-body{
   position:relative;
-  padding:20px 20px 22px;color:var(--netscli-text);font-size:.9rem;line-height:1.65;
+  padding:20px 20px 22px;color:var(--ui-text);font-size:.9rem;line-height:1.65;
   width:100%;min-width:0;max-width:100%;box-sizing:border-box;
   overflow-wrap:anywhere;word-break:normal;
 }
@@ -299,13 +299,13 @@ html[data-js] .release-collapsible:not(.release-expanded) .release-body::after{
   content:"";
   position:absolute;left:0;right:0;bottom:0;height:84px;
   pointer-events:none;
-  background:linear-gradient(180deg,rgba(var(--netscli-bg-rgb), 0),rgba(var(--netscli-bg-rgb), .95) 70%,var(--netscli-surface));
+  background:linear-gradient(180deg,rgba(var(--ui-bg-rgb), 0),rgba(var(--ui-bg-rgb), .95) 70%,var(--ui-surface));
 }
 .release-body>*+*{margin-top:14px}
 .release-summary{
   margin:0;
   max-width:none;
-  color:var(--netscli-text);
+  color:var(--ui-text);
   font-size:.94rem;
   line-height:1.65;
   padding:0;
@@ -319,7 +319,7 @@ html[data-js] .release-collapsible:not(.release-expanded) .release-body::after{
  * introduces. More space above than below now, which is the relationship a
  * section heading is supposed to have. */
 .release-body .release-heading{
-  color:var(--netscli-text);font-size:.96rem;line-height:1.35;
+  color:var(--ui-text);font-size:.96rem;line-height:1.35;
   margin:26px 0 9px;
 }
 .release-body .release-heading:first-child{margin-top:0}
@@ -337,40 +337,40 @@ html[data-js] .release-collapsible:not(.release-expanded) .release-body::after{
 .release-body :not(pre)>code{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;
   font-size:.86em;line-height:1.45;
-  background:rgba(var(--netscli-accent-rgb),.09);color:var(--netscli-accent-bright);
-  border:1px solid rgba(var(--netscli-accent-rgb),.18);border-radius:4px;
+  background:rgba(var(--ui-accent-rgb),.09);color:var(--ui-accent-bright);
+  border:1px solid rgba(var(--ui-accent-rgb),.18);border-radius:4px;
   padding:.08em .34em;white-space:normal;overflow-wrap:anywhere;word-break:break-word;
 }
 .release-body .release-code{
   position:relative;margin:0;max-width:100%;overflow-x:auto;
-  background:var(--netscli-surface-raised);border:1px solid rgba(140,149,166,.2);
-  border-radius:8px;padding:.82rem 1rem;color:var(--netscli-text);
+  background:var(--ui-surface-raised);border:1px solid rgba(140,149,166,.2);
+  border-radius:8px;padding:.82rem 1rem;color:var(--ui-text);
   box-shadow:none;
 }
 .release-body .release-code::before{
   content:"";position:absolute;inset-block-start:0;inset-inline:0;
-  height:2px;background:rgba(var(--netscli-accent-rgb),.55);
+  height:2px;background:rgba(var(--ui-accent-rgb),.55);
 }
 .release-body .release-code-content{
   display:block;background:transparent;border:0;border-radius:0;
   color:inherit;font-size:.82rem;line-height:1.64;padding:0;
   white-space:pre;
 }
-.release-body a{color:var(--netscli-accent);text-decoration:none}
+.release-body a{color:var(--ui-accent);text-decoration:none}
 .release-body a,
 .release-body a .external-link-label{
   min-width:0;overflow-wrap:anywhere;word-break:break-word;
 }
 .release-body a .external-link-label{text-decoration:underline;text-underline-offset:3px}
-.release-body a:hover{color:var(--netscli-accent-bright)}
-.release-body a:hover .external-link-label{text-decoration-color:var(--netscli-accent-bright)}
+.release-body a:hover{color:var(--ui-accent-bright)}
+.release-body a:hover .external-link-label{text-decoration-color:var(--ui-accent-bright)}
 .release-quote{
-  margin:0;max-width:none;border-left:3px solid rgba(var(--netscli-accent-rgb),.55);
-  padding:8px 12px;background:rgba(var(--netscli-accent-rgb),.065);color:var(--netscli-text);
+  margin:0;max-width:none;border-left:3px solid rgba(var(--ui-accent-rgb),.55);
+  padding:8px 12px;background:rgba(var(--ui-accent-rgb),.065);color:var(--ui-text);
 }
 .release-empty{
-  color:var(--netscli-text-muted);background:rgba(var(--netscli-lift-rgb),.03);
-  border:1px dashed rgba(var(--netscli-lift-rgb),.12);border-radius:10px;padding:16px;
+  color:var(--ui-text-muted);background:rgba(var(--ui-lift-rgb),.03);
+  border:1px dashed rgba(var(--ui-lift-rgb),.12);border-radius:10px;padding:16px;
 }
 .release-disclosure{
   /* `display` is set above, gated on data-js. */
@@ -385,7 +385,7 @@ html[data-js] .release-collapsible:not(.release-expanded) .release-body::after{
   border:0;
   border-radius:0;
   background:transparent;
-  color:var(--netscli-accent);
+  color:var(--ui-accent);
   font:inherit;
   font-size:.8rem;
   font-weight:400;
@@ -397,11 +397,11 @@ html[data-js] .release-collapsible:not(.release-expanded) .release-body::after{
 }
 .release-toggle::after{
   content:"";
-  color:var(--netscli-accent-bright);
+  color:var(--ui-accent-bright);
 }
 .release-toggle:hover,
 .release-toggle:focus-visible{
-  color:var(--netscli-accent-bright);
+  color:var(--ui-accent-bright);
   background:transparent;
   outline:0;
 }

--- a/site/src/scripts/docs-header.ts
+++ b/site/src/scripts/docs-header.ts
@@ -42,7 +42,7 @@ export function initDocsHeader(): void {
   window.addEventListener('resize', updateMobileScrollDirection);
 
   const placeMobileTableOfContents = () => {
-    const wrapper = document.querySelector('.netscli-mobile-toc-wrapper');
+    const wrapper = document.querySelector('.ui-mobile-toc-wrapper');
     const titlePanel = document.querySelector(
       '.main-pane .content-panel:first-of-type, .content-panel:first-of-type'
     );
@@ -155,8 +155,8 @@ export function initDocsHeader(): void {
     if (!drawer) return;
 
     const maxScroll = drawer.scrollHeight - drawer.clientHeight;
-    drawer.classList.toggle('netscli-search-overflow-top', drawer.scrollTop > 2);
-    drawer.classList.toggle('netscli-search-overflow-bottom', maxScroll - drawer.scrollTop > 2);
+    drawer.classList.toggle('ui-search-overflow-top', drawer.scrollTop > 2);
+    drawer.classList.toggle('ui-search-overflow-bottom', maxScroll - drawer.scrollTop > 2);
   };
 
   let searchOverflowFrame = 0;

--- a/site/src/scripts/docs-search-keys.ts
+++ b/site/src/scripts/docs-search-keys.ts
@@ -76,7 +76,7 @@ export function initDocsSearchKeys(): void {
  */
 const MESSAGE_SELECTOR = '.pagefind-ui__message';
 const SEARCH_TIMEOUT_MS = 8000;
-const OFFLINE_NOTE = 'netscli-search-offline';
+const OFFLINE_NOTE = 'ui-search-offline';
 
 export function initDocsSearchResilience(): void {
   let timer: ReturnType<typeof setTimeout> | undefined;

--- a/site/src/scripts/docs-tables.ts
+++ b/site/src/scripts/docs-tables.ts
@@ -54,17 +54,17 @@ export function applyDocsTableBehaviour(): void {
   };
 
   const tableOptionClasses = new Map([
-    ['netscli-table: row-headers', 'table-row-headers'],
-    ['netscli-table: plain-first-column', 'table-plain-first-column'],
+    ['ui-table: row-headers', 'table-row-headers'],
+    ['ui-table: plain-first-column', 'table-plain-first-column'],
   ]);
 
   const applyTableOptions = () => {
     const content = document.querySelector('.sl-markdown-content');
     if (!content) return;
 
-    content.querySelectorAll('[data-netscli-table]').forEach((marker) => {
-      const markerValue = marker.getAttribute('data-netscli-table')?.trim().toLowerCase();
-      const option = tableOptionClasses.get(`netscli-table: ${markerValue}`);
+    content.querySelectorAll('[data-ui-table]').forEach((marker) => {
+      const markerValue = marker.getAttribute('data-ui-table')?.trim().toLowerCase();
+      const option = tableOptionClasses.get(`ui-table: ${markerValue}`);
       if (!option) return;
 
       tagNextTableElement(marker, option);
@@ -81,10 +81,10 @@ export function applyDocsTableBehaviour(): void {
     content.querySelectorAll('table').forEach((table) => {
       labelCellsWithTheirColumn(table);
 
-      if (table.parentElement?.classList.contains('netscli-table-scroll')) return;
+      if (table.parentElement?.classList.contains('ui-table-scroll')) return;
 
       const wrapper = document.createElement('div');
-      wrapper.className = 'netscli-table-scroll';
+      wrapper.className = 'ui-table-scroll';
       // The wrapper is the horizontally-scrollable region; make it reachable
       // by keyboard (axe scrollable-region-focusable) since the table inside
       // it isn't otherwise a focusable element.

--- a/site/src/styles/code-surface.css
+++ b/site/src/styles/code-surface.css
@@ -23,16 +23,16 @@
    * Contrast on #10151b: fg 13.32, comment 6.52, punct 5.31, key 6.67,
    * string 8.44, inline accent 13.06. scripts/contrast-sweep.mjs measures
    * these as rendered rather than trusting the numbers here. */
-  --netscli-code-bg: #10151b;
-  --netscli-code-fg: #d7dce5;
-  --netscli-code-border: rgba(255, 255, 255, 0.08);
+  --ui-code-bg: #10151b;
+  --ui-code-fg: #d7dce5;
+  --ui-code-border: rgba(255, 255, 255, 0.08);
   /* Opaque, for the 1px gaps between stacked command rows. A translucent
      white there would composite against the PAGE, not the panel, and render
      as near-white lines across a dark block in the light theme. */
-  --netscli-code-divider: #232a34;
+  --ui-code-divider: #232a34;
   /* Inline `code` ink. The dark accent-bright in both themes, because the
      chip behind it is dark in both. */
-  --netscli-code-inline-fg: #86efac;
+  --ui-code-inline-fg: #86efac;
 
   /* ---- Code sample colours -------------------------------------------
    *
@@ -50,8 +50,8 @@
    * measured the punctuation grey at 4.46:1 on the page and 3.99:1 on a card
    * -- below AA, and wrong since long before the light theme. They are also
    * no longer #888888 beside #7b7b7b, a 3% difference no reader can see. */
-  --netscli-code-comment: #9a9a9a;
-  --netscli-code-punct: #8a8a8a;
-  --netscli-code-key: #7c9fc7;
-  --netscli-code-string: #8fbc7f;
+  --ui-code-comment: #9a9a9a;
+  --ui-code-punct: #8a8a8a;
+  --ui-code-key: #7c9fc7;
+  --ui-code-string: #8fbc7f;
 }

--- a/site/src/styles/docs/README.md
+++ b/site/src/styles/docs/README.md
@@ -19,7 +19,7 @@ way are short.
 | `tables.css`, `tables-narrow.css` | Tables; what changes below 72rem. |
 | `search.css`, `search-input.css`, `search-results.css` | The search dialog, its input row and states, its results. |
 
-The brand palette itself (`--netscli-accent` and friends) is in
+The brand palette itself (`--ui-accent` and friends) is in
 `../tokens.css`, which the landing page loads too. The code surface tokens
 are in `../code-surface.css` for the same reason.
 

--- a/site/src/styles/docs/base.css
+++ b/site/src/styles/docs/base.css
@@ -61,12 +61,12 @@ body[data-search-modal-open] {
 /* ---- Scrollbars ------------------------------------------------------ */
 html {
   scrollbar-width: thin;
-  scrollbar-color: rgba(var(--netscli-hairline-rgb), 0.5) rgba(17, 17, 17, 0.9);
+  scrollbar-color: rgba(var(--ui-hairline-rgb), 0.5) rgba(17, 17, 17, 0.9);
 }
 
 * {
   scrollbar-width: thin;
-  scrollbar-color: rgba(var(--netscli-hairline-rgb), 0.42) rgba(var(--netscli-lift-rgb), 0.035);
+  scrollbar-color: rgba(var(--ui-hairline-rgb), 0.42) rgba(var(--ui-lift-rgb), 0.035);
 }
 
 ::-webkit-scrollbar {
@@ -79,7 +79,7 @@ html {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(var(--netscli-hairline-rgb), 0.45);
+  background: rgba(var(--ui-hairline-rgb), 0.45);
   border: 3px solid #151515;
   border-radius: 999px;
 }
@@ -97,7 +97,7 @@ html[data-theme='light'] {
 }
 
 html[data-theme='light'] * {
-  scrollbar-color: rgba(68, 81, 106, 0.36) rgba(var(--netscli-hairline-rgb), 0.045);
+  scrollbar-color: rgba(68, 81, 106, 0.36) rgba(var(--ui-hairline-rgb), 0.045);
 }
 
 html[data-theme='light'] ::-webkit-scrollbar-track {

--- a/site/src/styles/docs/code.css
+++ b/site/src/styles/docs/code.css
@@ -9,35 +9,35 @@
   --ec-codePadInl: 1.15rem;
   --ec-codePadBlk: 0.62rem;
   --ec-codeLineHt: 1.52;
-  --ec-codeBg: var(--netscli-code-bg);
-  --ec-codeFg: var(--netscli-code-fg);
-  --ec-brdCol: rgba(var(--netscli-hairline-rgb), 0.2);
+  --ec-codeBg: var(--ui-code-bg);
+  --ec-codeFg: var(--ui-code-fg);
+  --ec-brdCol: rgba(var(--ui-hairline-rgb), 0.2);
   --ec-focusBrd: rgba(215, 220, 229, 0.8);
-  --ec-sbThumbCol: rgba(var(--netscli-hairline-rgb), 0.24);
+  --ec-sbThumbCol: rgba(var(--ui-hairline-rgb), 0.24);
   --ec-sbThumbHoverCol: rgba(194, 202, 216, 0.42);
   --ec-frm-frameBoxShdCssVal: 0 16px 36px rgba(0, 0, 0, 0.3);
-  --ec-frm-trmBg: var(--netscli-code-bg);
+  --ec-frm-trmBg: var(--ui-code-bg);
   --ec-frm-trmTtbBg: #202733;
-  --ec-frm-trmTtbBrdBtmCol: rgba(var(--netscli-hairline-rgb), 0.2);
+  --ec-frm-trmTtbBrdBtmCol: rgba(var(--ui-hairline-rgb), 0.2);
   --ec-frm-trmTtbDotsFg: #8c95a6;
   --ec-frm-trmTtbDotsOpa: 0.48;
-  --ec-frm-inlBtnFg: var(--netscli-accent-high);
-  --ec-frm-inlBtnBg: var(--netscli-accent-high);
-  --ec-frm-inlBtnBrd: var(--netscli-accent-high);
+  --ec-frm-inlBtnFg: var(--ui-accent-high);
+  --ec-frm-inlBtnBg: var(--ui-accent-high);
+  --ec-frm-inlBtnBrd: var(--ui-accent-high);
   --ec-frm-tooltipSuccessBg: #2b313d;
   /* The copy button's size, and the room the code keeps clear for it. */
-  --netscli-code-copy-size: 1.75rem;
-  --netscli-code-copy-space: 3rem;
-  --netscli-code-copy-inset: 0.48rem;
+  --ui-code-copy-size: 1.75rem;
+  --ui-code-copy-space: 3rem;
+  --ui-code-copy-inset: 0.48rem;
   margin-block: 0.9rem 1.2rem;
 }
 
 .sl-markdown-content .expressive-code .frame {
   position: relative;
   overflow: hidden;
-  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.2);
+  border: 1px solid rgba(var(--ui-hairline-rgb), 0.2);
   border-radius: 8px;
-  background: var(--netscli-code-bg);
+  background: var(--ui-code-bg);
   box-shadow: none;
 }
 
@@ -49,28 +49,28 @@
   inset-inline: 0;
   z-index: 1;
   height: 2px;
-  background: rgba(var(--netscli-accent-rgb), 0.55);
+  background: rgba(var(--ui-accent-rgb), 0.55);
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .frame {
-  border-color: rgba(var(--netscli-hairline-rgb), 0.13);
+  border-color: rgba(var(--ui-hairline-rgb), 0.13);
   box-shadow: none;
 }
 
 html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
-  background: rgba(var(--netscli-accent-rgb), 0.42);
+  background: rgba(var(--ui-accent-rgb), 0.42);
 }
 
 .sl-markdown-content .expressive-code pre {
-  background: var(--netscli-code-bg);
+  background: var(--ui-code-bg);
 }
 
 .sl-markdown-content .expressive-code code {
-  padding-inline-end: var(--netscli-code-copy-space);
+  padding-inline-end: var(--ui-code-copy-space);
 }
 
 .sl-markdown-content .expressive-code .ec-line:first-child .code {
-  padding-inline-end: calc(var(--ec-codePadInl) + var(--netscli-code-copy-space));
+  padding-inline-end: calc(var(--ec-codePadInl) + var(--ui-code-copy-space));
 }
 
 /* Terminal frames: no title bar, the top border moves onto the code. */
@@ -122,14 +122,14 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
 
 /* ---- Copy button ------------------------------------------------------ */
 .sl-markdown-content .expressive-code .copy {
-  inset-inline-end: calc(var(--ec-brdWd) + var(--netscli-code-copy-inset));
-  inset-block-start: calc(var(--ec-brdWd) + var(--netscli-code-copy-inset));
+  inset-inline-end: calc(var(--ec-brdWd) + var(--ui-code-copy-inset));
+  inset-block-start: calc(var(--ec-brdWd) + var(--ui-code-copy-inset));
 }
 
 .sl-markdown-content .expressive-code .copy button {
-  width: var(--netscli-code-copy-size);
-  height: var(--netscli-code-copy-size);
-  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.18);
+  width: var(--ui-code-copy-size);
+  height: var(--ui-code-copy-size);
+  border: 1px solid rgba(var(--ui-hairline-rgb), 0.18);
   border-radius: 5px;
   background: #252b36;
   opacity: 0.9;
@@ -137,7 +137,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
 }
 
 .sl-markdown-content .expressive-code .copy button::before {
-  border-color: rgba(var(--netscli-hairline-rgb), 0.38);
+  border-color: rgba(var(--ui-hairline-rgb), 0.38);
 }
 
 .sl-markdown-content .expressive-code .copy button::after {
@@ -147,7 +147,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
 .sl-markdown-content .expressive-code .copy button:hover,
 .sl-markdown-content .expressive-code .copy button:focus-visible {
   opacity: 1;
-  border-color: rgba(var(--netscli-accent-rgb), 0.42);
+  border-color: rgba(var(--ui-accent-rgb), 0.42);
   background: #2b313d;
 }
 
@@ -179,7 +179,7 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
 }
 
 .sl-markdown-content .expressive-code .copy button[data-copied] {
-  border-color: rgba(var(--netscli-hairline-rgb), 0.18);
+  border-color: rgba(var(--ui-hairline-rgb), 0.18);
   background: #252b36;
   color: rgba(216, 222, 232, 0.46);
 }
@@ -225,6 +225,6 @@ html[data-theme='light'] .sl-markdown-content .expressive-code .frame::before {
    untitled blocks keep a line of air above the code for it. */
 @media (max-width: 700px) {
   .sl-markdown-content .expressive-code .frame:not(.has-title) pre {
-    padding-block-start: calc(var(--netscli-code-copy-size) + 0.5rem);
+    padding-block-start: calc(var(--ui-code-copy-size) + 0.5rem);
   }
 }

--- a/site/src/styles/docs/content.css
+++ b/site/src/styles/docs/content.css
@@ -36,7 +36,7 @@
 }
 
 /* Markers the table script reads (src/scripts/docs-tables.ts); never shown. */
-.sl-markdown-content [data-netscli-table] {
+.sl-markdown-content [data-ui-table] {
   display: none;
 }
 
@@ -49,15 +49,15 @@
 .sl-markdown-content .sl-anchor-link,
 .sl-markdown-content .sl-anchor-link:focus,
 .sl-markdown-content .sl-heading-wrapper:hover .sl-anchor-link {
-  color: var(--netscli-accent);
+  color: var(--ui-accent);
 }
 
 .sl-markdown-content a:hover {
-  color: var(--netscli-accent-bright);
+  color: var(--ui-accent-bright);
 }
 
 .sl-markdown-content .sl-anchor-icon > svg {
-  color: var(--netscli-accent);
+  color: var(--ui-accent);
   height: var(--sl-anchor-icon-size);
 }
 
@@ -88,7 +88,7 @@ html[data-theme='light'] .sl-markdown-content a:hover {
   background: none;
   -webkit-mask: none;
   mask: none;
-  color: var(--netscli-accent);
+  color: var(--ui-accent);
   font-size: 0.92em;
   font-weight: 700;
   line-height: 1;
@@ -96,7 +96,7 @@ html[data-theme='light'] .sl-markdown-content a:hover {
 
 .external-link:hover::after,
 .sl-markdown-content a[href^='http']:hover::after {
-  color: var(--netscli-accent-bright);
+  color: var(--ui-accent-bright);
 }
 
 html[data-theme='light'] .external-link::after,
@@ -111,15 +111,15 @@ html[data-theme='light'] .sl-markdown-content a[href^='http']:hover::after {
 
 /* ---- Inline code ----------------------------------------------------- */
 .sl-markdown-content :not(pre) > code {
-  border: 1px solid var(--netscli-code-border);
+  border: 1px solid var(--ui-code-border);
   border-radius: 0.24rem;
   font-family: var(--__sl-font-mono);
   font-size: 0.9em;
   line-height: 1.45;
   padding: 0.08em 0.34em;
   white-space: nowrap;
-  background: var(--netscli-code-bg);
-  color: var(--netscli-code-inline-fg);
+  background: var(--ui-code-bg);
+  color: var(--ui-code-inline-fg);
 }
 
 /* ---- Callouts -------------------------------------------------------- */
@@ -170,7 +170,7 @@ html[data-theme='light'] .sl-markdown-content a[href^='http']:hover::after {
   background: transparent;
   background-image: none;
   box-shadow: none;
-  border-color: var(--netscli-panel-hover-border);
+  border-color: var(--ui-panel-hover-border);
 }
 
 .pagination-links a:hover :where(.link-subtitle, span:not(.link-title)),
@@ -189,7 +189,7 @@ html[data-theme='light'] .pagination-links a:focus-visible {
   color: var(--sl-color-white);
   background: transparent;
   background-image: none;
-  border-color: rgba(var(--netscli-accent-rgb), 0.22);
+  border-color: rgba(var(--ui-accent-rgb), 0.22);
   box-shadow: none;
 }
 

--- a/site/src/styles/docs/header-controls.css
+++ b/site/src/styles/docs/header-controls.css
@@ -13,9 +13,9 @@ header.header site-search button {
 site-search button[data-open-modal] {
   border: 1px solid var(--sl-color-hairline-light);
   border-radius: 6px;
-  background: rgba(var(--netscli-lift-rgb), 0.035);
+  background: rgba(var(--ui-lift-rgb), 0.035);
   color: var(--sl-color-gray-2);
-  box-shadow: inset 0 1px 0 rgba(var(--netscli-lift-rgb), 0.035);
+  box-shadow: inset 0 1px 0 rgba(var(--ui-lift-rgb), 0.035);
 }
 
 site-search button[data-open-modal] svg {
@@ -23,9 +23,9 @@ site-search button[data-open-modal] svg {
 }
 
 site-search button[data-open-modal] > kbd {
-  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.24);
+  border: 1px solid rgba(var(--ui-hairline-rgb), 0.24);
   border-radius: 4px;
-  background: rgba(var(--netscli-lift-rgb), 0.04);
+  background: rgba(var(--ui-lift-rgb), 0.04);
   color: var(--sl-color-gray-3);
 }
 
@@ -38,34 +38,34 @@ site-search button[data-open-modal]:focus-visible {
 site-search button[data-open-modal]:hover {
   color: var(--sl-color-white);
   box-shadow:
-    0 0 0 1px rgba(var(--netscli-accent-rgb), 0.16),
-    inset 0 1px 0 rgba(var(--netscli-lift-rgb), 0.035);
+    0 0 0 1px rgba(var(--ui-accent-rgb), 0.16),
+    inset 0 1px 0 rgba(var(--ui-lift-rgb), 0.035);
 }
 
 site-search button[data-open-modal]:focus-visible {
   outline: 0;
   box-shadow:
-    0 0 0 2px rgba(var(--netscli-accent-rgb), 0.18),
-    inset 0 1px 0 rgba(var(--netscli-lift-rgb), 0.04);
+    0 0 0 2px rgba(var(--ui-accent-rgb), 0.18),
+    inset 0 1px 0 rgba(var(--ui-lift-rgb), 0.04);
 }
 
 site-search button[data-open-modal]:hover svg,
 site-search button[data-open-modal]:focus-visible svg {
-  color: var(--netscli-accent-high);
+  color: var(--ui-accent-high);
 }
 
 /* Light: the resting border stays the shared hairline-light (measured: the
    old stack's lighter 0.14 border never won against it), and the hover
    ring is the same as the dark theme's. */
 html[data-theme='light'] site-search button[data-open-modal] {
-  background: rgba(var(--netscli-hairline-rgb), 0.035);
-  box-shadow: 0 1px 2px rgba(var(--netscli-hairline-rgb), 0.04);
+  background: rgba(var(--ui-hairline-rgb), 0.035);
+  box-shadow: 0 1px 2px rgba(var(--ui-hairline-rgb), 0.04);
 }
 
 html[data-theme='light'] site-search button[data-open-modal]:hover,
 html[data-theme='light'] site-search button[data-open-modal]:focus-visible {
   background: var(--sl-color-black);
-  border-color: rgba(var(--netscli-accent-rgb), 0.45);
+  border-color: rgba(var(--ui-accent-rgb), 0.45);
 }
 
 /* The hover ring restated here because the light resting rule above outranks
@@ -73,8 +73,8 @@ html[data-theme='light'] site-search button[data-open-modal]:focus-visible {
 html[data-theme='light'] site-search button[data-open-modal]:hover {
   color: #172033;
   box-shadow:
-    0 0 0 1px rgba(var(--netscli-accent-rgb), 0.16),
-    inset 0 1px 0 rgba(var(--netscli-lift-rgb), 0.035);
+    0 0 0 1px rgba(var(--ui-accent-rgb), 0.16),
+    inset 0 1px 0 rgba(var(--ui-lift-rgb), 0.035);
 }
 
 /* The dialog's close button also sits inside .docs-header-search. These
@@ -90,14 +90,14 @@ site-search button {
 
 .docs-header-search button:hover,
 .docs-header-search button:focus-visible {
-  border-color: var(--netscli-hover-border);
+  border-color: var(--ui-hover-border);
 }
 
 /* ---- Mobile menu button -------------------------------------------- */
 starlight-menu-button button {
   border: 1px solid var(--sl-color-hairline-light);
   border-radius: 6px;
-  background: rgba(var(--netscli-lift-rgb), 0.035);
+  background: rgba(var(--ui-lift-rgb), 0.035);
   color: var(--sl-color-gray-2);
   box-shadow: none;
 }
@@ -105,13 +105,13 @@ starlight-menu-button button {
 starlight-menu-button button:hover,
 starlight-menu-button button:focus-visible,
 starlight-menu-button[aria-expanded='true'] button {
-  background: rgba(var(--netscli-accent-rgb), 0.12);
-  border-color: rgba(var(--netscli-accent-rgb), 0.28);
+  background: rgba(var(--ui-accent-rgb), 0.12);
+  border-color: rgba(var(--ui-accent-rgb), 0.28);
   color: var(--sl-color-white);
 }
 
 html[data-theme='light'] starlight-menu-button button {
-  background: rgba(var(--netscli-hairline-rgb), 0.035);
+  background: rgba(var(--ui-hairline-rgb), 0.035);
 }
 
 /* Restated for the light theme: the light resting rule above outranks the
@@ -119,6 +119,6 @@ html[data-theme='light'] starlight-menu-button button {
 html[data-theme='light'] starlight-menu-button button:hover,
 html[data-theme='light'] starlight-menu-button button:focus-visible,
 html[data-theme='light'] starlight-menu-button[aria-expanded='true'] button {
-  background: rgba(var(--netscli-accent-rgb), 0.12);
+  background: rgba(var(--ui-accent-rgb), 0.12);
   color: var(--sl-color-white);
 }

--- a/site/src/styles/docs/header.css
+++ b/site/src/styles/docs/header.css
@@ -19,7 +19,7 @@ header.header {
   min-height: var(--sl-nav-height);
   background: var(--sl-color-bg-nav);
   backdrop-filter: blur(12px);
-  border-bottom: 1px solid rgba(var(--netscli-accent-rgb), 0.12);
+  border-bottom: 1px solid rgba(var(--ui-accent-rgb), 0.12);
   box-shadow: none;
   transition: box-shadow 160ms ease, border-color 160ms ease;
 }
@@ -43,7 +43,7 @@ header.header::after {
 html[data-docs-scrolled='true'] header.header {
   box-shadow:
     0 14px 34px rgba(0, 0, 0, 0.28),
-    0 1px 0 rgba(var(--netscli-accent-rgb), 0.12);
+    0 1px 0 rgba(var(--ui-accent-rgb), 0.12);
 }
 
 html[data-docs-scrolled='true'] header.header::after {
@@ -51,17 +51,17 @@ html[data-docs-scrolled='true'] header.header::after {
 }
 
 html[data-theme='light'] header.header {
-  border-bottom-color: rgba(var(--netscli-accent-rgb), 0.14);
+  border-bottom-color: rgba(var(--ui-accent-rgb), 0.14);
 }
 
 html[data-theme='light']:not([data-docs-scrolled='true']) header.header {
-  box-shadow: inset 0 -1px 0 rgba(var(--netscli-accent-rgb), 0.18);
+  box-shadow: inset 0 -1px 0 rgba(var(--ui-accent-rgb), 0.18);
 }
 
 html[data-theme='light'][data-docs-scrolled='true'] header.header {
   box-shadow:
-    0 14px 30px rgba(var(--netscli-hairline-rgb), 0.11),
-    0 1px 0 rgba(var(--netscli-accent-rgb), 0.12);
+    0 14px 30px rgba(var(--ui-hairline-rgb), 0.11),
+    0 1px 0 rgba(var(--ui-accent-rgb), 0.12);
 }
 
 html[data-theme='light'][data-docs-scrolled='true'] header.header::after {

--- a/site/src/styles/docs/search-input.css
+++ b/site/src/styles/docs/search-input.css
@@ -15,9 +15,9 @@
   --pagefind-ui-primary: var(--sl-color-gray-1);
   --pagefind-ui-text: var(--sl-color-gray-2);
   --pagefind-ui-background: #171b22;
-  --pagefind-ui-border: rgba(var(--netscli-hairline-rgb), 0.28);
+  --pagefind-ui-border: rgba(var(--ui-hairline-rgb), 0.28);
   --pagefind-ui-border-width: 1px;
-  --pagefind-ui-tag: rgba(var(--netscli-accent-rgb), 0.12);
+  --pagefind-ui-tag: rgba(var(--ui-accent-rgb), 0.12);
   --sl-search-corners: 6px;
   display: flex;
   flex-direction: column;
@@ -27,8 +27,8 @@
 
 html[data-theme='light'] #starlight__search {
   --pagefind-ui-background: #ffffff;
-  --pagefind-ui-border: rgba(var(--netscli-hairline-rgb), 0.14);
-  --pagefind-ui-tag: rgba(var(--netscli-accent-rgb), 0.11);
+  --pagefind-ui-border: rgba(var(--ui-hairline-rgb), 0.14);
+  --pagefind-ui-tag: rgba(var(--ui-accent-rgb), 0.11);
 }
 
 #starlight__search .pagefind-ui,
@@ -64,26 +64,26 @@ html[data-theme='light'] #starlight__search .pagefind-ui__form::before {
 }
 
 #starlight__search .pagefind-ui__search-input {
-  border-color: rgba(var(--netscli-hairline-rgb), 0.32);
+  border-color: rgba(var(--ui-hairline-rgb), 0.32);
   border-radius: 6px;
   color: var(--sl-color-gray-1);
   height: 3rem;
   min-height: 3rem;
   line-height: 1.2;
   background: #171b22;
-  box-shadow: inset 0 0 0 1px rgba(var(--netscli-lift-rgb), 0.015);
+  box-shadow: inset 0 0 0 1px rgba(var(--ui-lift-rgb), 0.015);
 }
 
 #starlight__search .pagefind-ui__search-input:focus {
   outline: 0;
   border-color: rgba(159, 248, 222, 0.72);
   box-shadow:
-    0 0 0 2px rgba(var(--netscli-accent-rgb), 0.16),
-    inset 0 1px 0 rgba(var(--netscli-lift-rgb), 0.04);
+    0 0 0 2px rgba(var(--ui-accent-rgb), 0.16),
+    inset 0 1px 0 rgba(var(--ui-lift-rgb), 0.04);
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__search-input {
-  border-color: rgba(var(--netscli-hairline-rgb), 0.24);
+  border-color: rgba(var(--ui-hairline-rgb), 0.24);
   color: var(--sl-color-white);
   background: #ffffff;
   box-shadow: none;
@@ -102,7 +102,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__search-input::placehol
 }
 
 #starlight__search .pagefind-ui__search-clear::before {
-  background-color: var(--netscli-accent-high);
+  background-color: var(--ui-accent-high);
   opacity: 0.86;
   -webkit-mask-size: 42%;
   mask-size: 42%;
@@ -153,7 +153,7 @@ html[data-theme='light'] #starlight__search .pagefind-ui__message .search-data {
   display: grid;
   place-items: center;
   min-height: 10rem;
-  border: 1px dashed rgba(var(--netscli-hairline-rgb), 0.22);
+  border: 1px dashed rgba(var(--ui-hairline-rgb), 0.22);
   border-radius: 8px;
   background: rgba(32, 36, 43, 0.56);
 }
@@ -176,7 +176,7 @@ site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidde
   place-items: center;
   min-height: 10rem;
   margin-top: 1rem;
-  border: 1px dashed rgba(var(--netscli-hairline-rgb), 0.22);
+  border: 1px dashed rgba(var(--ui-hairline-rgb), 0.22);
   border-radius: 8px;
   background: rgba(32, 36, 43, 0.56);
   color: var(--sl-color-gray-3);
@@ -189,7 +189,7 @@ site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidde
   display: grid;
   align-content: center;
   min-height: 10rem;
-  border: 1px dashed rgba(var(--netscli-hairline-rgb), 0.22);
+  border: 1px dashed rgba(var(--ui-hairline-rgb), 0.22);
   border-radius: 8px;
   background: rgba(32, 36, 43, 0.56);
 }
@@ -204,13 +204,13 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer:not(:has(.pagef
 html[data-theme='light'] site-search dialog .search-container:has(.pagefind-ui__drawer.pagefind-ui__hidden)::after,
 html[data-theme='light'] #starlight__search .pagefind-ui__drawer:has(.pagefind-ui__message):not(:has(.pagefind-ui__result)) {
   background: var(--sl-color-black);
-  border-color: rgba(var(--netscli-hairline-rgb), 0.18);
+  border-color: rgba(var(--ui-hairline-rgb), 0.18);
   color: var(--sl-color-gray-2);
 }
 
 /* Injected by scripts/docs-search-keys.ts when Pagefind neither answers
    nor errors; sized like the message it sits under. */
-#starlight__search .netscli-search-offline {
+#starlight__search .ui-search-offline {
   margin: 0.35rem 0 0;
   color: var(--sl-color-gray-2);
   font-size: 0.875rem;

--- a/site/src/styles/docs/search-results.css
+++ b/site/src/styles/docs/search-results.css
@@ -111,8 +111,8 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer::after {
   background: linear-gradient(0deg, rgba(244, 246, 248, 0.94), rgba(244, 246, 248, 0));
 }
 
-#starlight__search .pagefind-ui__drawer.netscli-search-overflow-top::before,
-#starlight__search .pagefind-ui__drawer.netscli-search-overflow-bottom::after {
+#starlight__search .pagefind-ui__drawer.ui-search-overflow-top::before,
+#starlight__search .pagefind-ui__drawer.ui-search-overflow-bottom::after {
   opacity: 1;
 }
 
@@ -129,11 +129,11 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer::after {
 
 #starlight__search .pagefind-ui__result-inner {
   overflow: hidden;
-  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.16);
+  border: 1px solid rgba(var(--ui-hairline-rgb), 0.16);
   border-radius: 8px;
-  background: var(--netscli-panel-bg);
+  background: var(--ui-panel-bg);
   box-shadow:
-    0 1px 0 rgba(var(--netscli-lift-rgb), 0.025) inset,
+    0 1px 0 rgba(var(--ui-lift-rgb), 0.025) inset,
     0 12px 26px rgba(0, 0, 0, 0.16);
   margin-top: 0;
 }
@@ -143,18 +143,18 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer::after {
 #starlight__search .pagefind-ui__result-tags {
   border: 0;
   border-radius: 0;
-  background: var(--netscli-panel-bg);
+  background: var(--ui-panel-bg);
 }
 
 /* The page-title row is a shade lighter than the sub-results under it, with
    a hairline between. */
 #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)) {
   background: #252b36;
-  box-shadow: inset 0 -1px 0 rgba(var(--netscli-hairline-rgb), 0.13);
+  box-shadow: inset 0 -1px 0 rgba(var(--ui-hairline-rgb), 0.13);
 }
 
 #starlight__search .pagefind-ui__result-nested {
-  box-shadow: inset 0 1px 0 rgba(var(--netscli-hairline-rgb), 0.1);
+  box-shadow: inset 0 1px 0 rgba(var(--ui-hairline-rgb), 0.1);
 }
 
 #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):hover,
@@ -164,18 +164,18 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer::after {
   outline: 0;
   background: #2b313d;
   box-shadow:
-    inset 2px 0 0 rgba(var(--netscli-accent-rgb), 0.74),
-    inset 0 -1px 0 rgba(var(--netscli-hairline-rgb), 0.13);
+    inset 2px 0 0 rgba(var(--ui-accent-rgb), 0.74),
+    inset 0 -1px 0 rgba(var(--ui-hairline-rgb), 0.13);
 }
 
 #starlight__search .pagefind-ui__result-tags {
-  background: var(--netscli-panel-bg);
-  box-shadow: inset 0 1px 0 rgba(var(--netscli-hairline-rgb), 0.1);
+  background: var(--ui-panel-bg);
+  box-shadow: inset 0 1px 0 rgba(var(--ui-hairline-rgb), 0.1);
 }
 
 #starlight__search mark {
-  color: var(--netscli-accent-high);
-  background: rgba(var(--netscli-accent-rgb), 0.16);
+  color: var(--ui-accent-high);
+  background: rgba(var(--ui-accent-rgb), 0.16);
   border-radius: 3px;
   padding-inline: 0.12em;
 }
@@ -183,9 +183,9 @@ html[data-theme='light'] #starlight__search .pagefind-ui__drawer::after {
 html[data-theme='light'] #starlight__search .pagefind-ui__result-inner {
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.8) inset,
-    0 10px 24px rgba(var(--netscli-hairline-rgb), 0.07);
+    0 10px 24px rgba(var(--ui-hairline-rgb), 0.07);
   background: var(--sl-color-black);
-  border-color: rgba(var(--netscli-hairline-rgb), 0.14);
+  border-color: rgba(var(--ui-hairline-rgb), 0.14);
 }
 
 html[data-theme='light'] #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)) {
@@ -225,7 +225,7 @@ html[data-theme='light'] #starlight__search mark {
   border-radius: 0;
   background: transparent;
   box-shadow: none;
-  color: var(--netscli-accent);
+  color: var(--ui-accent);
   font: inherit;
   font-size: 0.8rem;
   font-weight: 400;
@@ -240,7 +240,7 @@ html[data-theme='light'] #starlight__search mark {
 #starlight__search .pagefind-ui__button:focus-visible {
   background: transparent;
   box-shadow: none;
-  color: var(--netscli-accent-bright);
+  color: var(--ui-accent-bright);
   outline: 0;
 }
 

--- a/site/src/styles/docs/search.css
+++ b/site/src/styles/docs/search.css
@@ -15,11 +15,11 @@
 
 /* ---- Dialog ---------------------------------------------------------- */
 site-search dialog {
-  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.34);
+  border: 1px solid rgba(var(--ui-hairline-rgb), 0.34);
   border-radius: 8px;
   box-shadow:
     0 34px 90px rgba(0, 0, 0, 0.62),
-    0 0 0 1px rgba(var(--netscli-lift-rgb), 0.02) inset;
+    0 0 0 1px rgba(var(--ui-lift-rgb), 0.02) inset;
   overflow: hidden;
   background: #252b36;
 }
@@ -42,10 +42,10 @@ site-search dialog .search-container {
 
 html[data-theme='light'] site-search dialog {
   box-shadow:
-    0 30px 70px rgba(var(--netscli-hairline-rgb), 0.18),
+    0 30px 70px rgba(var(--ui-hairline-rgb), 0.18),
     0 0 0 1px rgba(255, 255, 255, 0.72) inset;
   background: #f6f8fa;
-  border-color: rgba(var(--netscli-hairline-rgb), 0.24);
+  border-color: rgba(var(--ui-hairline-rgb), 0.24);
 }
 
 html[data-theme='light'] site-search dialog .dialog-frame {
@@ -63,7 +63,7 @@ site-search button[data-close-modal] {
 site-search button[data-close-modal]:hover,
 site-search button[data-close-modal]:focus-visible {
   outline: 0;
-  background: rgba(var(--netscli-accent-rgb), 0.12);
+  background: rgba(var(--ui-accent-rgb), 0.12);
   color: var(--sl-color-white);
 }
 
@@ -73,7 +73,7 @@ html[data-theme='light'] site-search button[data-close-modal] {
 
 html[data-theme='light'] site-search button[data-close-modal]:hover,
 html[data-theme='light'] site-search button[data-close-modal]:focus-visible {
-  background: rgba(var(--netscli-accent-rgb), 0.1);
+  background: rgba(var(--ui-accent-rgb), 0.1);
   color: var(--sl-color-white);
 }
 

--- a/site/src/styles/docs/shell.css
+++ b/site/src/styles/docs/shell.css
@@ -47,14 +47,14 @@ main,
   z-index: 0;
   pointer-events: none;
   background:
-    radial-gradient(circle at 0 0, rgba(var(--netscli-accent-rgb), 0.11), transparent min(25rem, 70vw)),
-    linear-gradient(128deg, rgba(var(--netscli-accent-rgb), 0.045), rgba(30, 220, 255, 0.016) 38%, transparent 72%);
+    radial-gradient(circle at 0 0, rgba(var(--ui-accent-rgb), 0.11), transparent min(25rem, 70vw)),
+    linear-gradient(128deg, rgba(var(--ui-accent-rgb), 0.045), rgba(30, 220, 255, 0.016) 38%, transparent 72%);
 }
 
 html[data-theme='light'] .main-pane > main > .content-panel:first-of-type::before {
   background:
-    radial-gradient(circle at 0 0, rgba(var(--netscli-accent-rgb), 0.08), transparent min(24rem, 70vw)),
-    linear-gradient(128deg, rgba(var(--netscli-accent-rgb), 0.035), rgba(30, 220, 255, 0.024) 38%, transparent 72%);
+    radial-gradient(circle at 0 0, rgba(var(--ui-accent-rgb), 0.08), transparent min(24rem, 70vw)),
+    linear-gradient(128deg, rgba(var(--ui-accent-rgb), 0.035), rgba(30, 220, 255, 0.024) 38%, transparent 72%);
 }
 
 .main-pane > main > .content-panel:first-of-type > .sl-container {
@@ -63,7 +63,7 @@ html[data-theme='light'] .main-pane > main > .content-panel:first-of-type::befor
   display: flex;
   align-items: center;
   box-sizing: border-box;
-  min-height: var(--netscli-docs-hero-height);
+  min-height: var(--ui-docs-hero-height);
   padding-block: clamp(1.2rem, 2vw, 1.7rem);
   padding-inline: clamp(1.75rem, 2.2vw, 2.5rem);
 }
@@ -75,7 +75,7 @@ html[data-theme='light'] .main-pane > main > .content-panel:first-of-type::befor
 /* ---- Frame widths -------------------------------------------------- */
 @media (min-width: 72rem) {
   .main-frame {
-    width: min(calc(100% - (var(--netscli-docs-shell-gutter) * 2)), var(--netscli-docs-frame-width));
+    width: min(calc(100% - (var(--ui-docs-shell-gutter) * 2)), var(--ui-docs-frame-width));
     margin-inline: auto;
   }
 
@@ -86,7 +86,7 @@ html[data-theme='light'] .main-pane > main > .content-panel:first-of-type::befor
 
 @media (min-width: 72rem) and (max-width: 86rem) {
   :where([data-has-sidebar][data-has-toc]) .main-pane {
-    width: calc(100% - var(--netscli-docs-toc-width));
+    width: calc(100% - var(--ui-docs-toc-width));
   }
 
   .content-panel {
@@ -106,7 +106,7 @@ html[data-theme='light'] .main-pane > main > .content-panel:first-of-type::befor
 
 @media (min-width: 108rem) {
   .main-frame {
-    width: var(--netscli-docs-frame-width);
+    width: var(--ui-docs-frame-width);
   }
 }
 

--- a/site/src/styles/docs/sidebar.css
+++ b/site/src/styles/docs/sidebar.css
@@ -16,7 +16,7 @@
 
 .sidebar-content {
   padding-top: 1.25rem;
-  padding-inline: var(--netscli-sidebar-rail-inset) 1.85rem;
+  padding-inline: var(--ui-sidebar-rail-inset) 1.85rem;
   gap: 1.1rem;
   overflow-x: hidden;
 }
@@ -67,12 +67,12 @@
 /* ---- Links, hover and focus ---------------------------------------- */
 .sidebar-content a:hover {
   color: var(--sl-color-white);
-  background: rgba(var(--netscli-lift-rgb), 0.045);
+  background: rgba(var(--ui-lift-rgb), 0.045);
 }
 
 .sidebar-content :where(details > ul) a:focus-visible {
   color: var(--sl-color-white);
-  background: rgba(var(--netscli-lift-rgb), 0.045);
+  background: rgba(var(--ui-lift-rgb), 0.045);
 }
 
 .sidebar-content :where(details > ul) a:hover {
@@ -92,23 +92,23 @@
   position: relative;
   color: var(--sl-color-white);
   border-color: transparent;
-  border-inline-start-color: var(--netscli-accent);
-  background: rgba(var(--netscli-accent-rgb), 0.12);
+  border-inline-start-color: var(--ui-accent);
+  background: rgba(var(--ui-accent-rgb), 0.12);
   box-shadow: none;
 }
 
 /* ---- Responsive ---------------------------------------------------- */
 @media (min-width: 72rem) {
   nav.sidebar {
-    left: max(var(--netscli-docs-shell-gutter), calc((100% - var(--netscli-docs-frame-width)) / 2));
-    inset-inline-start: max(var(--netscli-docs-shell-gutter), calc((100% - var(--netscli-docs-frame-width)) / 2));
-    width: calc(var(--netscli-docs-sidebar-width) + var(--netscli-docs-shell-gutter));
+    left: max(var(--ui-docs-shell-gutter), calc((100% - var(--ui-docs-frame-width)) / 2));
+    inset-inline-start: max(var(--ui-docs-shell-gutter), calc((100% - var(--ui-docs-frame-width)) / 2));
+    width: calc(var(--ui-docs-sidebar-width) + var(--ui-docs-shell-gutter));
   }
 
   .sidebar-pane {
-    left: max(var(--netscli-docs-shell-gutter), calc((100% - var(--netscli-docs-frame-width)) / 2));
-    flex-basis: var(--netscli-docs-sidebar-width);
-    width: var(--netscli-docs-sidebar-width);
+    left: max(var(--ui-docs-shell-gutter), calc((100% - var(--ui-docs-frame-width)) / 2));
+    flex-basis: var(--ui-docs-sidebar-width);
+    width: var(--ui-docs-sidebar-width);
     margin-inline-start: 0;
   }
 }
@@ -116,7 +116,7 @@
 @media (max-width: 72rem) {
   .sidebar-pane {
     background:
-      linear-gradient(180deg, rgba(var(--netscli-accent-rgb), 0.035), transparent 9rem),
+      linear-gradient(180deg, rgba(var(--ui-accent-rgb), 0.035), transparent 9rem),
       var(--sl-color-bg-sidebar);
   }
 
@@ -146,8 +146,8 @@
   }
 
   .sidebar-content {
-    --netscli-sidebar-rail-inset: 1.35rem;
-    padding-inline: var(--netscli-sidebar-rail-inset) 1.35rem;
+    --ui-sidebar-rail-inset: 1.35rem;
+    padding-inline: var(--ui-sidebar-rail-inset) 1.35rem;
     gap: 0.95rem;
   }
 
@@ -168,10 +168,10 @@
     height: auto;
     max-height: calc(100dvh - var(--sl-nav-height) - 1.3rem);
     padding: 0;
-    border: 1px solid rgba(var(--netscli-hairline-rgb), 0.22);
+    border: 1px solid rgba(var(--ui-hairline-rgb), 0.22);
     border-radius: 8px;
     background:
-      linear-gradient(180deg, rgba(var(--netscli-accent-rgb), 0.04), transparent 11rem),
+      linear-gradient(180deg, rgba(var(--ui-accent-rgb), 0.04), transparent 11rem),
       var(--sl-color-bg-sidebar);
     overflow: auto;
     overscroll-behavior: contain;

--- a/site/src/styles/docs/tables-narrow.css
+++ b/site/src/styles/docs/tables-narrow.css
@@ -4,7 +4,7 @@
  */
 
 @media (min-width: 72rem) {
-  .sl-markdown-content .netscli-table-scroll table {
+  .sl-markdown-content .ui-table-scroll table {
     min-width: 100%;
   }
 }
@@ -24,7 +24,7 @@
   .sl-markdown-content table th {
     width: auto;
     padding: 0.68rem 0.85rem;
-    border-bottom: 1px solid rgba(var(--netscli-hairline-rgb), 0.11);
+    border-bottom: 1px solid rgba(var(--ui-hairline-rgb), 0.11);
   }
 
   .sl-markdown-content table td:first-child,
@@ -42,29 +42,29 @@
 
   .sl-markdown-content table td + td,
   .sl-markdown-content table th + th {
-    border-inline-start: 1px solid rgba(var(--netscli-hairline-rgb), 0.11);
+    border-inline-start: 1px solid rgba(var(--ui-hairline-rgb), 0.11);
   }
 }
 
 @media (max-width: 49.99rem) {
-  .sl-markdown-content .netscli-table-scroll {
+  .sl-markdown-content .ui-table-scroll {
     display: block;
     width: 100%;
     max-width: 100%;
     margin-block: 1rem 1.35rem;
     overflow-x: auto;
     overflow-y: hidden;
-    border: 1px solid rgba(var(--netscli-hairline-rgb), 0.2);
+    border: 1px solid rgba(var(--ui-hairline-rgb), 0.2);
     border-radius: 8px;
-    background: var(--netscli-table-bg);
+    background: var(--ui-table-bg);
     -webkit-overflow-scrolling: touch;
   }
 
-  html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
+  html[data-theme='light'] .sl-markdown-content .ui-table-scroll {
     background: #f7faf9;
   }
 
-  .sl-markdown-content .netscli-table-scroll table {
+  .sl-markdown-content .ui-table-scroll table {
     display: table;
     table-layout: fixed;
     width: max-content;
@@ -74,16 +74,16 @@
     background: transparent;
   }
 
-  .sl-markdown-content .netscli-table-scroll thead {
+  .sl-markdown-content .ui-table-scroll thead {
     display: table-header-group;
   }
 
-  .sl-markdown-content .netscli-table-scroll tbody {
+  .sl-markdown-content .ui-table-scroll tbody {
     gap: 0.75rem;
     display: table-row-group;
   }
 
-  .sl-markdown-content .netscli-table-scroll tr {
+  .sl-markdown-content .ui-table-scroll tr {
     gap: 0.75rem;
     display: table-row;
     padding: 0;
@@ -92,30 +92,30 @@
     background: transparent;
   }
 
-  html[data-theme='light'] .sl-markdown-content .netscli-table-scroll tr {
+  html[data-theme='light'] .sl-markdown-content .ui-table-scroll tr {
     background: #eef3f2;
   }
 
-  .sl-markdown-content .netscli-table-scroll th,
-  .sl-markdown-content .netscli-table-scroll td {
+  .sl-markdown-content .ui-table-scroll th,
+  .sl-markdown-content .ui-table-scroll td {
     display: table-cell;
     width: auto;
     min-width: 0;
     padding: 0.85rem 1rem;
     border: 0;
-    border-bottom: 1px solid rgba(var(--netscli-hairline-rgb), 0.11);
+    border-bottom: 1px solid rgba(var(--ui-hairline-rgb), 0.11);
     line-height: 1.42;
     white-space: normal;
     overflow-wrap: normal;
     word-break: normal;
   }
 
-  .sl-markdown-content .netscli-table-scroll td:last-child,
-  .sl-markdown-content .netscli-table-scroll th:last-child {
+  .sl-markdown-content .ui-table-scroll td:last-child,
+  .sl-markdown-content .ui-table-scroll th:last-child {
     padding-inline-end: 1rem;
   }
 
-  .sl-markdown-content .netscli-table-scroll td::before {
+  .sl-markdown-content .ui-table-scroll td::before {
     margin-bottom: 0.32rem;
     color: var(--sl-color-gray-3);
     font-size: 0.72rem;
@@ -125,26 +125,26 @@
     display: none;
   }
 
-  .sl-markdown-content .netscli-table-scroll td,
-  .sl-markdown-content .netscli-table-scroll tbody th {
+  .sl-markdown-content .ui-table-scroll td,
+  .sl-markdown-content .ui-table-scroll tbody th {
     font-weight: 400;
   }
 
-  .sl-markdown-content .netscli-table-scroll thead th,
-  .sl-markdown-content .netscli-table-scroll thead th:first-child {
+  .sl-markdown-content .ui-table-scroll thead th,
+  .sl-markdown-content .ui-table-scroll thead th:first-child {
     font-weight: 720;
   }
 
-  .sl-markdown-content .netscli-table-scroll th:first-child,
-  .sl-markdown-content .netscli-table-scroll td:first-child,
-  .sl-markdown-content .netscli-table-scroll table.table-row-headers tbody td:first-child {
+  .sl-markdown-content .ui-table-scroll th:first-child,
+  .sl-markdown-content .ui-table-scroll td:first-child,
+  .sl-markdown-content .ui-table-scroll table.table-row-headers tbody td:first-child {
     width: 11rem;
     color: inherit;
     background: transparent;
   }
 
-  .sl-markdown-content .netscli-table-scroll td:first-child,
-  .sl-markdown-content .netscli-table-scroll table.table-row-headers tbody td:first-child {
+  .sl-markdown-content .ui-table-scroll td:first-child,
+  .sl-markdown-content .ui-table-scroll table.table-row-headers tbody td:first-child {
     font-weight: 400;
   }
 }

--- a/site/src/styles/docs/tables.css
+++ b/site/src/styles/docs/tables.css
@@ -1,6 +1,6 @@
 /* Docs tables, the base rules. Below 72rem docs/tables-narrow.css takes
  * over. Every table in .sl-markdown-content is wrapped at runtime in
- * div.netscli-table-scroll by src/scripts/docs-tables.ts, which is the
+ * div.ui-table-scroll by src/scripts/docs-tables.ts, which is the
  * horizontally scrolling region; the table inside keeps a minimum width so
  * columns never crush. Markers in the markdown add `table-row-headers`.
  *
@@ -33,16 +33,16 @@
   padding: 0.76rem 1rem;
   text-align: left;
   vertical-align: middle;
-  border-color: rgba(var(--netscli-hairline-rgb), 0.13);
+  border-color: rgba(var(--ui-hairline-rgb), 0.13);
 }
 
 .sl-markdown-content tbody td {
-  border-bottom: 1px solid rgba(var(--netscli-hairline-rgb), 0.11);
+  border-bottom: 1px solid rgba(var(--ui-hairline-rgb), 0.11);
 }
 
 .sl-markdown-content td + td,
 .sl-markdown-content th + th {
-  border-inline-start: 1px solid rgba(var(--netscli-hairline-rgb), 0.11);
+  border-inline-start: 1px solid rgba(var(--ui-hairline-rgb), 0.11);
 }
 
 .sl-markdown-content td:first-child,
@@ -78,7 +78,7 @@
 
 /* Weights: bold header row, regular body -- including the first column,
    which an earlier design set bold and a later one took back. */
-.sl-markdown-content .netscli-table-scroll th {
+.sl-markdown-content .ui-table-scroll th {
   font-weight: 720;
 }
 
@@ -89,36 +89,36 @@
 }
 
 .sl-markdown-content table:not(.table-row-headers) tbody td:first-child,
-.sl-markdown-content .netscli-table-scroll table.table-row-headers tbody td:first-child {
+.sl-markdown-content .ui-table-scroll table.table-row-headers tbody td:first-child {
   color: inherit;
   background: transparent;
 }
 
-.sl-markdown-content .netscli-table-scroll table.table-row-headers tbody td:first-child {
+.sl-markdown-content .ui-table-scroll table.table-row-headers tbody td:first-child {
   font-weight: 400;
 }
 
 /* ---- Surfaces -------------------------------------------------------- */
 .sl-markdown-content thead tr {
-  box-shadow: inset 0 -2px 0 rgba(var(--netscli-accent-rgb), 0.55);
+  box-shadow: inset 0 -2px 0 rgba(var(--ui-accent-rgb), 0.55);
 }
 
 .sl-markdown-content tbody tr:hover {
-  background: var(--netscli-table-bg);
+  background: var(--ui-table-bg);
 }
 
 .sl-markdown-content tbody tr:nth-child(even),
 .sl-markdown-content tbody tr:nth-child(even):hover {
-  background: var(--netscli-table-stripe);
+  background: var(--ui-table-stripe);
 }
 
 html[data-theme='light'] .sl-markdown-content table {
-  background: var(--netscli-table-bg);
+  background: var(--ui-table-bg);
   box-shadow: none;
 }
 
 html[data-theme='light'] .sl-markdown-content thead tr {
-  box-shadow: inset 0 -2px 0 rgba(var(--netscli-accent-rgb), 0.42);
+  box-shadow: inset 0 -2px 0 rgba(var(--ui-accent-rgb), 0.42);
 }
 
 html[data-theme='light'] .sl-markdown-content th {
@@ -132,26 +132,26 @@ html[data-theme='light'] .sl-markdown-content tbody tr:hover {
 
 html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even),
 html[data-theme='light'] .sl-markdown-content tbody tr:nth-child(even):hover {
-  background: var(--netscli-table-stripe);
+  background: var(--ui-table-stripe);
 }
 
 /* ---- Scroll wrapper -------------------------------------------------- */
-.sl-markdown-content .netscli-table-scroll {
+.sl-markdown-content .ui-table-scroll {
   max-width: 100%;
   margin-block: 1.2rem;
   overflow-x: auto;
   overflow-y: hidden;
-  border: 1px solid rgba(var(--netscli-hairline-rgb), 0.2);
+  border: 1px solid rgba(var(--ui-hairline-rgb), 0.2);
   border-radius: 8px;
-  background: var(--netscli-table-bg);
+  background: var(--ui-table-bg);
   -webkit-overflow-scrolling: touch;
 }
 
-html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
-  background: var(--netscli-table-bg);
+html[data-theme='light'] .sl-markdown-content .ui-table-scroll {
+  background: var(--ui-table-bg);
 }
 
-.sl-markdown-content .netscli-table-scroll table {
+.sl-markdown-content .ui-table-scroll table {
   display: table;
   width: 100%;
   min-width: 42rem;
@@ -163,21 +163,21 @@ html[data-theme='light'] .sl-markdown-content .netscli-table-scroll {
   background: transparent;
 }
 
-.sl-markdown-content .netscli-table-scroll thead {
+.sl-markdown-content .ui-table-scroll thead {
   display: table-header-group;
 }
 
-.sl-markdown-content .netscli-table-scroll tbody {
+.sl-markdown-content .ui-table-scroll tbody {
   display: table-row-group;
 }
 
-.sl-markdown-content .netscli-table-scroll tr {
+.sl-markdown-content .ui-table-scroll tr {
   display: table-row;
   background: transparent;
 }
 
-.sl-markdown-content .netscli-table-scroll th,
-.sl-markdown-content .netscli-table-scroll td {
+.sl-markdown-content .ui-table-scroll th,
+.sl-markdown-content .ui-table-scroll td {
   display: table-cell;
   min-width: 0;
   white-space: normal;

--- a/site/src/styles/docs/theme.css
+++ b/site/src/styles/docs/theme.css
@@ -1,7 +1,7 @@
 /* Docs theme: every token the docs shell reads, both themes.
  *
  * Re-theming the docs for another project means editing this file. The
- * brand palette itself (--netscli-accent and friends) lives in
+ * brand palette itself (--ui-accent and friends) lives in
  * styles/tokens.css, which the landing page loads too; this file maps
  * Starlight's own --sl-* tokens onto it and adds the docs-only surfaces.
  *
@@ -16,8 +16,8 @@
 html[data-theme='dark'],
 html[data-theme='dark'] ::backdrop {
   --sl-color-accent-low: #0a2a13;
-  --sl-color-accent: var(--netscli-accent);
-  --sl-color-accent-high: var(--netscli-accent-high);
+  --sl-color-accent: var(--ui-accent);
+  --sl-color-accent-high: var(--ui-accent-high);
   --sl-color-white: #f4f4f4;
   --sl-color-gray-1: #e7edf6;
   --sl-color-gray-2: #c2cad8;
@@ -32,7 +32,7 @@ html[data-theme='dark'] ::backdrop {
   /* Neutral, not green: inline code is dense and frequent, and a green wash
      behind every identifier made the accent a fill colour instead of a
      state colour. */
-  --sl-color-bg-inline-code: rgba(var(--netscli-hairline-rgb), 0.13);
+  --sl-color-bg-inline-code: rgba(var(--ui-hairline-rgb), 0.13);
   --sl-color-hairline: rgba(255, 255, 255, 0.08);
   --sl-color-hairline-light: rgba(255, 255, 255, 0.1);
   --sl-color-hairline-shade: #070707;
@@ -41,17 +41,17 @@ html[data-theme='dark'] ::backdrop {
   /* Table surfaces. Three roles, and the striping is a real distinction --
      odd and even rows differ on purpose, so these must not be collapsed into
      one value however close they look. */
-  --netscli-table-bg: #20242b;
-  --netscli-table-stripe: #242932;
-  --netscli-table-head: #252b36;
+  --ui-table-bg: #20242b;
+  --ui-table-stripe: #242932;
+  --ui-table-head: #252b36;
 
   /* The raised panel that content sits on: search results and their tag
      rows, and the frame and body of a code block. */
-  --netscli-panel-bg: #20242b;
+  --ui-panel-bg: #20242b;
 
   /* The floating menu surface: the mobile section menu and the mobile table
      of contents dropdown, which are the same panel. */
-  --netscli-menu-bg: #1b2028;
+  --ui-menu-bg: #1b2028;
 }
 
 /* ---- Colour, light --------------------------------------------------- */
@@ -81,41 +81,41 @@ html[data-theme='light'] ::backdrop {
   --sl-color-bg: #fbfbfb;
   --sl-color-bg-nav: rgba(251, 251, 251, 0.92);
   --sl-color-bg-sidebar: #fbfbfb;
-  --sl-color-bg-inline-code: rgba(var(--netscli-hairline-rgb), 0.07);
+  --sl-color-bg-inline-code: rgba(var(--ui-hairline-rgb), 0.07);
   --sl-color-hairline: rgba(17, 24, 39, 0.1);
   --sl-color-hairline-light: rgba(17, 24, 39, 0.12);
   --sl-color-hairline-shade: rgba(17, 24, 39, 0.04);
   --sl-content-width: 64rem;
 
-  --netscli-table-bg: #f7faf9;
-  --netscli-table-stripe: #f6f8fa;
-  --netscli-table-head: #eef2f4;
-  --netscli-panel-bg: #f6f8fa;
+  --ui-table-bg: #f7faf9;
+  --ui-table-stripe: #f6f8fa;
+  --ui-table-head: #eef2f4;
+  --ui-panel-bg: #f6f8fa;
   /* Plain white, which this theme also calls --sl-color-black. Named for
      the role so both themes read the same way at the call site. */
-  --netscli-menu-bg: #ffffff;
+  --ui-menu-bg: #ffffff;
 }
 
 /* ---- Layout ---------------------------------------------------------- */
 :root {
-  --sl-nav-height: var(--netscli-nav-height);
-  --netscli-docs-sidebar-width: 16rem;
+  --sl-nav-height: var(--ui-nav-height);
+  --ui-docs-sidebar-width: 16rem;
   /* 15rem, not 13rem. The rail's text column is inset from the frame edge by
-     its own padding (--netscli-sidebar-rail-inset below), and this width
+     its own padding (--ui-sidebar-rail-inset below), and this width
      restores the text column the padding costs it, so the two rails put the
      same air down each edge of the page. */
-  --netscli-docs-toc-width: 15rem;
-  --netscli-docs-shell-gutter: clamp(1.25rem, 2vw, 2.5rem);
+  --ui-docs-toc-width: 15rem;
+  --ui-docs-shell-gutter: clamp(1.25rem, 2vw, 2.5rem);
   /* How far a rail insets its text from the frame's outer edge. Both rails
      read it; it was once declared twice with drifted values. */
-  --netscli-sidebar-rail-inset: clamp(2.2rem, 3vw, 3.15rem);
+  --ui-sidebar-rail-inset: clamp(2.2rem, 3vw, 3.15rem);
   /* Height of the title band at the top of every docs page. The band's own
      min-height and the offset that starts the contents rail below it both
      read this, so they move together. Measured across all eleven docs pages
      at five widths: no page's title wraps. */
-  --netscli-docs-hero-height: clamp(6.75rem, 9vw, 8.25rem);
-  --netscli-docs-frame-width: calc(
-    var(--netscli-shell-width) + var(--netscli-docs-sidebar-width) + var(--netscli-docs-toc-width)
+  --ui-docs-hero-height: clamp(6.75rem, 9vw, 8.25rem);
+  --ui-docs-frame-width: calc(
+    var(--ui-shell-width) + var(--ui-docs-sidebar-width) + var(--ui-docs-toc-width)
   );
 
   /* Heading scale. Starlight's defaults put h1 at 42px and h2 at 35px
@@ -127,12 +127,12 @@ html[data-theme='light'] ::backdrop {
   --sl-text-h4: 1.125rem;
   --sl-text-h5: 1rem;
 
-  --netscli-panel-hover-border: color-mix(in srgb, var(--sl-color-accent) 34%, var(--sl-color-hairline));
+  --ui-panel-hover-border: color-mix(in srgb, var(--sl-color-accent) 34%, var(--sl-color-hairline));
 }
 
 @media (min-width: 108rem) {
   :root {
-    --netscli-docs-shell-gutter: 2.5rem;
+    --ui-docs-shell-gutter: 2.5rem;
   }
 }
 
@@ -147,7 +147,7 @@ html[data-theme='light'] ::backdrop {
 
 @media (min-width: 72rem) {
   html[data-has-sidebar] {
-    --sl-sidebar-width: var(--netscli-docs-sidebar-width);
+    --sl-sidebar-width: var(--ui-docs-sidebar-width);
   }
 }
 
@@ -157,22 +157,22 @@ html[data-theme='light'] ::backdrop {
   }
 
   html[data-has-sidebar] {
-    --sl-content-inline-start: var(--netscli-docs-sidebar-width);
+    --sl-content-inline-start: var(--ui-docs-sidebar-width);
   }
 }
 
 @media (min-width: 86.01rem) {
   html[data-has-sidebar] {
-    --sl-content-inline-start: var(--netscli-docs-sidebar-width);
+    --sl-content-inline-start: var(--ui-docs-sidebar-width);
   }
 }
 
 @media (max-width: 71.99rem) {
   :root {
-    --netscli-mobile-toc-bar-height: 2.625rem;
+    --ui-mobile-toc-bar-height: 2.625rem;
   }
 
   html[data-has-toc] {
-    --sl-mobile-toc-height: var(--netscli-mobile-toc-bar-height);
+    --sl-mobile-toc-height: var(--ui-mobile-toc-bar-height);
   }
 }

--- a/site/src/styles/docs/toc-bar.css
+++ b/site/src/styles/docs/toc-bar.css
@@ -1,7 +1,7 @@
 /* Docs table of contents, narrow: the collapsed "On this page" bar below
  * 72rem. The wide rail is docs/toc.css.
  *
- * The bar is always rendered inside .netscli-mobile-toc-wrapper (see
+ * The bar is always rendered inside .ui-mobile-toc-wrapper (see
  * components/starlight/PageSidebar.astro), and the wrapper is what is
  * sticky; Starlight's own <nav> inside it is put back into normal flow. Four
  * files in the old stack restyled this dropdown in turn -- 14, 18, 20 and
@@ -15,10 +15,10 @@
  */
 
 /* ---- Bar (narrow) -------------------------------------------------- */
-.netscli-mobile-toc-wrapper mobile-starlight-toc summary,
-.netscli-mobile-toc-wrapper mobile-starlight-toc .toggle,
-.netscli-mobile-toc-wrapper mobile-starlight-toc .display-current,
-.netscli-mobile-toc-wrapper mobile-starlight-toc .dropdown a {
+.ui-mobile-toc-wrapper mobile-starlight-toc summary,
+.ui-mobile-toc-wrapper mobile-starlight-toc .toggle,
+.ui-mobile-toc-wrapper mobile-starlight-toc .display-current,
+.ui-mobile-toc-wrapper mobile-starlight-toc .dropdown a {
   cursor: pointer;
 }
 
@@ -47,7 +47,7 @@
     overflow: visible;
   }
 
-  .netscli-mobile-toc-wrapper {
+  .ui-mobile-toc-wrapper {
     display: block;
     position: sticky;
     top: var(--sl-nav-height);
@@ -61,7 +61,7 @@
     position: relative;
     display: block;
     width: 100%;
-    height: var(--netscli-mobile-toc-bar-height);
+    height: var(--ui-mobile-toc-bar-height);
   }
 
   mobile-starlight-toc nav {
@@ -80,7 +80,7 @@
     display: flex;
     align-items: center;
     gap: 0.65rem;
-    height: var(--netscli-mobile-toc-bar-height);
+    height: var(--ui-mobile-toc-bar-height);
     padding: 0 clamp(1rem, 3.4vw, 1.75rem);
     border: 0;
   }
@@ -114,7 +114,7 @@
 
   mobile-starlight-toc .caret,
   mobile-starlight-toc details[open] .caret {
-    color: var(--netscli-accent);
+    color: var(--ui-accent);
     transform: none;
     transition: none;
   }
@@ -133,7 +133,7 @@
     overscroll-behavior: contain;
     border-block: 1px solid var(--sl-color-hairline);
     border-inline: 0;
-    background: var(--netscli-menu-bg);
+    background: var(--ui-menu-bg);
     box-shadow: none;
   }
 
@@ -161,13 +161,13 @@
   mobile-starlight-toc .dropdown a:hover,
   mobile-starlight-toc .dropdown a:focus-visible {
     outline: 0;
-    color: var(--netscli-accent-high);
+    color: var(--ui-accent-high);
   }
 
   mobile-starlight-toc .dropdown a[aria-current='true'] {
-    color: var(--netscli-accent-high);
-    border-inline-start-color: var(--netscli-accent);
-    background: rgba(var(--netscli-accent-rgb), 0.07);
+    color: var(--ui-accent-high);
+    border-inline-start-color: var(--ui-accent);
+    background: rgba(var(--ui-accent-rgb), 0.07);
   }
 
   mobile-starlight-toc .dropdown a[aria-current='true']::after {
@@ -177,7 +177,7 @@
 
   /* ---- Bar, light theme ---- */
   html[data-theme='light'] mobile-starlight-toc .toggle {
-    border-color: rgba(var(--netscli-hairline-rgb), 0.14);
+    border-color: rgba(var(--ui-hairline-rgb), 0.14);
     background: rgba(255, 255, 255, 0.72);
     color: var(--sl-color-gray-1);
   }
@@ -190,7 +190,7 @@
   html[data-theme='light'] mobile-starlight-toc details[open] .toggle,
   html[data-theme='light'] mobile-starlight-toc details .toggle:hover,
   html[data-theme='light'] mobile-starlight-toc summary:focus-visible .toggle {
-    border-color: rgba(var(--netscli-accent-rgb), 0.36);
+    border-color: rgba(var(--ui-accent-rgb), 0.36);
     background: transparent;
     color: var(--sl-color-white);
   }
@@ -200,8 +200,8 @@
   }
 
   html[data-theme='light'] mobile-starlight-toc .dropdown {
-    box-shadow: 0 14px 32px rgba(var(--netscli-hairline-rgb), 0.12);
-    background: var(--netscli-menu-bg);
+    box-shadow: 0 14px 32px rgba(var(--ui-hairline-rgb), 0.12);
+    background: var(--ui-menu-bg);
   }
 
   html[data-theme='light'] mobile-starlight-toc details[open] .dropdown {
@@ -211,7 +211,7 @@
   html[data-theme='light'] mobile-starlight-toc .dropdown a:hover,
   html[data-theme='light'] mobile-starlight-toc .dropdown a:focus-visible {
     color: var(--sl-color-white);
-    background: rgba(var(--netscli-hairline-rgb), 0.045);
+    background: rgba(var(--ui-hairline-rgb), 0.045);
   }
 
   html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true'],
@@ -219,7 +219,7 @@
   html[data-theme='light'] mobile-starlight-toc .dropdown a[aria-current='true']:focus-visible {
     color: var(--sl-color-accent-high);
     border-inline-start-color: var(--sl-color-accent);
-    background: rgba(var(--netscli-accent-rgb), 0.055);
+    background: rgba(var(--ui-accent-rgb), 0.055);
   }
 }
 
@@ -233,7 +233,7 @@
     overflow: visible;
   }
 
-  .netscli-mobile-toc-wrapper {
+  .ui-mobile-toc-wrapper {
     margin-bottom: 1.15rem;
   }
 }

--- a/site/src/styles/docs/toc.css
+++ b/site/src/styles/docs/toc.css
@@ -21,7 +21,7 @@
 .right-sidebar-panel :where(a[aria-current='true']),
 .right-sidebar-panel :where(a[aria-current='page']),
 .right-sidebar-panel :where(a[aria-current='location']) {
-  color: var(--netscli-accent-high);
+  color: var(--ui-accent-high);
   background: transparent;
 }
 
@@ -40,9 +40,9 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
 
 @media (min-width: 72rem) {
   .right-sidebar-panel {
-    flex-basis: var(--netscli-docs-toc-width);
-    width: var(--netscli-docs-toc-width);
-    padding-inline: 1.85rem var(--netscli-sidebar-rail-inset, clamp(2.2rem, 3vw, 3.15rem));
+    flex-basis: var(--ui-docs-toc-width);
+    width: var(--ui-docs-toc-width);
+    padding-inline: 1.85rem var(--ui-sidebar-rail-inset, clamp(2.2rem, 3vw, 3.15rem));
     position: sticky;
     top: var(--sl-nav-height);
     max-height: calc(100vh - var(--sl-nav-height));
@@ -54,7 +54,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
     border-inline-start: 0;
     position: static;
     height: 100%;
-    padding-top: calc(var(--netscli-docs-hero-height) + 1px);
+    padding-top: calc(var(--ui-docs-hero-height) + 1px);
     overflow: visible;
   }
 
@@ -69,7 +69,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
     content: "";
     position: absolute;
     inset-inline: 0;
-    inset-block-start: var(--netscli-docs-hero-height);
+    inset-block-start: var(--ui-docs-hero-height);
     height: 1px;
     background: var(--sl-color-hairline);
     pointer-events: none;
@@ -79,7 +79,7 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
     content: "";
     position: absolute;
     inset-inline-start: 0;
-    inset-block: calc(var(--netscli-docs-hero-height) + 1px) 0;
+    inset-block: calc(var(--ui-docs-hero-height) + 1px) 0;
     width: 1px;
     background: var(--sl-color-hairline);
     pointer-events: none;
@@ -93,11 +93,11 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   }
 
   .right-sidebar-container {
-    flex: 0 0 var(--netscli-docs-toc-width);
-    width: var(--netscli-docs-toc-width);
+    flex: 0 0 var(--ui-docs-toc-width);
+    width: var(--ui-docs-toc-width);
   }
 
   .right-sidebar {
-    width: var(--netscli-docs-toc-width);
+    width: var(--ui-docs-toc-width);
   }
 }

--- a/site/src/styles/landing/base.css
+++ b/site/src/styles/landing/base.css
@@ -1,6 +1,6 @@
 *,*::before,*::after{box-sizing:border-box}
 :root{
-  --netscli-shell-gutter:24px;
+  --ui-shell-gutter:24px;
 }
 html{
   scroll-behavior:smooth;
@@ -9,17 +9,17 @@ html{
 }
 *{
   scrollbar-width:thin;
-  scrollbar-color:rgba(140,149,166,.42) rgba(var(--netscli-lift-rgb),.035);
+  scrollbar-color:rgba(140,149,166,.42) rgba(var(--ui-lift-rgb),.035);
 }
 ::-webkit-scrollbar{width:12px;height:12px}
-::-webkit-scrollbar-track{background:var(--netscli-bg)}
+::-webkit-scrollbar-track{background:var(--ui-bg)}
 ::-webkit-scrollbar-thumb{
   background:rgba(140,149,166,.45);
-  border:3px solid var(--netscli-bg);
+  border:3px solid var(--ui-bg);
   border-radius:999px;
 }
 ::-webkit-scrollbar-thumb:hover{background:rgba(170,178,192,.62)}
-::-webkit-scrollbar-corner{background:var(--netscli-bg)}
+::-webkit-scrollbar-corner{background:var(--ui-bg)}
 html[data-theme='light']{
   scrollbar-color:rgba(68,81,106,.42) rgba(241,245,249,.92);
 }
@@ -36,7 +36,7 @@ html[data-theme='light'] ::-webkit-scrollbar-corner{background:#f1f5f9}
 body{
   margin:0;
   font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
-  background:var(--netscli-bg);color:var(--netscli-text);line-height:1.6;
+  background:var(--ui-bg);color:var(--ui-text);line-height:1.6;
   -webkit-font-smoothing:antialiased;
 }
 .skip-link{
@@ -47,8 +47,8 @@ body{
   padding:8px 12px;
   border:1px solid #2dd4bf;
   border-radius:6px;
-  background:var(--netscli-bg);
-  color:var(--netscli-text-strong);
+  background:var(--ui-bg);
+  color:var(--ui-text-strong);
   transform:translateY(calc(-100% - 16px));
   transition:transform .15s ease;
 }
@@ -76,17 +76,17 @@ body.not-found-page .not-found{
 }
 a{color:inherit}
 /* Inline code follows the theme, like the command chips and unlike the block
-   samples. It was `--netscli-code-bg`, so a near-black chip landed mid-
+   samples. It was `--ui-code-bg`, so a near-black chip landed mid-
    sentence on a white page -- `netscli`, `--json`, `netscli serve` punching
    holes through the surfaces prose. See the chip note in code-surface.css. */
 code{
   font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:.85em;
-  background:var(--netscli-chip-bg);padding:2px 6px;border-radius:4px;
-  color:var(--netscli-chip-code-fg);
+  background:var(--ui-chip-bg);padding:2px 6px;border-radius:4px;
+  color:var(--ui-chip-code-fg);
 }
 
 /* layout */
-.w{max-width:var(--netscli-shell-width);margin:0 auto;padding:0 var(--netscli-shell-gutter)}
+.w{max-width:var(--ui-shell-width);margin:0 auto;padding:0 var(--ui-shell-gutter)}
 
 /* buttons */
 .btn{
@@ -94,10 +94,10 @@ code{
   padding:10px 20px;border-radius:8px;font-size:.875rem;font-weight:600;
   text-decoration:none;transition:all 120ms;
 }
-.btn-w{background:#e5e5e5;color:var(--netscli-bg);border:1px solid #e5e5e5}
+.btn-w{background:#e5e5e5;color:var(--ui-bg);border:1px solid #e5e5e5}
 .btn-w:hover{background:#fff;border-color:#fff}
-.btn-o{background:transparent;color:var(--netscli-text-muted);border:1px solid rgba(var(--netscli-lift-rgb),.15)}
-.btn-o:hover{color:var(--netscli-text);border-color:rgba(255,255,255,.3);text-decoration:none}
+.btn-o{background:transparent;color:var(--ui-text-muted);border:1px solid rgba(var(--ui-lift-rgb),.15)}
+.btn-o:hover{color:var(--ui-text);border-color:rgba(255,255,255,.3);text-decoration:none}
 .gh-icon{width:16px;height:16px;fill:currentColor;flex-shrink:0}
 
 
@@ -119,9 +119,9 @@ section{
  * what axe does with text over a gradient. */
 section:nth-of-type(even){
   background:
-    linear-gradient(180deg,rgba(var(--netscli-lift-rgb),.018),rgba(var(--netscli-lift-rgb),.006)),
-    var(--netscli-surface);
-  border-block:1px solid rgba(var(--netscli-lift-rgb),.045);
+    linear-gradient(180deg,rgba(var(--ui-lift-rgb),.018),rgba(var(--ui-lift-rgb),.006)),
+    var(--ui-surface);
+  border-block:1px solid rgba(var(--ui-lift-rgb),.045);
 }
 /* No alternating band on a light page. Two dark moments carry the rhythm
  * instead -- #install below and the footer -- and every other section is the
@@ -148,7 +148,7 @@ section:nth-of-type(even){
  * one and not the other, which is invisible from either file alone. */
 html[data-theme='light'] section,
 html[data-theme='light'] .surfaces-section{
-  background:var(--netscli-bg);
+  background:var(--ui-bg);
 }
 
 /* The accent wash went with the band it belonged to. It is a radial
@@ -180,17 +180,17 @@ html[data-theme='light'] section:nth-of-type(even)::before{
  * Both themes, like the surface cards, so the rhythm is not a light-mode-only
  * device. */
 #install{
-  background:var(--netscli-band-dark);
-  box-shadow:var(--netscli-band-inset),var(--netscli-band-edge-shadow);
-  color:var(--netscli-ondark-text);
-  --netscli-text:var(--netscli-ondark-text);
-  --netscli-text-strong:var(--netscli-ondark-text-strong);
-  --netscli-text-muted:var(--netscli-ondark-text-muted);
-  --netscli-accent:var(--netscli-ondark-accent);
-  --netscli-accent-rgb:var(--netscli-ondark-accent-rgb);
-  --netscli-accent-bright:var(--netscli-ondark-accent-bright);
-  --netscli-hairline-rgb:255, 255, 255;
-  --netscli-lift-rgb:255, 255, 255;
+  background:var(--ui-band-dark);
+  box-shadow:var(--ui-band-inset),var(--ui-band-edge-shadow);
+  color:var(--ui-ondark-text);
+  --ui-text:var(--ui-ondark-text);
+  --ui-text-strong:var(--ui-ondark-text-strong);
+  --ui-text-muted:var(--ui-ondark-text-muted);
+  --ui-accent:var(--ui-ondark-accent);
+  --ui-accent-rgb:var(--ui-ondark-accent-rgb);
+  --ui-accent-bright:var(--ui-ondark-accent-bright);
+  --ui-hairline-rgb:255, 255, 255;
+  --ui-lift-rgb:255, 255, 255;
 }
 
 /* The recommended-install card is a LIGHT card on the band in the light
@@ -198,15 +198,15 @@ html[data-theme='light'] section:nth-of-type(even)::before{
    in dark, where .reco is a dark card and the on-dark ramp above is already
    right -- hence the theme scope. Same trap as .faq-command and the chips. */
 html[data-theme='light'] #install .reco{
-  color:var(--netscli-text);
-  --netscli-text:#44516a;
-  --netscli-text-strong:#111827;
-  --netscli-text-muted:#596478;
-  --netscli-accent:#146b2e;
-  --netscli-accent-rgb:20, 107, 46;
-  --netscli-accent-bright:#0e5122;
-  --netscli-hairline-rgb:17, 24, 39;
-  --netscli-lift-rgb:17, 24, 39;
+  color:var(--ui-text);
+  --ui-text:#44516a;
+  --ui-text-strong:#111827;
+  --ui-text-muted:#596478;
+  --ui-accent:#146b2e;
+  --ui-accent-rgb:20, 107, 46;
+  --ui-accent-bright:#0e5122;
+  --ui-hairline-rgb:17, 24, 39;
+  --ui-lift-rgb:17, 24, 39;
 }
 
 /* The Try-it panel stays a dark code surface -- it is something you read, not
@@ -219,22 +219,22 @@ html[data-theme='light'] #install .reco{
 }
 
 html[data-theme='light'] footer{
-  --netscli-band-navy:#141c2e;
-  background:var(--netscli-band-navy);
-  box-shadow:var(--netscli-band-inset),var(--netscli-band-edge-shadow);
+  --ui-band-navy:#141c2e;
+  background:var(--ui-band-navy);
+  box-shadow:var(--ui-band-inset),var(--ui-band-edge-shadow);
   /* Explicit, not just the token. The element inherits `color` from <body>,
      where the token already resolved to the light ramp, so re-pointing the
      token alone leaves text that sets no colour of its own dark on navy.
      Measured rgb(68,81,106) until this line. */
-  color:var(--netscli-text);
-  --netscli-text:var(--netscli-ondark-text);
-  --netscli-text-strong:var(--netscli-ondark-text-strong);
-  --netscli-text-muted:var(--netscli-ondark-text-muted);
-  --netscli-accent:var(--netscli-ondark-accent);
-  --netscli-accent-rgb:var(--netscli-ondark-accent-rgb);
-  --netscli-accent-bright:var(--netscli-ondark-accent-bright);
-  --netscli-hairline-rgb:255, 255, 255;
-  --netscli-lift-rgb:255, 255, 255;
+  color:var(--ui-text);
+  --ui-text:var(--ui-ondark-text);
+  --ui-text-strong:var(--ui-ondark-text-strong);
+  --ui-text-muted:var(--ui-ondark-text-muted);
+  --ui-accent:var(--ui-ondark-accent);
+  --ui-accent-rgb:var(--ui-ondark-accent-rgb);
+  --ui-accent-bright:var(--ui-ondark-accent-bright);
+  --ui-hairline-rgb:255, 255, 255;
+  --ui-lift-rgb:255, 255, 255;
 }
 
 section:nth-of-type(even)::before{
@@ -242,13 +242,13 @@ section:nth-of-type(even)::before{
   position:absolute;inset:0;
   pointer-events:none;
   z-index:0;
-  background:radial-gradient(circle at 18% 0%,rgba(var(--netscli-accent-rgb),.055),transparent 34rem);
+  background:radial-gradient(circle at 18% 0%,rgba(var(--ui-accent-rgb),.055),transparent 34rem);
 }
 section>.w{position:relative;z-index:1}
-section h2{font-size:1.5rem;font-weight:700;color:var(--netscli-text-strong);margin:0 0 6px}
-section .lead{color:var(--netscli-text-muted);font-size:.9375rem;margin:0 0 28px}
-section .lead a{color:var(--netscli-accent);text-decoration:underline;text-underline-offset:3px}
-section .lead a:hover{color:var(--netscli-accent-bright)}
+section h2{font-size:1.5rem;font-weight:700;color:var(--ui-text-strong);margin:0 0 6px}
+section .lead{color:var(--ui-text-muted);font-size:.9375rem;margin:0 0 28px}
+section .lead a{color:var(--ui-accent);text-decoration:underline;text-underline-offset:3px}
+section .lead a:hover{color:var(--ui-accent-bright)}
 
 
 /* ─── COPY BUTTON ─── */
@@ -256,16 +256,16 @@ section .lead a:hover{color:var(--netscli-accent-bright)}
 .copy-btn{
   position:absolute;top:50%;right:5px;transform:translateY(-50%);
   /* Opaque background so text behind the button isn't visible through it */
-  background:var(--netscli-surface-raised);border:1px solid rgba(var(--netscli-lift-rgb),.12);
+  background:var(--ui-surface-raised);border:1px solid rgba(var(--ui-lift-rgb),.12);
   border-radius:6px;
   /* Themed, not a literal white. The icon is an inline SVG stroked with
      `currentColor`, so `rgba(255,255,255,.34)` drew it white on white in the
      light theme -- every copy button rendered as an empty square. The button's
      own background and border already used the lift channel; only the ink did
-     not. --netscli-text-muted rather than a lift alpha because it is the same
+     not. --ui-text-muted rather than a lift alpha because it is the same
      ink the rest of the page uses for secondary marks, and it is contrast
      checked. */
-  color:var(--netscli-text-muted);
+  color:var(--ui-text-muted);
   width:27px;height:27px;padding:0;
   display:inline-flex;align-items:center;justify-content:center;
   cursor:pointer;opacity:0;
@@ -275,7 +275,7 @@ section .lead a:hover{color:var(--netscli-accent-bright)}
 .has-copy:hover .copy-btn,.has-copy:focus-within .copy-btn{opacity:1}
 .faq-command:hover .copy-btn,.faq-command:focus-within .copy-btn{opacity:1}
 .faq-command .copy-btn{right:10px}
-.copy-btn:hover{background:var(--netscli-surface-raised);border-color:rgba(var(--netscli-lift-rgb),.18);color:var(--netscli-text-strong)}
+.copy-btn:hover{background:var(--ui-surface-raised);border-color:rgba(var(--ui-lift-rgb),.18);color:var(--ui-text-strong)}
 .copy-btn.copied{color:#3fb950;border-color:rgba(63,185,80,.4)}
 .surface-visual .codeblock .copy-btn,
 .tryblock .copy-btn{

--- a/site/src/styles/landing/lightbox.css
+++ b/site/src/styles/landing/lightbox.css
@@ -23,7 +23,7 @@
   inset:0;
   z-index:1200; /* above .skip-link's 1000 */
   padding:32px;
-  background:rgba(var(--netscli-bg-rgb), .86);
+  background:rgba(var(--ui-bg-rgb), .86);
   backdrop-filter:blur(3px);
 }
 .image-lightbox.open{
@@ -44,9 +44,9 @@ body.lightbox-open{overflow:hidden}
 }
 .image-lightbox-frame{
   min-height:0; /* lets the image shrink inside the flex column */
-  border:1px solid rgba(var(--netscli-lift-rgb),.14);
+  border:1px solid rgba(var(--ui-lift-rgb),.14);
   border-radius:10px;
-  background:var(--netscli-bg);
+  background:var(--ui-bg);
   overflow:hidden;
 }
 .image-lightbox-frame img{
@@ -65,7 +65,7 @@ body.lightbox-open{overflow:hidden}
   font-size:.85rem;
   /* Deliberately not a dim grey: this sits on the overlay's near-black
      backdrop, where the site's muted greys fall under 4.5:1. */
-  color:var(--netscli-text);
+  color:var(--ui-text);
 }
 .image-lightbox-caption:empty{display:none}
 
@@ -84,15 +84,15 @@ body.lightbox-open{overflow:hidden}
   height:36px;
   display:grid;
   place-items:center;
-  border:1px solid rgba(var(--netscli-lift-rgb),.18);
+  border:1px solid rgba(var(--ui-lift-rgb),.18);
   border-radius:999px;
-  background:var(--netscli-surface);
-  color:var(--netscli-text-strong);
+  background:var(--ui-surface);
+  color:var(--ui-text-strong);
   font-size:1.25rem;
   line-height:1;
   cursor:pointer;
 }
-.image-lightbox-close:hover{background:var(--netscli-surface-raised);border-color:rgba(255,255,255,.32)}
+.image-lightbox-close:hover{background:var(--ui-surface-raised);border-color:rgba(255,255,255,.32)}
 .image-lightbox-close:focus-visible{outline:2px solid #2dd4bf;outline-offset:2px}
 
 /* No light-theme overrides here on purpose. The lightbox only runs on the

--- a/site/src/styles/landing/tokens.css
+++ b/site/src/styles/landing/tokens.css
@@ -24,24 +24,24 @@
    * Defaults are the code surface, so the dark theme is unchanged and the two
    * kinds of thing look identical there -- on a dark page there is nothing to
    * mismatch. Only the light theme pulls them apart. */
-  --netscli-chip-bg: var(--netscli-code-bg);
-  --netscli-chip-border: var(--netscli-code-border);
-  --netscli-chip-divider: var(--netscli-code-divider);
-  --netscli-chip-fg: var(--netscli-code-fg);
-  --netscli-chip-fg-muted: #9a9a9a;
-  --netscli-chip-raised: #20242b;
-  --netscli-chip-lift-rgb: 255, 255, 255;
+  --ui-chip-bg: var(--ui-code-bg);
+  --ui-chip-border: var(--ui-code-border);
+  --ui-chip-divider: var(--ui-code-divider);
+  --ui-chip-fg: var(--ui-code-fg);
+  --ui-chip-fg-muted: #9a9a9a;
+  --ui-chip-raised: #20242b;
+  --ui-chip-lift-rgb: 255, 255, 255;
   /* Inline `code` in prose rides the chip too. A word inside a sentence is
      neither a control nor a sample: on a white page a near-black chip mid-
      paragraph reads as a hole punched in the text. */
-  --netscli-chip-code-fg: var(--netscli-code-inline-fg);
+  --ui-chip-code-fg: var(--ui-code-inline-fg);
   /* Accent INSIDE a chip. The install band re-points the accent to its
      on-dark values, and a control sitting on a light chip on that band
      inherited them -- the Download button's hover was #86efac on a light
      row, 1.62:1. */
-  --netscli-chip-accent: var(--netscli-ondark-accent);
-  --netscli-chip-accent-rgb: var(--netscli-ondark-accent-rgb);
-  --netscli-chip-accent-bright: var(--netscli-ondark-accent-bright);
+  --ui-chip-accent: var(--ui-ondark-accent);
+  --ui-chip-accent-rgb: var(--ui-ondark-accent-rgb);
+  --ui-chip-accent-bright: var(--ui-ondark-accent-bright);
 
   /* ---- Ink on a dark surface -------------------------------------------
    *
@@ -50,18 +50,18 @@
    * alternating dark surface cards, and any future one. Each was carrying
    * its own copy of these six values, which is exactly how two of them
    * would eventually disagree. One definition, referenced. */
-  --netscli-ondark-text: #d7dce5;
-  --netscli-ondark-text-strong: #f4f4f4;
-  --netscli-ondark-text-muted: #9aa4b8;
-  --netscli-ondark-accent: #22c55e;
-  --netscli-ondark-accent-rgb: 34, 197, 94;
-  --netscli-ondark-accent-bright: #86efac;
+  --ui-ondark-text: #d7dce5;
+  --ui-ondark-text-strong: #f4f4f4;
+  --ui-ondark-text-muted: #9aa4b8;
+  --ui-ondark-accent: #22c55e;
+  --ui-ondark-accent-rgb: 34, 197, 94;
+  --ui-ondark-accent-bright: #86efac;
 
   /* The dark band behind every other surface card. Measured against the
      light page at 14.75:1, and it carries body ink at 11.09:1 and muted ink
      at 6.09:1. Not as dark as the code surface on purpose -- see the note on
      the card rule in Surfaces.astro for why that gap cannot do the work. */
-  --netscli-band-dark: #1c2634;
+  --ui-band-dark: #1c2634;
 
   /* The band's inner edge. A pair of inset shadows, top and bottom, with a
      negative spread so each one stays a thin gradient at its own edge instead
@@ -76,11 +76,11 @@
      half -- the page picking up a little shade where the dark section meets
      it, so the two do not simply abut. Small on purpose: the join should
      read as a seam, not as a floating panel. */
-  --netscli-band-edge-shadow:
+  --ui-band-edge-shadow:
     0 -6px 14px -6px rgba(17, 24, 39, 0.18),
     0 6px 14px -6px rgba(17, 24, 39, 0.18);
 
-  --netscli-band-inset:
+  --ui-band-inset:
     inset 0 14px 18px -10px rgba(0, 0, 0, 0.7),
     inset 0 -14px 18px -10px rgba(0, 0, 0, 0.7);
 
@@ -97,33 +97,33 @@
    * scale so they stay in proportion to each other when either theme
    * changes. The light values use the hairline channel rather than black,
    * which is the same thing the nav's scroll shadow was corrected to. */
-  --netscli-lift-sm: 0 12px 28px rgba(0, 0, 0, 0.32);
-  --netscli-lift-md: 0 12px 40px rgba(0, 0, 0, 0.4);
-  --netscli-lift-lg: 0 32px 80px rgba(0, 0, 0, 0.6);
+  --ui-lift-sm: 0 12px 28px rgba(0, 0, 0, 0.32);
+  --ui-lift-md: 0 12px 40px rgba(0, 0, 0, 0.4);
+  --ui-lift-lg: 0 32px 80px rgba(0, 0, 0, 0.6);
 }
 
 html[data-theme='light'] {
   /* Same surface and the same 1.52:1 edge as the .reco card, so a chip and a
      card read as the same family of object. */
-  --netscli-chip-bg: #f2f5fa;
-  --netscli-chip-border: rgba(17, 24, 39, 0.2);
-  --netscli-chip-divider: rgba(17, 24, 39, 0.14);
-  --netscli-chip-fg: #44516a;
-  --netscli-chip-fg-muted: #596478;
-  --netscli-chip-raised: #f2f5fa;
-  --netscli-chip-lift-rgb: 17, 24, 39;
+  --ui-chip-bg: #f2f5fa;
+  --ui-chip-border: rgba(17, 24, 39, 0.2);
+  --ui-chip-divider: rgba(17, 24, 39, 0.14);
+  --ui-chip-fg: #44516a;
+  --ui-chip-fg-muted: #596478;
+  --ui-chip-raised: #f2f5fa;
+  --ui-chip-lift-rgb: 17, 24, 39;
   /* 8.66:1 on the light chip. The dark theme's #86efac is a light-on-dark
      green and measures 1.5:1 there, so it cannot simply carry over. */
-  --netscli-chip-code-fg: #0e5122;
-  --netscli-chip-accent: #146b2e;
-  --netscli-chip-accent-rgb: 20, 107, 46;
-  --netscli-chip-accent-bright: #0e5122;
+  --ui-chip-code-fg: #0e5122;
+  --ui-chip-accent: #146b2e;
+  --ui-chip-accent-rgb: 20, 107, 46;
+  --ui-chip-accent-bright: #0e5122;
 
   /* Elevation on a light page: the hairline channel, not black, and much
      shallower. See the scale above. */
-  --netscli-lift-sm: 0 6px 16px rgba(17, 24, 39, 0.07);
-  --netscli-lift-md: 0 10px 28px rgba(17, 24, 39, 0.1);
-  --netscli-lift-lg: 0 22px 56px rgba(17, 24, 39, 0.14);
+  --ui-lift-sm: 0 6px 16px rgba(17, 24, 39, 0.07);
+  --ui-lift-md: 0 10px 28px rgba(17, 24, 39, 0.1);
+  --ui-lift-lg: 0 22px 56px rgba(17, 24, 39, 0.14);
 }
 
 /* ─── INK ON THE DARK CODE SURFACE ───
@@ -133,7 +133,7 @@ html[data-theme='light'] {
  *
  * Done by redefining the ramp tokens on the subtree rather than by restating
  * `color:` on each descendant. The children already say
- * `color: var(--netscli-text)` and friends -- about a dozen of them across the
+ * `color: var(--ui-text)` and friends -- about a dozen of them across the
  * install section alone -- so re-pointing the token fixes all of them at once
  * and, more usefully, cannot miss one that gets added later. The first attempt
  * patched them individually and the contrast sweep found 52 it had not
@@ -148,12 +148,12 @@ html[data-theme='light'] {
 .try,
 .codeblock,
 .faq-command code {
-  --netscli-text: var(--netscli-code-fg);
-  --netscli-text-strong: #f4f4f4;
-  --netscli-text-muted: #9a9a9a;
-  --netscli-accent-bright: var(--netscli-code-inline-fg);
+  --ui-text: var(--ui-code-fg);
+  --ui-text-strong: #f4f4f4;
+  --ui-text-muted: #9a9a9a;
+  --ui-accent-bright: var(--ui-code-inline-fg);
   /* The copy button sits INSIDE these blocks, and global.css draws it with
-   * `background: var(--netscli-surface-raised)` -- a page surface, which is
+   * `background: var(--ui-surface-raised)` -- a page surface, which is
    * near-white in the light theme. Measured on the landing page before this
    * line: rgb(242,245,250) on an rgb(16,21,27) block, a white chip on a dark
    * sample. The ramp above fixed the button's ink and left its background
@@ -167,7 +167,7 @@ html[data-theme='light'] {
    * than for the ink: its copy button really does sit on the light card, not
    * on the chip, so it must keep the light surface. Only `.faq-command code`
    * is remapped, and that element has no button inside it. */
-  --netscli-surface-raised: #20242b;
+  --ui-surface-raised: #20242b;
 }
 
 /* The same remap for chips, pointed at the chip tokens instead of the code
@@ -180,16 +180,16 @@ html[data-theme='light'] {
 .cmd,
 .alt,
 .hero-command {
-  --netscli-text: var(--netscli-chip-fg);
-  --netscli-text-strong: var(--netscli-chip-fg);
-  --netscli-text-muted: var(--netscli-chip-fg-muted);
-  --netscli-surface-raised: var(--netscli-chip-raised);
-  --netscli-lift-rgb: var(--netscli-chip-lift-rgb);
+  --ui-text: var(--ui-chip-fg);
+  --ui-text-strong: var(--ui-chip-fg);
+  --ui-text-muted: var(--ui-chip-fg-muted);
+  --ui-surface-raised: var(--ui-chip-raised);
+  --ui-lift-rgb: var(--ui-chip-lift-rgb);
   /* The accent too, not just the ink. A control sitting on a chip -- the
      install rows' Download button -- otherwise inherits the band's on-dark
      accent and hovers to #86efac on a light row: measured 1.19:1. */
-  --netscli-accent: var(--netscli-chip-accent);
-  --netscli-accent-rgb: var(--netscli-chip-accent-rgb);
-  --netscli-accent-bright: var(--netscli-chip-accent-bright);
-  color: var(--netscli-text);
+  --ui-accent: var(--ui-chip-accent);
+  --ui-accent-rgb: var(--ui-chip-accent-rgb);
+  --ui-accent-bright: var(--ui-chip-accent-bright);
+  color: var(--ui-text);
 }

--- a/site/src/styles/theme-control.css
+++ b/site/src/styles/theme-control.css
@@ -28,7 +28,7 @@
  * nothing else reads them -- and because tokens.css is at the 300-line guard,
  * where the answer is to split by ownership rather than to raise the limit.
  * The cross-stack values the control also uses (the accent, the text ramp,
- * --netscli-hover-border, --netscli-lift-rgb) stay there: those are shared.
+ * --ui-hover-border, --ui-lift-rgb) stay there: those are shared.
  *
  * The option colours are stated opaquely and per theme on purpose. The
  * dropdown list is drawn by the platform, which will not use a translucent
@@ -36,27 +36,27 @@
  * rows fell back to the browser default -- white rows with black text hanging
  * off a dark header, which is what "the dropdown is unstyled" looks like. */
 :root {
-  --netscli-control-border: rgba(var(--netscli-lift-rgb), 0.1);
-  --netscli-control-bg: rgba(var(--netscli-lift-rgb), 0.03);
-  --netscli-control-option-fg: #f4f4f4;
-  --netscli-control-option-bg: #1a1f27;
+  --ui-control-border: rgba(var(--ui-lift-rgb), 0.1);
+  --ui-control-bg: rgba(var(--ui-lift-rgb), 0.03);
+  --ui-control-option-fg: #f4f4f4;
+  --ui-control-option-bg: #1a1f27;
 }
 
 html[data-theme='light'] {
   /* Not the lift channel at a different alpha, unlike the dark pair above: a
      wash of the light theme's near-black reads grey-blue and heavy on a white
      bar, so these keep the hand-picked values the docs control already used. */
-  --netscli-control-border: rgba(70, 89, 120, 0.24);
-  --netscli-control-bg: rgba(255, 255, 255, 0.58);
-  --netscli-control-option-fg: #132033;
-  --netscli-control-option-bg: #f4f7fb;
+  --ui-control-border: rgba(70, 89, 120, 0.24);
+  --ui-control-bg: rgba(255, 255, 255, 0.58);
+  --ui-control-option-fg: #132033;
+  --ui-control-option-bg: #f4f7fb;
 }
 
 /* Structure. Starlight's Select.astro supplies this for the docs control
    through its own scoped styles; the landing control has no such source, so
    it is stated here for both rather than left to one side's component. */
 starlight-theme-select label,
-.netscli-theme-select label {
+.ui-theme-select label {
   --sl-label-icon-size: 0.875rem;
   --sl-caret-size: 1.25rem;
   --sl-inline-padding: 0.5rem;
@@ -72,19 +72,19 @@ starlight-theme-select label,
   min-height: 2.35rem;
   min-width: 5.35rem;
   padding-inline: 0.65rem;
-  border: 1px solid var(--netscli-control-border);
+  border: 1px solid var(--ui-control-border);
   border-radius: 6px;
-  background: var(--netscli-control-bg);
-  color: var(--netscli-text);
+  background: var(--ui-control-bg);
+  color: var(--ui-text);
 }
 
 starlight-theme-select,
-.netscli-theme-select {
-  color: var(--netscli-text);
+.ui-theme-select {
+  color: var(--ui-text);
 }
 
 starlight-theme-select label .icon,
-.netscli-theme-select label .icon {
+.ui-theme-select label .icon {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -99,7 +99,7 @@ starlight-theme-select label .icon,
    padding instead. The <select> keeps its own left padding, so its text still
    clears the icon. */
 starlight-theme-select label .label-icon,
-.netscli-theme-select label .label-icon {
+.ui-theme-select label .label-icon {
   font-size: var(--sl-label-icon-size);
   inset-inline-start: 0.65rem;
 }
@@ -110,13 +110,13 @@ starlight-theme-select label .label-icon,
    0. Measured: the icon sat 11.2px from the label's left edge and the caret
    0.8px from its right, inside 10.4px of padding on both sides. */
 starlight-theme-select label .caret,
-.netscli-theme-select label .caret {
+.ui-theme-select label .caret {
   font-size: var(--sl-caret-size);
   inset-inline-end: 0.65rem;
 }
 
 starlight-theme-select select,
-.netscli-theme-select select {
+.ui-theme-select select {
   border: 0;
   color: inherit;
   background: transparent;
@@ -154,9 +154,9 @@ starlight-theme-select select,
 }
 
 starlight-theme-select label:hover,
-.netscli-theme-select label:hover {
-  color: var(--netscli-text-strong);
-  border-color: var(--netscli-hover-border);
+.ui-theme-select label:hover {
+  color: var(--ui-text-strong);
+  border-color: var(--ui-hover-border);
   background: transparent;
 }
 
@@ -175,30 +175,30 @@ starlight-theme-select label:hover,
  * background, which is three signals for one state and read as an error
  * rather than a cursor position. */
 starlight-theme-select label:focus-within,
-.netscli-theme-select label:focus-within {
-  color: var(--netscli-text-strong);
-  border-color: rgba(var(--netscli-accent-rgb), 0.45);
-  box-shadow: 0 0 0 2px rgba(var(--netscli-accent-rgb), 0.22);
+.ui-theme-select label:focus-within {
+  color: var(--ui-text-strong);
+  border-color: rgba(var(--ui-accent-rgb), 0.45);
+  box-shadow: 0 0 0 2px rgba(var(--ui-accent-rgb), 0.22);
   outline: 0;
 }
 
 starlight-theme-select select:focus-visible,
-.netscli-theme-select select:focus-visible {
+.ui-theme-select select:focus-visible {
   outline: 0;
 }
 
 /* Opaque, per theme -- see the note on the tokens at the top of this file. */
 starlight-theme-select option,
-.netscli-theme-select option {
-  color: var(--netscli-control-option-fg);
-  background-color: var(--netscli-control-option-bg);
+.ui-theme-select option {
+  color: var(--ui-control-option-fg);
+  background-color: var(--ui-control-option-bg);
 }
 
 html[data-theme='light'] starlight-theme-select label:hover,
 html[data-theme='light'] starlight-theme-select label:focus-within,
-html[data-theme='light'] .netscli-theme-select label:hover,
-html[data-theme='light'] .netscli-theme-select label:focus-within {
-  border-color: rgba(var(--netscli-accent-rgb), 0.34);
+html[data-theme='light'] .ui-theme-select label:hover,
+html[data-theme='light'] .ui-theme-select label:focus-within {
+  border-color: rgba(var(--ui-accent-rgb), 0.34);
 }
 
 /* The landing bar's theme icon, one of three.
@@ -215,13 +215,13 @@ html[data-theme='light'] .netscli-theme-select label:focus-within {
  * the case where that script did not run at all (storage blocked and it threw
  * before the assignment): auto is the honest default there, because auto is
  * what an unset preference means. */
-.netscli-theme-select .label-icon {
+.ui-theme-select .label-icon {
   display: none;
 }
 
-html:not([data-theme-choice]) .netscli-theme-select .label-icon[data-icon='auto'],
-html[data-theme-choice='auto'] .netscli-theme-select .label-icon[data-icon='auto'],
-html[data-theme-choice='light'] .netscli-theme-select .label-icon[data-icon='light'],
-html[data-theme-choice='dark'] .netscli-theme-select .label-icon[data-icon='dark'] {
+html:not([data-theme-choice]) .ui-theme-select .label-icon[data-icon='auto'],
+html[data-theme-choice='auto'] .ui-theme-select .label-icon[data-icon='auto'],
+html[data-theme-choice='light'] .ui-theme-select .label-icon[data-icon='light'],
+html[data-theme-choice='dark'] .ui-theme-select .label-icon[data-icon='dark'] {
   display: block;
 }

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -30,8 +30,8 @@
   /* Total height of the top bar including its bottom border, on both the
      landing page and the docs. Starlight's own --sl-nav-height is set from
      this in starlight/01-tokens-and-header.css. */
-  --netscli-nav-height: 3.75rem;
-  --netscli-shell-width: 72rem;
+  --ui-nav-height: 3.75rem;
+  --ui-shell-width: 72rem;
 
   /* ---- Wordmark ------------------------------------------------------
    *
@@ -49,7 +49,7 @@
    *
    * A ratio rather than a length because the transparent margin scales with
    * the rendered width, so the compensation has to as well: a breakpoint
-   * that narrows the wordmark sets --netscli-mark-width and the inset
+   * that narrows the wordmark sets --ui-mark-width and the inset
    * follows. Do not pre-compose the two into a single length token -- a
    * var() inside a custom property resolves where it is DECLARED, so the
    * composed value would freeze at whatever :root said and quietly ignore
@@ -57,15 +57,15 @@
    *
    * scripts/wordmark-inset.mjs re-derives the ratio from the PNG itself and
    * fails if this value has drifted from it. */
-  --netscli-mark-width: 160px;
+  --ui-mark-width: 160px;
 
   /* Both bars filter the wordmark through this. Dark leaves it alone; the
      light theme darkens it -- see the override below for why. A token rather
      than a rule on `.mark`, because the landing bar and the docs bar are
      different components with their own scoped styles, and this is one
      decision, not two. */
-  --netscli-mark-filter: none;
-  --netscli-mark-inset-ratio: 0.0778;
+  --ui-mark-filter: none;
+  --ui-mark-inset-ratio: 0.0778;
 
   /* Tells the browser which way to draw the controls it renders itself: the
    * <select> popup in the theme control, native focus rings, and form
@@ -87,28 +87,28 @@
    * sites that need an alpha. There were 108 hard-coded copies of the old
    * value across 20 files before this; changing it should be one edit here.
    * The light theme's darker accent is in the light block below. */
-  --netscli-accent: #22c55e;
-  --netscli-accent-rgb: 34, 197, 94;
+  --ui-accent: #22c55e;
+  --ui-accent-rgb: 34, 197, 94;
   /* Hover and other lifted states.
    *
    * #4ade80 was only a 1.31x luminance step up from the accent, against the
    * 1.52x the old teal pair had, so hovering a link looked like nothing
    * happened. #86efac restores a visible step at 1.63x. */
-  --netscli-accent-bright: #86efac;
+  --ui-accent-bright: #86efac;
   /* Pale tint for active text on dark surfaces. */
-  --netscli-accent-high: #a7f3c6;
+  --ui-accent-high: #a7f3c6;
   /* Hover border for interactive chrome: the theme control in both bars, and
      the pagination links in the docs. Was declared only in
      starlight/28-final-interaction-guardrails.css, so the landing bar's copy
      of the same control could not reach it and hovered a different colour.
      The expression is unchanged -- --sl-color-accent and --sl-color-hairline
      were aliases of these two netscli values. */
-  --netscli-hover-border: color-mix(in srgb, var(--netscli-accent) 42%, rgba(var(--netscli-lift-rgb), 0.08));
+  --ui-hover-border: color-mix(in srgb, var(--ui-accent) 42%, rgba(var(--ui-lift-rgb), 0.08));
 
   /* Text drawn ON the accent, where the accent is a fill rather than ink.
      A literal near-black in 404.astro until the light theme existed, at
      which point it became near-black on a dark green button. */
-  --netscli-on-accent: #06130f;
+  --ui-on-accent: #06130f;
 
   /* ---- Brand gradient -------------------------------------------------
    *
@@ -125,9 +125,9 @@
    *
    * Every stop now clears 4.5:1 on its own theme's page: 5.73 / 8.29 / 11.45
    * dark, 8.18 / 6.40 / 7.02 light. scripts/design-tokens.mjs checks them. */
-  --netscli-brand-gradient-from: #16a34a;
-  --netscli-brand-gradient-via: #22c55e;
-  --netscli-brand-gradient-to: #1edcff;
+  --ui-brand-gradient-from: #16a34a;
+  --ui-brand-gradient-via: #22c55e;
+  --ui-brand-gradient-to: #1edcff;
 
   /* ---- Cross-stack role channels -------------------------------------
    *
@@ -143,9 +143,9 @@
    * its own alpha. */
 
   /* Hairlines, dividers, and the neutral washes drawn from them. */
-  --netscli-hairline-rgb: 140, 149, 166;
+  --ui-hairline-rgb: 140, 149, 166;
   /* The direction "raised" points: white on a dark surface. */
-  --netscli-lift-rgb: 255, 255, 255;
+  --ui-lift-rgb: 255, 255, 255;
 
   /* ---- Text ramp ------------------------------------------------------
    *
@@ -164,10 +164,10 @@
    * There is no fourth, dimmer step. One was tried, borrowing Starlight's
    * gray-4, and axe caught it on both themes at 3.04:1 and 3.50:1 against a
    * 4.5 floor -- gray-4 is a BORDER colour there, and using it for text was
-   * the mistake. The dimmest text this site draws is --netscli-text-muted. */
-  --netscli-text-strong: #f4f4f4;
-  --netscli-text: #c2cad8;
-  --netscli-text-muted: #8c95a6;
+   * the mistake. The dimmest text this site draws is --ui-text-muted. */
+  --ui-text-strong: #f4f4f4;
+  --ui-text: #c2cad8;
+  --ui-text-muted: #8c95a6;
 
   /* ---- Surfaces -------------------------------------------------------
    *
@@ -181,14 +181,14 @@
    * Values are the docs' --sl-color-bg, gray-6 and the panel surface, so a
    * card on the landing page and a card in the docs are finally the same
    * colour. */
-  --netscli-bg: #111111;
-  --netscli-surface: #191d25;
-  --netscli-surface-raised: #20242b;
+  --ui-bg: #111111;
+  --ui-surface: #191d25;
+  --ui-surface-raised: #20242b;
   /* The page background as channels, for the translucent bars drawn over
      content: the sticky nav, the mobile menu, the lightbox scrim. Those were
      four slightly different near-black rgba() values -- 17/17/17, 22/24/26,
      25/25/25, 8/8/8 -- none of which could follow a theme. */
-  --netscli-bg-rgb: 17, 17, 17;
+  --ui-bg-rgb: 17, 17, 17;
 }
 
 /* The wordmark's one size step, for both bars.
@@ -208,7 +208,7 @@
  * custom property resolving where it is declared. */
 @media (max-width: 600px) {
   :root {
-    --netscli-mark-width: 132px;
+    --ui-mark-width: 132px;
   }
 }
 
@@ -236,12 +236,12 @@ html[data-theme='light'] {
    * would also be a second file to keep in step with this one and with
    * scripts/wordmark-inset.mjs. One declaration, reversible, until the hue
    * shift bothers someone. */
-  --netscli-mark-filter: brightness(0.62);
+  --ui-mark-filter: brightness(0.62);
 
   /* The accent, as a colour and as channels.
    *
    * Only the -rgb form was overridden here until now, so every
-   * `color: var(--netscli-accent)` call site kept rendering the DARK #22c55e
+   * `color: var(--ui-accent)` call site kept rendering the DARK #22c55e
    * on a white page -- 2.0:1, and the single largest source of the light
    * theme's contrast failures. It went unnoticed because the a11y check's
    * light pass was passing no colour-scheme flag and so tested dark twice on
@@ -250,50 +250,50 @@ html[data-theme='light'] {
    * Depth inverts with the theme here as it does for surfaces: "bright" is a
    * hover state, which means further from the page, so on white it is DARKER
    * than the base accent rather than lighter. */
-  --netscli-accent: #146b2e;
-  --netscli-accent-rgb: 20, 107, 46;
-  --netscli-accent-bright: #0e5122;
-  --netscli-accent-high: #0a3d19;
+  --ui-accent: #146b2e;
+  --ui-accent-rgb: 20, 107, 46;
+  --ui-accent-bright: #0e5122;
+  --ui-accent-high: #0a3d19;
   /* White on the accent fill: 6.62:1 against #146b2e, where the dark theme's
      near-black would be 1.7:1. */
-  --netscli-on-accent: #ffffff;
+  --ui-on-accent: #ffffff;
 
   /* 0.1, not the dark theme's 0.08: --sl-color-hairline carried a different
      alpha per theme, and this reproduces it rather than rounding the two
      together. */
-  --netscli-hover-border: color-mix(in srgb, var(--netscli-accent) 42%, rgba(var(--netscli-lift-rgb), 0.1));
+  --ui-hover-border: color-mix(in srgb, var(--ui-accent) 42%, rgba(var(--ui-lift-rgb), 0.1));
   /* The same arc, walked in the direction that stays legible on white. */
-  --netscli-brand-gradient-from: #005a1e;
-  --netscli-brand-gradient-via: #146b2e;
-  --netscli-brand-gradient-to: #155e75;
+  --ui-brand-gradient-from: #005a1e;
+  --ui-brand-gradient-via: #146b2e;
+  --ui-brand-gradient-to: #155e75;
 
-  --netscli-hairline-rgb: 17, 24, 39;
+  --ui-hairline-rgb: 17, 24, 39;
   /* On a light surface, raised is DARKER. See the note in the docs' token
      file for the 27 rules that had this backwards. */
-  --netscli-lift-rgb: 17, 24, 39;
+  --ui-lift-rgb: 17, 24, 39;
 
   /* The light ramp, again matching the docs. Starlight inverts its own
      naming here -- --sl-color-white is #111827 in the light theme -- which is
      why "strong" is the darkest of these rather than the lightest.
      --sl-color-gray-3 carries a note about not lightening it; the same
-     applies to --netscli-text-muted, which is the same value and is checked
+     applies to --ui-text-muted, which is the same value and is checked
      against every surface by scripts/design-tokens.mjs. */
-  --netscli-text-strong: #111827;
-  --netscli-text: #44516a;
-  --netscli-text-muted: #596478;
+  --ui-text-strong: #111827;
+  --ui-text: #44516a;
+  --ui-text-muted: #596478;
 
   /* Light surfaces, again the docs' own: --sl-color-bg, gray-6, and the
      panel. Depth inverts with the theme -- a raised surface is lighter than
      the page in the dark theme and darker than it here -- which is why these
      are named for depth rather than for a colour. */
-  --netscli-bg: #fbfbfb;
+  --ui-bg: #fbfbfb;
   /* Blue-grey, not neutral grey. The alternating band and the cards standing
      on it were #f4f6f8/#f6f8fa, which is the page with the colour taken out
      -- so the "Get started" section read as a slightly dirty white rather
      than as its own surface. A navy cast gives it somewhere to be without
      touching a single piece of text: the ramp measures 15.68 / 7.05 / 5.27
      on the band and 16.23 / 7.30 / 5.46 on a card. */
-  --netscli-surface: #eef1f7;
-  --netscli-surface-raised: #f2f5fa;
-  --netscli-bg-rgb: 251, 251, 251;
+  --ui-surface: #eef1f7;
+  --ui-surface-raised: #f2f5fa;
+  --ui-bg-rgb: 251, 251, 251;
 }


### PR DESCRIPTION
79 custom properties, six class names and the docs table marker carried the product's name while meaning nothing product-specific. In a fork that made every search for the product name turn up hundreds of irrelevant hits.

Mechanical rename; the product's own names (installer files, the wordmark asset) are untouched. Stacked on #346.

No visual change: all 240 screenshot captures match the baseline, and the contrast and design-token gates pass on the renamed tokens.