### PR TITLE
site: read the 404 and changelog page copy from site-content

### DIFF
--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -1,7 +1,7 @@
 ---
 import { site } from '../data/site';
 import { hrefFor, isCurrent, navGroupBreak, navLinks } from '../data/site-content/nav';
-const { branding } = site;
+const { branding, meta } = site;
 const pathname = Astro.url.pathname;
 const onHome = pathname === '/';
 
@@ -17,7 +17,7 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
 ---
 <nav data-site-nav data-open="false">
   <div class="nav-inner">
-    <a class="mark" href="/" aria-label="NetsCLI home">
+    <a class="mark" href="/" aria-label={`${meta.siteName} home`}>
       <img src={branding.wordmark} alt="" width="160" height="32" />
     </a>
     <button

--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -7,7 +7,7 @@ const shouldRenderSearch =
   config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
 
 import { hrefFor, isCurrent, navGroupBreak, navLinks } from '../../data/site-content/nav';
-import { branding } from '../../data/site-content/meta';
+import { branding, meta } from '../../data/site-content/meta';
 
 const pathname = Astro.url.pathname;
 
@@ -21,7 +21,7 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
 ---
 
 <div class="docs-topbar">
-  <a class="docs-mark" href="/" aria-label="NetsCLI home">
+  <a class="docs-mark" href="/" aria-label={`${meta.siteName} home`}>
     <img src={branding.wordmark} alt={branding.wordmarkAlt} width="160" height="32" />
   </a>
 

--- a/site/src/data/site-content/changelog.ts
+++ b/site/src/data/site-content/changelog.ts
@@ -1,0 +1,40 @@
+import type { SectionCopy } from './types';
+import { meta } from './meta';
+
+// The changelog page's own copy, and one plain-language summary per release.
+//
+// The page reads GitHub Releases at runtime and falls back to CHANGELOG.md,
+// so the version list itself is never written here. These summaries are the
+// part a person writes: what a release meant for someone using the product,
+// in a sentence, above the generated notes. A tag with no entry here simply
+// renders without one.
+export const changelogCopy: SectionCopy = {
+  heading: `${meta.siteName} release notes`,
+  leadHtml: `Versioned release notes for shipped ${meta.siteName} changes, fixes, and packaging updates.`,
+};
+
+/** Shown when the page is shared. */
+export const changelogOgDescription = `Versioned ${meta.siteName} release notes and shipped changes.`;
+
+export const releaseSummaries: Record<string, string> = {
+  'v0.3.0':
+    'The desktop workspace is redesigned, scan results carry richer status data, and interactive interfaces gain probe concurrency controls. Public docs are refreshed and packaging is fixed across release channels.',
+  'v0.2.6':
+    'Installed GUI builds now identify themselves correctly, and the Windows title-bar controls work. Also completes the CLI/TUI refactors that make future interface changes easier to review and test.',
+  'v0.2.5':
+    'Closes a DNS resolver security advisory. Windows subnet detection is fixed, so discovery and sweep find real LAN hosts again, and package publishing now covers GUI installers.',
+  'v0.2.4':
+    'v0.2.3 built the GUI installers but never attached them. Publishing is repaired here, along with the AUR deploy action that was blocking Linux packages.',
+  'v0.2.3':
+    'GUI installer builds move again once the Tauri JavaScript and Rust versions agree, and the AUR packaging handoff is fixed. CLI packages were already usable from v0.2.2; the GUI artifacts needed these pipeline fixes.',
+  'v0.2.2':
+    'This is a release-pipeline recovery build. It refreshes Cargo.lock so locked release builds can run reproducibly after dependency bumps, giving package-manager users a working replacement for the failed v0.2.1 artifacts.',
+  'v0.2.1':
+    'Desktop installers and signed release assets mean you no longer need a Rust toolchain to install. Adds concurrency tuning for networks that struggle with large parallel scans.',
+  'v0.2.0':
+    'Turns the initial scanner into something distributable. mDNS discovery and typed core errors on the product side; shell completions, man pages, package-manager templates and signed artifacts on the shipping side.',
+  'v0.1.1':
+    'Cleans up the first public version: crate documentation, security notes and a structured changelog, plus the release workflow fixes that make binaries and pcap variants reproducible.',
+  'v0.1.0':
+    'This is the first public NetsCLI release: one Rust core powers the CLI, terminal UI, desktop app, and MCP server, with structured output and cross-platform binaries for early users.',
+};

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -2,11 +2,14 @@
 import Page from '../layouts/Page.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
+import { site } from '../data/site';
+
+const { meta } = site;
 ---
 
 <Page
