### PR TITLE
site: read the last of the product's copy from site-content

### DIFF
--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -7,6 +7,7 @@ const shouldRenderSearch =
   config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
 
 import { hrefFor, isCurrent, navGroupBreak, navLinks } from '../../data/site-content/nav';
+import { branding } from '../../data/site-content/meta';
 
 const pathname = Astro.url.pathname;
 
@@ -21,7 +22,7 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
 
 <div class="docs-topbar">
   <a class="docs-mark" href="/" aria-label="NetsCLI home">
-    <img src="/assets/netscli-wordmark.png" alt="NetsCLI" width="160" height="32" />
+    <img src={branding.wordmark} alt={branding.wordmarkAlt} width="160" height="32" />
   </a>
 
   <div class="docs-header-search print:hidden">

--- a/site/src/data/site-content/hero.ts
+++ b/site/src/data/site-content/hero.ts
@@ -1,5 +1,5 @@
-import type { Hero, HeroDownload } from './types';
-import { INSTALL_SH_COMMAND } from './install-urls';
+import type { Hero, HeroCommands, HeroDownload } from './types';
+import { INSTALL_PS1_COMMAND, INSTALL_SH_COMMAND } from './install-urls';
 
 export const hero: Hero = {
   // Platforms only. "Open source" and "MIT" repeat in the footer and the
@@ -126,3 +126,32 @@ export const heroDownloads: HeroDownload[] = [
     cue: 'Linux · .deb package',
   },
 ];
+
+// What the hero's two command rows say once the visitor's platform is known.
+// `quickInstall` and `quickInstallAlt` above are the server-rendered defaults
+// for the same two rows; these replace them per platform.
+//
+// Keyed by ROUTE, not by rank: `packageManager` is the package-manager line
+// and `script` the one-liner, and the hero puts each in the row that fits it
+// -- the wide row beside the button takes the script, the narrower row below
+// takes the package manager. They were once named `primary`/`secondary`,
+// which described rank rather than route, and Linux had the two the other way
+// round, so the wide row got a 90-character URL on one platform and a short
+// package command on the others.
+export const heroCommands: HeroCommands = {
+  windows: {
+    // Moniker, matching the hero's server-rendered default. `Moniker:
+    // netscli` is published in the winget catalog alongside the canonical
+    // `fstubner.netscli`, so both resolve.
+    packageManager: 'winget install netscli',
+    script: INSTALL_PS1_COMMAND,
+  },
+  macos: {
+    packageManager: 'brew tap fstubner/tap && brew install netscli',
+    script: INSTALL_SH_COMMAND,
+  },
+  linux: {
+    packageManager: 'yay -S netscli-bin',
+    script: INSTALL_SH_COMMAND,
+  },
+};

