### PR TITLE
site: describe the install groups without naming the product

### DIFF
--- a/site/src/data/site-content/types.ts
+++ b/site/src/data/site-content/types.ts
@@ -167,9 +167,10 @@ export interface InstallEntry {
  *  alternative rows in array order.
  */
 export interface PlatformInstall {
-  /** CLI + terminal UI (the `netscli` binary). */
+  /** Command-line routes: the binary itself, however it is installed. */
   cli: InstallEntry[];
-  /** Desktop GUI application. */
+  /** Desktop application routes. Leave empty for a product with no
+   *  desktop build; the section renders without that column. */
   desktop: InstallEntry[];
 }
 


### PR DESCRIPTION
One doc comment in the content types named netscli's binary while describing what the field is for. Also says what an empty `desktop` list means, which the hero already documents.