### PR TITLE
site: keep the measurements in four comments, drop the product name

### DIFF
--- a/site/scripts/wordmark-inset.mjs
+++ b/site/scripts/wordmark-inset.mjs
@@ -27,8 +27,8 @@ import { fileURLToPath } from 'node:url';
 
 const siteRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 // Which file, from the same place the bars read it: site-content/meta.ts.
-// Hard-coding the name here meant a fork that swapped in its own wordmark
-// still had this guard measuring netscli's.
+// Hard-coding the name here meant a site that swapped in its own wordmark
+// still had this guard measuring the one it replaced.
 const metaSource = fs.readFileSync(path.join(siteRoot, 'src', 'data', 'site-content', 'meta.ts'), 'utf8');
 const wordmark = metaSource.match(/wordmark:\s*'([^']+)'/);
 if (!wordmark) {

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -240,9 +240,10 @@ const defaultDownload = heroDownloads[0];
 .hero .social-proof .sep{color:var(--ui-text-muted)}
 .hero-cta{
   /* 610, not 560, and sized off the viewport rather than a vw fraction.
-     At 560 the wide command slot was 351px against 397px of text, so
-     `iwr -useb https://netscli.com/install.ps1 | iex` was still clipped by
-     46px even after the URL was shortened -- measured, not estimated. The
+     At 560 the wide command slot was 351px against 397px of text, so a
+     47-character install one-liner -- `iwr -useb https://<domain>/install.ps1
+     | iex` -- was still clipped by 46px even after the URL was shortened,
+     measured rather than estimated. The
      62vw term also made the width non-monotonic: it governed between 900 and
      984px and put the CTA back under 560 there, so a cap alone would have
      fixed only the widest screens. Below 820px the CTA switches to a wrapped

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -371,8 +371,8 @@ a.install-download:focus-visible{
  * itself the horizontal scroller (`overflow-x:auto; white-space:pre`) with
  * the copy button absolutely positioned inside it, and overflowing inline
  * content paints straight across a scroll container's right padding -- so
- * the `padding-right:74px` above reserved nothing. Measured at 375px, 38px
- * of `winget install fstubner.netscli.gui` rendered underneath an opaque
+ * the `padding-right:74px` above reserved nothing. Measured at 375px with a
+ * 35-character winget command, 38px of it rendered underneath an opaque
  * button, with a scrollbar beneath it.
  *
  * `overflow:hidden` + `text-overflow:ellipsis` clips at the *content* box

--- a/site/src/scripts/landing/copy-buttons.ts
+++ b/site/src/scripts/landing/copy-buttons.ts
@@ -37,12 +37,13 @@ export function initCopyButtons(): void {
         // Copy the commands, not the sample output shown beneath them.
         //
         // Every non-empty line used to be kept, `$` stripped, and the lot
-        // joined. On the CLI example that meant a button labelled "Copy
-        // command" produced the two commands *plus* the JSON they print:
+        // joined. On a block that shows a command and its output, that meant
+        // a button labelled "Copy command" produced the command *plus* the
+        // JSON it prints:
         //
-        //     netscli scan demo.local -p 80,443 --json
+        //     some-tool run --json
         //     [
-        //       { "port": 80,  "open": true, "service": "http"  },
+        //       { "ok": true },
         //     ...
         //
         // Pasted into a shell that runs the scan, then tries to execute


### PR DESCRIPTION
Four comments explained a defect using a netscli string as the measurement's input, which reads oddly in a fork. The measurements are unchanged — 46px of clipping against a 47-character one-liner, 38px of a 35-character command — only the strings are now described by length rather than quoted.

All 68 built files are byte-identical to main's.