--- a/site/src/data/site-content/install.ts
+++ b/site/src/data/site-content/install.ts
@@ -178,3 +178,16 @@ export const tryCommands: TryCommand[] = [
  * rather than a choice. */
 export const installBinariesNote =
   'Rust users can <code>cargo install netscli</code>. Every asset is checksummed and signed with <a href="https://docs.sigstore.dev/cosign/overview/">Sigstore cosign</a> — see <a href="/docs/install/#verifying-a-download">how to verify a download</a>, plus standalone binaries and packet-capture builds.';
+
+// Two things /llms.txt says that no page does: a build-from-source route,
+// listed after the per-platform quickstart, and any caveat a reader acting
+// on that list needs. They live here because they are claims about the
+// product, and a claim kept in the route file is one nobody edits when it
+// stops being true.
+export const installFromSource = 'cargo install netscli';
+
+export const installNotes = [
+  'Packet capture is a compile-time feature. No published desktop installer',
+  'includes it; capture-enabled CLI assets are published separately and also',
+  'need a system capture library (libpcap or Npcap).',
+];

--- a/site/src/data/site-content/types.ts
+++ b/site/src/data/site-content/types.ts
@@ -38,6 +38,17 @@ export interface Branding {
   fg: string;
 }
 
+/** The hero's two command rows, per platform. */
+export type HeroCommands = Record<
+  Platform,
+  {
+    /** Package-manager line, for the narrower row. */
+    packageManager: string;
+    /** Install one-liner, for the wide row beside the download button. */
+    script: string;
+  }
+>;
+
 /** One installer in the hero's Desktop app menu.
  *
  *  The list is content, not markup: a product with no desktop build leaves
@@ -224,6 +235,10 @@ export interface SiteData {
     byPlatform: Record<Platform, PlatformInstall>;
     tryCommands: TryCommand[];
     binariesNote: string;
+    /** Build-from-source command, listed in /llms.txt after the quickstart. */
+    fromSource: string;
+    /** Caveats /llms.txt prints under the install list, one line each. */
+    notes: string[];
   };
   faq: FaqItem[];
   builtWith: BuiltWithEntry[];

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -9,6 +9,8 @@ import {
   installBinariesNote,
   installByPlatform,
   installCopy,
+  installFromSource,
+  installNotes,
   tryCommands,
 } from './site-content/install';
 import { faq, faqCopy } from './site-content/faq';
@@ -49,6 +51,8 @@ export const site: SiteData = {
     byPlatform: installByPlatform,
     tryCommands,
     binariesNote: installBinariesNote,
+    fromSource: installFromSource,
+    notes: installNotes,
   },
   faq,
   builtWith,

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -108,11 +108,11 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
     // define:vars scripts aren't run through Vite's import resolution, so a
     // relative `import` here 404s at runtime. Stash the server-computed data
     // on window and import the real module from a plain script below instead.
-    window.__netscliChangelogData = { repo, fallbackReleases, releaseSummaries };
+    window.__siteChangelogData = { repo, fallbackReleases, releaseSummaries };
   </script>
   <script>
     import { initChangelogPage } from '../scripts/changelog-page';
-    const { repo, fallbackReleases, releaseSummaries } = window.__netscliChangelogData;
+    const { repo, fallbackReleases, releaseSummaries } = window.__siteChangelogData;
     initChangelogPage(repo, fallbackReleases, releaseSummaries);
   </script>
 </Page>

