### PR TITLE
site: make the landing page's section order content

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,6 +1,11 @@
 ---
 import { site } from '../data/site';
+import { sections } from '../data/site-content/sections';
 const { hero, heroDownloads, social } = site;
+// The jump link only exists if there is an install section to jump to.
+// sections.ts can drop one, and a link to a section the page does not render
+// scrolls nowhere.
+const hasInstall = (sections as readonly string[]).includes('install');
 // What the button points at before any script runs, and what a crawler
 // reads. The list's first entry, so the markup can never name a file the
 // content file does not list.
@@ -112,7 +117,7 @@ const defaultDownload = heroDownloads[0];
       <div class="hero-command has-copy hero-copy" id="hero-package-install" data-copy={hero.quickInstall}>
         <code>{hero.quickInstall}</code>
       </div>
-      <a class="hero-install-link" href="#install">{hero.installLinkLabel}</a>
+      {hasInstall && <a class="hero-install-link" href="#install">{hero.installLinkLabel}</a>}
     </div>
   </div>
 </div>

--- a/site/src/data/site-content/nav.ts
+++ b/site/src/data/site-content/nav.ts
@@ -14,6 +14,8 @@
  * form.
  */
 
+import { sections } from './sections';
+
 export interface NavLink {
   label: string;
   /** Set for links to another page. Mutually exclusive with `section`. */
@@ -26,7 +28,7 @@ export interface NavLink {
   mobileGroup: 'site' | 'project';
 }
 
-export const navLinks: NavLink[] = [
+const allLinks: NavLink[] = [
   { label: 'Features', section: 'surfaces', mobileGroup: 'site' },
   { label: 'Install', section: 'install', mobileGroup: 'site' },
   { label: 'FAQ', section: 'faq', mobileGroup: 'site' },
@@ -39,6 +41,18 @@ export const navLinks: NavLink[] = [
     mobileGroup: 'project',
   },
 ];
+
+/** The links this site actually has.
+ *
+ * An anchor link is only reachable if the landing page renders the section it
+ * points at, and site-content/sections.ts decides that. Without this filter a
+ * product that dropped a section kept a bar link that scrolled nowhere -- the
+ * same defect as a docs sidebar entry whose page was deleted, in the one
+ * component every page renders.
+ */
+export const navLinks: NavLink[] = allLinks.filter(
+  (link) => !link.section || (sections as readonly string[]).includes(link.section)
+);
 
 /** Index of the first link that NAVIGATES rather than scrolling.
  *

--- a/site/src/data/site-content/sections.ts
+++ b/site/src/data/site-content/sections.ts
@@ -1,0 +1,13 @@
+import type { LandingSection } from './types';
+
+// Which sections the landing page renders, in order.
+//
+// The four are independent: each reads its own content file and none assumes
+// what sits above it. So a product with no install story drops 'install'
+// rather than filling it with something weak, and one whose visitors ask
+// questions before they read features can put 'faq' second.
+//
+// A name that appears twice renders twice; a name whose content is empty
+// renders nothing. Dropping the last section is fine -- the footer is not in
+// this list, and neither is the nav.
+export const sections: LandingSection[] = ['hero', 'surfaces', 'install', 'faq'];

--- a/site/src/data/site-content/types.ts
+++ b/site/src/data/site-content/types.ts
@@ -211,6 +211,10 @@ export interface SectionCopy {
   leadHtml: string;
 }
 
+/** A section the landing page can render. Adding one here means adding a
+ *  component for it in src/pages/index.astro's map. */
+export type LandingSection = 'hero' | 'surfaces' | 'install' | 'faq';
+
 /** One group in the docs sidebar, as Starlight expects it. */
 export interface DocsSection {
   label: string;

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -7,15 +7,22 @@ import Install from '../components/Install.astro';
 import Faq from '../components/Faq.astro';
 import Footer from '../components/Footer.astro';
 import { site } from '../data/site';
+import { sections } from '../data/site-content/sections';
+
 const githubRepo = site.social.repo;
+
+// One component per section name. The list in site-content/sections.ts is
+// the order; this is only the lookup, and a name with no entry here is a
+// type error rather than a silently missing section.
+const COMPONENTS = { hero: Hero, surfaces: Surfaces, install: Install, faq: Faq };
 ---
 <Page>
   <Nav />
   <main id="main" data-github-repo={githubRepo}>
-    <Hero />
-    <Surfaces />
-    <Install />
-    <Faq />
+    {sections.map((name) => {
+      const Section = COMPONENTS[name];
+      return <Section />;
+    })}
   </main>
   <Footer />
 


### PR DESCRIPTION
`site-content/sections.ts` is now the list of landing sections and their order; `index.astro` maps over it.

Dropping a section is the case that matters: the nav in both headers and the hero's jump link read the same list, so a dropped section takes its links with it rather than leaving one that scrolls nowhere.

netscli's own output is byte-identical. Verified the other way with `['hero', 'faq', 'surfaces']` — reordered, install gone, no dead links.