-  title="Page not found | NetsCLI"
-  description="The requested NetsCLI page could not be found."
+  title={`Page not found | ${meta.siteName}`}
+  description={`The requested ${meta.siteName} page could not be found.`}
   canonicalPath="/404.html"
   includeFaqSchema={false}
   bodyClass="not-found-page"

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -5,33 +5,16 @@ import Footer from '../components/Footer.astro';
 import { site } from '../data/site';
 import changelogText from '../../../CHANGELOG.md?raw';
 import { renderReleaseListHtml } from '../scripts/changelog/render-static';
+import {
+  changelogCopy,
+  changelogOgDescription,
+  releaseSummaries,
+} from '../data/site-content/changelog';
 
 const { hero, social } = site;
-const title = 'NetsCLI release notes';
-const description = 'Versioned release notes for shipped NetsCLI changes, fixes, and packaging updates.';
+const title = changelogCopy.heading;
+const description = changelogCopy.leadHtml;
 
-const releaseSummaries: Record<string, string> = {
-  'v0.3.0':
-    'The desktop workspace is redesigned, scan results carry richer status data, and interactive interfaces gain probe concurrency controls. Public docs are refreshed and packaging is fixed across release channels.',
-  'v0.2.6':
-    'Installed GUI builds now identify themselves correctly, and the Windows title-bar controls work. Also completes the CLI/TUI refactors that make future interface changes easier to review and test.',
-  'v0.2.5':
-    'Closes a DNS resolver security advisory. Windows subnet detection is fixed, so discovery and sweep find real LAN hosts again, and package publishing now covers GUI installers.',
-  'v0.2.4':
-    'v0.2.3 built the GUI installers but never attached them. Publishing is repaired here, along with the AUR deploy action that was blocking Linux packages.',
-  'v0.2.3':
-    'GUI installer builds move again once the Tauri JavaScript and Rust versions agree, and the AUR packaging handoff is fixed. CLI packages were already usable from v0.2.2; the GUI artifacts needed these pipeline fixes.',
-  'v0.2.2':
-    'This is a release-pipeline recovery build. It refreshes Cargo.lock so locked release builds can run reproducibly after dependency bumps, giving package-manager users a working replacement for the failed v0.2.1 artifacts.',
-  'v0.2.1':
-    'Desktop installers and signed release assets mean you no longer need a Rust toolchain to install. Adds concurrency tuning for networks that struggle with large parallel scans.',
-  'v0.2.0':
-    'Turns the initial scanner into something distributable. mDNS discovery and typed core errors on the product side; shell completions, man pages, package-manager templates and signed artifacts on the shipping side.',
-  'v0.1.1':
-    'Cleans up the first public version: crate documentation, security notes and a structured changelog, plus the release workflow fixes that make binaries and pcap variants reproducible.',
-  'v0.1.0':
-    'This is the first public NetsCLI release: one Rust core powers the CLI, terminal UI, desktop app, and MCP server, with structured output and cross-platform binaries for early users.',
-};
 
 const parseLocalChangelog = (text: string) => {
   const headings = [...text.matchAll(/^## \[([^\]]+)\](?:\s+(?:—|-)\s+(\d{4}-\d{2}-\d{2}))?/gm)];
@@ -75,7 +58,7 @@ const staticRelease = renderReleaseListHtml(fallbackReleases, hero.sourceUrl.spl
   title={title}
   description={description}
   canonicalPath="/changelog/"
-  ogDescription="Versioned NetsCLI release notes and shipped changes."
+  ogDescription={changelogOgDescription}
   includeFaqSchema={false}
 >
   <Nav />

--- a/site/src/scripts/landing/os-tabs.ts
+++ b/site/src/scripts/landing/os-tabs.ts
@@ -87,8 +87,8 @@ export function initOsTabs(): void {
     // Confirmed on a Pixel 8 UA, where `platform` is exactly "Android".
     //
     // Apple's mobile platforms group with macOS, and Android/Chrome OS
-    // with Linux. Neither can actually run NetsCLI, so the goal is only to
-    // show the least wrong thing to someone browsing on a phone and to
+    // with Linux. Neither runs a desktop binary at all, so the goal is only
+    // to show the least wrong thing to someone browsing on a phone and to
     // stop claiming a Mac is involved when it is not.
     //
     // `cros` is matched before `linux` deliberately: Chrome OS is


### PR DESCRIPTION
Seven more places with the product name compiled into the shell: the 404 page's head copy, the changelog page's copy and its ten per-release summaries, and the home link's accessible name in both bars. None are on the landing page, which is why the earlier check missed them.

The summaries move to `site-content/changelog.ts`. All 68 built files are byte-identical.