--- a/site/src/pages/llms.txt.ts
+++ b/site/src/pages/llms.txt.ts
@@ -41,7 +41,7 @@ export async function GET() {
   });
 
   const lines = [
-    '# NetsCLI',
+    `# ${meta.siteName}`,
     '',
     `> ${hero.subhead}`,
     '',
@@ -50,11 +50,9 @@ export async function GET() {
     '## Install',
     '',
     ...quickstart,
-    `- **From source**: \`cargo install netscli\``,
+    `- **From source**: \`${install.fromSource}\``,
     '',
-    'Packet capture is a compile-time feature. No published desktop installer',
-    'includes it; capture-enabled CLI assets are published separately and also',
-    'need a system capture library (libpcap or Npcap).',
+    ...install.notes,
     '',
     '## Documentation',
     '',

--- a/site/src/scripts/changelog/global.d.ts
+++ b/site/src/scripts/changelog/global.d.ts
@@ -5,7 +5,7 @@ declare global {
     /** Server-computed changelog data, bridged from a define:vars script
      *  (which isn't run through Vite's import resolution) to the plain
      *  module script that renders it. See pages/changelog.astro. */
-    __netscliChangelogData: {
+    __siteChangelogData: {
       repo: string;
       fallbackReleases: ChangelogRelease[];
       releaseSummaries: Record<string, string>;

--- a/site/src/scripts/docs-header.ts
+++ b/site/src/scripts/docs-header.ts
@@ -96,7 +96,7 @@ export function initDocsHeader(): void {
       const text = message.textContent?.trim().replace(/\s+/g, ' ');
       if (
         !text ||
-        ((message as HTMLElement).dataset.netscliMessageText === text &&
+        ((message as HTMLElement).dataset.uiMessageText === text &&
           message.querySelector('.search-data'))
       ) {
         return;
@@ -109,14 +109,14 @@ export function initDocsHeader(): void {
           `${results[2].toLowerCase()} for`,
           { value: results[3] },
         ]);
-        (message as HTMLElement).dataset.netscliMessageText = text;
+        (message as HTMLElement).dataset.uiMessageText = text;
         return;
       }
 
       const zeroResults = text.match(/^No results for\s+(.+)$/i);
       if (zeroResults) {
         setSearchMessage(message, ['No results for', { value: zeroResults[1] }]);
-        (message as HTMLElement).dataset.netscliMessageText = text;
+        (message as HTMLElement).dataset.uiMessageText = text;
       }
     });
   };

--- a/site/src/scripts/landing/os-tabs.ts
+++ b/site/src/scripts/landing/os-tabs.ts
@@ -8,8 +8,7 @@
  * derived from both.
  */
 import type { NavigatorWithUserAgentData, OperatingSystem } from './os-types';
-import { INSTALL_PS1_COMMAND, INSTALL_SH_COMMAND } from '../../data/site-content/install-urls';
-import { heroDownloads } from '../../data/site-content/hero';
+import { heroCommands, heroDownloads } from '../../data/site-content/hero';
 
 export function initOsTabs(): void {
   // OS tab swap. Keep visual state and ARIA state aligned so package
@@ -19,7 +18,7 @@ export function initOsTabs(): void {
   // A chosen tab outlives the page. Detection is a guess -- someone on a
   // Windows machine installing on a Linux box was re-guessed back to
   // Windows on every reload, losing the choice they had just made.
-  const OS_KEY = "netscli:install-os";
+  const OS_KEY = "site:install-os";
   const remember = (os: OperatingSystem) => {
     try {
       localStorage.setItem(OS_KEY, os);
@@ -110,38 +109,10 @@ export function initOsTabs(): void {
     //   pipeline that does not run there, with the correct `winget` line
     //   demoted to the smaller box below it.
     //
-    //   Linux: `packageCommands.linux` was byte-identical to
+    //   Linux: the package command was byte-identical to
     //   `hero.quickInstall`, so the hero printed the same command twice.
     //
-    // Keyed by ROUTE, not by rank.
-    //
-    // These were `primary` and `secondary`, meaning "what the install section
-    // recommends" and "a genuinely different route" -- but the two rows the
-    // hero puts them in are different SIZES, not different ranks, and Linux
-    // had the script under `primary` while Windows and macOS had it under
-    // `secondary`. So the wide row got a package-manager command on two
-    // platforms and a 90-character URL on the third. Naming them for what
-    // they are lets each row take the one that fits it.
-    const heroCommands: Record<OperatingSystem, { packageManager: string; script: string }> = {
-      windows: {
-        // Moniker, matching the hero's server-rendered default. `Moniker:
-        // netscli` is published in the winget catalog alongside the
-        // canonical `fstubner.netscli`, so both resolve.
-        packageManager: "winget install netscli",
-        script:
-          INSTALL_PS1_COMMAND,
-      },
-      macos: {
-        packageManager: "brew tap fstubner/tap && brew install netscli",
-        script:
-          INSTALL_SH_COMMAND,
-      },
-      linux: {
-        packageManager: "yay -S netscli-bin",
-        script:
-          INSTALL_SH_COMMAND,
-      },
-    };
+    // The pairs themselves are content, in site-content/hero.ts.
 
     const setHeroCommand = (id: string, command: string) => {
       const host = document.getElementById(id);


### PR DESCRIPTION
Four places a fork would still ship netscli's content: the docs header wordmark, the hero's per-platform command pairs, three product claims inside `/llms.txt`, and three internal identifiers the prefix rename missed.

`/llms.txt` is byte-identical to main's, and all 240 screenshot captures match the baseline.