### PR TITLE
Collapse the unreleased notes into one 0.3.1 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,157 @@ them: it printed "24 Aug 2026" for 0.3.1 for four days on the strength of a
 date written here when the notes were drafted. An in-flight version keeps
 its heading and collects entries; the date and the link go on with the tag.
 
-## [Unreleased]
+## [0.3.1]
+
+The first release since 0.2.6 in May, and a large one: four months of work on
+the desktop app, the shared core and the website.
+
+The features are additive -- richer port-scan results, configurable probe
+concurrency everywhere, tab management in the workspace -- and the long tail
+is fixes, most of them found by using the desktop app on a real network
+rather than by reading the code. The recurring theme in that tail is code
+that reported success while doing nothing.
+
+It is numbered 0.3.1 because the crates, the desktop app and its Tauri
+manifest already carry that version. 0.3.0 was tagged and its notes drafted,
+but no release was ever published from it and no binary carries the number;
+its entries are here. There is no 0.3.0 release to look for.
+
+### Added
+
+- **Tabs can be reordered.** Drag one along the strip, or move it with the
+  keyboard. The strip already had a pointer drag, but it scrolled the strip,
+  so grabbing a tab moved the viewport rather than the tab -- and no gesture
+  did the thing a tab drag is for. Drag-to-scroll still works in the space
+  around the tabs. The drop slot is decided by tab midpoints rather than
+  pixels travelled, because tabs are sized by their labels and a fixed step
+  drifts further the more you move.
+- **Clear ARP table, then discover.** A chevron beside Run offers a
+  cache-flushing variant on discover, sweep and the ARP tab — the tools where
+  a stale neighbour entry changes the answer. Clearing needs administrator
+  rights; when it fails the run is suppressed rather than quietly returning
+  the stale entries it was meant to drop.
+- **Right-click a tab to close it, its neighbours, or all of them.** Close,
+  close others, close to the right, close to the left, close all. Every item
+  acts on the tab you clicked rather than the active one — those are often
+  different — and anything that would do nothing is greyed rather than
+  hidden, so the menu keeps its shape wherever you open it. Closing cancels
+  whatever those tabs were running.
+- **Richer port scan results across every interface.** Port scans now
+  report additive status and detail fields (`open`, `closed`,
+  `filtered`, `error`, latency, banners, HTTP metadata, TLS metadata,
+  and raw previews where available) while keeping the older `open`,
+  `port`, `service`, and `error` fields intact for compatibility.
+- **GUI render automation.** The desktop app now has Tauri/WebDriver
+  render coverage for the diagnostic workspace, including tab layout,
+  top menus, toolbar actions, filtering, row selection, detail panes,
+  command preview, and status bar behavior.
+- **User-configurable probe concurrency.** The CLI and MCP server already
+  accepted concurrency limits; the desktop app settings and TUI settings
+  now expose the same control so users can reduce simultaneous probes on
+  fragile networks or raise them within the core safety cap.
+- **Address-family display preference in the desktop app.** The status bar
+  now prefers IPv4 by default and lets users choose IPv6-first display when
+  that better matches their environment.
+
+### Changed
+
+- **A scan or inspect opened from a result starts on its own.** Right-clicking
+  a discovered host and choosing "Scan 192.168.1.5" opened a tab pre-filled
+  with that host and then waited for a Run press -- a step that asked you to
+  repeat what the click had already said.
+- **Destructive menu items are red before you hover them.** Exit had the
+  danger variant; Clear Current Results and Clear History did not, so two
+  items that throw work away looked exactly like Export CSV -- and the
+  context menu had no notion of a variant at all, so the same action looked
+  different depending on which menu you reached it through. The icon carries
+  the colour, not the label: a red row reads as an error sitting in the menu
+  rather than an ordinary item that happens to destroy something.
+- **The interface dropdown is quieter.** A row could carry three competing
+  status treatments at once — a `Primary` chip, a `Selected` chip and a
+  dot-plus-word `Up`/`Down` — with three different mint elements on the
+  selected row alone. Selection is now carried by the row highlight and
+  `aria-selected`, `Primary` is a plain label rather than a bordered chip, and
+  only `Down` is spelled out: an interface that is up is the unremarkable case,
+  and labelling every row `Up` spent width on a word that never varied.
+  Addresses are monospaced, matching the rule that monospace means "this is
+  literal".
+- **The warning icon in confirmation dialogs lost its amber box.** It sat in a
+  32px square with an amber border and wash, which read as decoration next to
+  every confirmation. It is now the icon alone, matching the packet-capture
+  notice, which had always done it that way.
+- **The app opens on Discover** rather than Scan. The first useful question
+  on an unfamiliar network is what is on it, and a scan needs a host you do
+  not have yet.
+- **Completion notifications only appear for tabs you are not looking at.**
+  On the visible tab the result arriving in the table already says the run
+  finished. Failures still report unconditionally.
+- Dependency updates: `pcap` 2.4 → 2.5, `astro`, `lucide-react`, `vitest`,
+  `@axe-core/cli`, and the vite/rollup group.
+- **Desktop app redesigned around a denser diagnostic workspace.**
+  NetsCLI Desktop moved from the earlier dashboard-style UI to a
+  native-like shell with operation tabs, compact forms, sortable and
+  filterable results, row details, CLI command previews, and status
+  summaries. The GUI continues to use the same `netscli-core`
+  operations as the CLI, TUI, and MCP server, so desktop behavior stays
+  aligned with the rest of the tool.
+- **Desktop app icon refreshed to match the current brand.** The Tauri
+  icon generator now renders the ANSI-style `N` using the same gradient
+  direction as the website/favicon, and regenerates the Windows/Tauri
+  icon assets from that source.
+- **CLI and TUI scan output now reflects richer status data.** Human
+  output stays concise, but scanned ports can show closed, filtered, and
+  error states with latency where available instead of only emphasizing
+  open ports.
+- **Windows install guidance now prefers Winget for the desktop app.**
+  Release notes and install docs call out Winget's manifest review and
+  installer hash verification as the recommended Windows path, while direct
+  GitHub Windows installers remain unsigned and may show Windows warnings
+  until code signing is added later.
+- **Website, docs, FAQ, 404 page, and changelog refreshed for the new
+  release.** The public site now uses a more consistent shell, unified code
+  and table styling, clearer search behavior, release-note summaries, and
+  a desktop-app screenshot captured from the real UI with representative
+  demo data.
+- **Linux/macOS install docs clarified.** mDNS is documented as the default
+  pure-Rust capability in published builds, while packet capture remains
+  the optional workflow that depends on libpcap/Npcap support.
+- **Website rebuilt for every screen width.** The landing page and docs were
+  swept across six widths and both themes, and the shell, navigation, contents
+  list, colour and typography were reworked to hold up at all of them. The
+  brand accent moved from a teal-green that read blue in small text to one that
+  reads green at any size, and contrast improved with it.
+  ([#190](https://github.com/fstubner/netscli/pull/190)–[#209](https://github.com/fstubner/netscli/pull/209))
+- **Search, head metadata and page titles rewritten** so the site describes
+  what it is rather than repeating adjectives.
+  ([#204](https://github.com/fstubner/netscli/pull/204))
+- **Per-PR site previews on Cloudflare Pages**, and GitHub Pages deploys are
+  manual-only. ([#165](https://github.com/fstubner/netscli/pull/165),
+  [#136](https://github.com/fstubner/netscli/pull/136))
+
+- **`netscli scan --json` now reports every port, not just the open ones.**
+  Filtering to open ports made "all closed", "all filtered" and "every
+  probe errored" the same empty array, so a script could not tell a clean
+  scan from a host that refused every probe. Each entry carries `open` and
+  `status`, so callers that want only open ports can filter for them.
+- **The MCP server now scans only local networks by default.** This is the
+  one surface driven by a model rather than by the person at the keyboard,
+  so the instruction to scan a third party can arrive from a web page or a
+  file someone else wrote — and the packets leave from your machine and
+  your IP. RFC1918, loopback, link-local and the carrier-grade NAT range
+  overlay networks use are allowed; set `NETSCLI_MCP_ALLOW_PUBLIC_TARGETS=1`
+  to reach past them.
+- **Scan results returned to a model are capped.** The full probe response
+  (`raw`) is no longer included and banners are truncated, both being bytes
+  chosen by the scanned host.
+- **Tool failures are returned as MCP `isError` results** rather than
+  JSON-RPC errors, so a failed scan no longer reads to a client as a broken
+  server.
+- **The desktop app's CSV export escapes spreadsheet formulas.** A cell
+  beginning `=` `+` `-` or `@` is evaluated on open by Excel and
+  LibreOffice, and exported cells carry banners and hostnames the scanned
+  host chose. Values that parse as numbers are untouched, so a negative
+  latency is still a number.
 
 ### Fixed
 
@@ -87,32 +237,6 @@ its heading and collects entries; the date and the link go on with the tag.
   their `169.254.x` APIPA addresses. The picker now shows one address, chosen
   by the existing IPv4/IPv6 preference — which the status bar already honoured
   and the picker did not, so the two could disagree about the same interface.
-
-### Changed
-
-- **The interface dropdown is quieter.** A row could carry three competing
-  status treatments at once — a `Primary` chip, a `Selected` chip and a
-  dot-plus-word `Up`/`Down` — with three different mint elements on the
-  selected row alone. Selection is now carried by the row highlight and
-  `aria-selected`, `Primary` is a plain label rather than a bordered chip, and
-  only `Down` is spelled out: an interface that is up is the unremarkable case,
-  and labelling every row `Up` spent width on a word that never varied.
-  Addresses are monospaced, matching the rule that monospace means "this is
-  literal".
-- **The warning icon in confirmation dialogs lost its amber box.** It sat in a
-  32px square with an amber border and wash, which read as decoration next to
-  every confirmation. It is now the icon alone, matching the packet-capture
-  notice, which had always done it that way.
-
-## [0.3.1]
-
-A bug-fix release. Most of it was found by using the desktop app on a real
-network rather than by reading the code, and the rest by an assessment run
-before tagging; the recurring theme is code that reported success while doing
-nothing.
-
-### Fixed
-
 - **Pinging your own machine no longer reports 100% loss.** On Windows,
   `ping 127.0.0.1` — and the machine's own LAN address — timed out while the
   system `ping` answered immediately. Two causes stacked up: raw ICMP sockets
@@ -186,232 +310,6 @@ nothing.
   winget-pkgs accepted all five without complaint and a merged manifest is
   permanent. The same two jobs would also have failed on the documented
   re-run path, looking for a release tagged `main`.
-
-### Added
-
-- **Clear ARP table, then discover.** A chevron beside Run offers a
-  cache-flushing variant on discover, sweep and the ARP tab — the tools where
-  a stale neighbour entry changes the answer. Clearing needs administrator
-  rights; when it fails the run is suppressed rather than quietly returning
-  the stale entries it was meant to drop.
-- **Right-click a tab to close it, its neighbours, or all of them.** Close,
-  close others, close to the right, close to the left, close all. Every item
-  acts on the tab you clicked rather than the active one — those are often
-  different — and anything that would do nothing is greyed rather than
-  hidden, so the menu keeps its shape wherever you open it. Closing cancels
-  whatever those tabs were running.
-
-### Changed
-
-- **The app opens on Discover** rather than Scan. The first useful question
-  on an unfamiliar network is what is on it, and a scan needs a host you do
-  not have yet.
-- **Completion notifications only appear for tabs you are not looking at.**
-  On the visible tab the result arriving in the table already says the run
-  finished. Failures still report unconditionally.
-- Dependency updates: `pcap` 2.4 → 2.5, `astro`, `lucide-react`, `vitest`,
-  `@axe-core/cli`, and the vite/rollup group.
-
-### Website
-
-- **The install guide has the verification steps the landing page promises.**
-  It advertised checksums and Sigstore signatures "see the install guide for
-  verification steps" and linked to a page with none of them on it.
-- **The changelog no longer dates a release that has not happened.** An entry
-  marked "Not yet released" was rendered beside a publication date taken from
-  this file's own heading.
-- **The docs table of contents is back in the right-hand rail.** It had been
-  moved under the page hero at every width, which is the mobile layout applied
-  to desktop.
-- **Release notes are in the page rather than painted in by script**, so the
-  changelog reads with JavaScript disabled and does not flash "Loading".
-- The website's colours are now covered by the contrast gate, which had been
-  measuring the desktop app's palette and reporting a pass for both.
-- **Docs pages are evenly padded.** The page frame was always centred, but
-  the two rails inset their text differently — the section list started 84px
-  from the edge while the contents list ended 40px from it. Both use the same
-  inset now, and the contents rail is wider so it did not lose its text to the
-  change.
-- **Headings are sized for reading rather than for a poster.** They were
-  42px and 35px against 16px body text; they are 34, 26 and 21 now.
-- **Anchor links move to the heading instead of jumping past it.** Following
-  a contents link or a shared deep link landed the heading behind the sticky
-  header, because the docs never loaded the rule that prevents it.
-- **The left nav's hover highlight lines up with the current page's.** Only
-  the current item sat on the rail, so hovering anything else drew a
-  highlight inset from it by 9px.
-- **The theme selector shows keyboard focus, and its dropdown is legible.**
-  Focus produced the hover treatment and removed the background rather than
-  drawing a ring, and the list itself was set in a translucent colour the
-  platform will not use, so it fell back to the browser default.
-- **The search button and the menu button match**, and the breadcrumb
-  separators sit level with their text.
-- **Search fills the screen on a phone.** The results stopped 151px above the
-  bottom, Cancel sat level with the middle of the results rather than with
-  the field, and the clear control floated short of the field's edge.
-- **The install section leads with `winget install netscli`.** The prominent
-  command was a `curl … | bash` pipeline until JavaScript ran, and stayed one
-  for anyone without it. The panel also lost a Cargo row repeated on all
-  three platforms and a hash note repeated four times in one panel, and the
-  direct-download button is no longer the loudest control in a section where
-  it is the least verified route.
-- **The interface coverage table says what it means.** Yes/No became ticks
-  and dashes with a legend, and the page now says that the CLI, terminal UI
-  and MCP server are one binary rather than three programs — a dash in the
-  MCP column never meant a second install. Rows that conflated two things
-  (setup with doctor, reading the ARP table with changing it) are split, and
-  dashes that meant "not applicable" say which.
-- **The FAQ answers two questions people actually search for**, from the
-  Search Console data rather than guesswork: whether there is a `netscan`
-  command, and whether this replaces nmap and has a terminal UI.
-
-## [0.3.0] — 2026-08-20
-
-### Added
-
-- **Richer port scan results across every interface.** Port scans now
-  report additive status and detail fields (`open`, `closed`,
-  `filtered`, `error`, latency, banners, HTTP metadata, TLS metadata,
-  and raw previews where available) while keeping the older `open`,
-  `port`, `service`, and `error` fields intact for compatibility.
-- **GUI render automation.** The desktop app now has Tauri/WebDriver
-  render coverage for the diagnostic workspace, including tab layout,
-  top menus, toolbar actions, filtering, row selection, detail panes,
-  command preview, and status bar behavior.
-- **User-configurable probe concurrency.** The CLI and MCP server already
-  accepted concurrency limits; the desktop app settings and TUI settings
-  now expose the same control so users can reduce simultaneous probes on
-  fragile networks or raise them within the core safety cap.
-- **Address-family display preference in the desktop app.** The status bar
-  now prefers IPv4 by default and lets users choose IPv6-first display when
-  that better matches their environment.
-
-### Changed
-
-- **Desktop app redesigned around a denser diagnostic workspace.**
-  NetsCLI Desktop moved from the earlier dashboard-style UI to a
-  native-like shell with operation tabs, compact forms, sortable and
-  filterable results, row details, CLI command previews, and status
-  summaries. The GUI continues to use the same `netscli-core`
-  operations as the CLI, TUI, and MCP server, so desktop behavior stays
-  aligned with the rest of the tool.
-- **Desktop app icon refreshed to match the current brand.** The Tauri
-  icon generator now renders the ANSI-style `N` using the same gradient
-  direction as the website/favicon, and regenerates the Windows/Tauri
-  icon assets from that source.
-- **CLI and TUI scan output now reflects richer status data.** Human
-  output stays concise, but scanned ports can show closed, filtered, and
-  error states with latency where available instead of only emphasizing
-  open ports.
-- **Windows install guidance now prefers Winget for the desktop app.**
-  Release notes and install docs call out Winget's manifest review and
-  installer hash verification as the recommended Windows path, while direct
-  GitHub Windows installers remain unsigned and may show Windows warnings
-  until code signing is added later.
-- **Website, docs, FAQ, 404 page, and changelog refreshed for the new
-  release.** The public site now uses a more consistent shell, unified code
-  and table styling, clearer search behavior, release-note summaries, and
-  a desktop-app screenshot captured from the real UI with representative
-  demo data.
-- **Linux/macOS install docs clarified.** mDNS is documented as the default
-  pure-Rust capability in published builds, while packet capture remains
-  the optional workflow that depends on libpcap/Npcap support.
-- **Website rebuilt for every screen width.** The landing page and docs were
-  swept across six widths and both themes, and the shell, navigation, contents
-  list, colour and typography were reworked to hold up at all of them. The
-  brand accent moved from a teal-green that read blue in small text to one that
-  reads green at any size, and contrast improved with it.
-  ([#190](https://github.com/fstubner/netscli/pull/190)–[#209](https://github.com/fstubner/netscli/pull/209))
-- **Search, head metadata and page titles rewritten** so the site describes
-  what it is rather than repeating adjectives.
-  ([#204](https://github.com/fstubner/netscli/pull/204))
-- **Per-PR site previews on Cloudflare Pages**, and GitHub Pages deploys are
-  manual-only. ([#165](https://github.com/fstubner/netscli/pull/165),
-  [#136](https://github.com/fstubner/netscli/pull/136))
-
-- **`netscli scan --json` now reports every port, not just the open ones.**
-  Filtering to open ports made "all closed", "all filtered" and "every
-  probe errored" the same empty array, so a script could not tell a clean
-  scan from a host that refused every probe. Each entry carries `open` and
-  `status`, so callers that want only open ports can filter for them.
-- **The MCP server now scans only local networks by default.** This is the
-  one surface driven by a model rather than by the person at the keyboard,
-  so the instruction to scan a third party can arrive from a web page or a
-  file someone else wrote — and the packets leave from your machine and
-  your IP. RFC1918, loopback, link-local and the carrier-grade NAT range
-  overlay networks use are allowed; set `NETSCLI_MCP_ALLOW_PUBLIC_TARGETS=1`
-  to reach past them.
-- **Scan results returned to a model are capped.** The full probe response
-  (`raw`) is no longer included and banners are truncated, both being bytes
-  chosen by the scanned host.
-- **Tool failures are returned as MCP `isError` results** rather than
-  JSON-RPC errors, so a failed scan no longer reads to a client as a broken
-  server.
-- **The desktop app's CSV export escapes spreadsheet formulas.** A cell
-  beginning `=` `+` `-` or `@` is evaluated on open by Excel and
-  LibreOffice, and exported cells carry banners and hostnames the scanned
-  host chose. Values that parse as numbers are untouched, so a negative
-  latency is still a number.
-
-### Changed (internal)
-
-- **The release pipeline verifies before it commits to anything.** The
-  three crates are now published in one command, so cargo packages and
-  compiles all of them before uploading any -- previously an upload of
-  `netscli-core` could succeed and leave that version permanent on
-  crates.io, which has no unpublish, while a later crate failed to package.
-  CI runs the same command as a dry run on every push, so packaging is
-  exercised long before a release rather than for the first time during
-  one. Release Drafter also resolves its version from tags instead of from
-  the last published release, which had it proposing v0.2.7 for a repo
-  already tagged v0.3.0.
-
-- **The Tauri render suite can run.** It had never passed: every run ended
-  at session creation, because msedgedriver looks for the debug port in a
-  `DevToolsActivePort` file inside its own temporary profile while wry
-  writes that file into Tauri's. The harness now starts the app itself and
-  attaches to it, which skips the lookup entirely. It does not pass yet --
-  the remaining failures are assertions to triage -- but it drives the real
-  app for the first time, and the throughput bug above is what it found.
-
-- **GUI architecture split into maintainable ownership modules.**
-  `App.tsx` and the old single CSS file were decomposed into workspace
-  state, tool presentation helpers, shell components, result/detail
-  components, Tauri services, and layered style files. The UI behavior
-  stays production-data driven; no mock/sample data is shipped in the
-  app.
-- **Core, CLI, TUI, MCP, and Tauri internals reduced from monolithic
-  files into facades plus focused modules.** The public Rust API, CLI
-  syntax, MCP schema, Tauri command payloads, GUI data shape, and SQLite
-  schema remain stable.
-- **CI tightened for future changes.** PR CI now includes GUI unit tests
-  before the GUI build, and a separate Tauri render workflow can run
-  manually, nightly, or on GUI/Tauri-related pull requests.
-- **Packaging templates and release workflows audited.** Release workflows
-  use the pinned Rust toolchain, AUR templates include runtime dependencies
-  and license installation, Winget/Scoop/Homebrew reference manifests were
-  refreshed, and packaging validation commands were added to the release
-  checklist.
-- **CI gates report unconditionally**, so branch protection can require them,
-  and both required checks were closed against a job that fails without
-  failing the gate. ([#161](https://github.com/fstubner/netscli/pull/161),
-  [#187](https://github.com/fstubner/netscli/pull/187))
-- **The end-to-end suite can now fail.** Several scenarios were structurally
-  incapable of it. ([#199](https://github.com/fstubner/netscli/pull/199))
-- **The Tauri render suite is schedule-only** and no longer gates releases.
-  ([#178](https://github.com/fstubner/netscli/pull/178))
-- **A dead-CSS budget runs in CI**, holding the docs override stack at its
-  current 126 provably shadowed declarations.
-  ([#207](https://github.com/fstubner/netscli/pull/207))
-- **Node 22, jsdom 30, ESLint 10, react-hooks 7**, and three Rust dependency
-  bumps. ([#187](https://github.com/fstubner/netscli/pull/187)–[#189](https://github.com/fstubner/netscli/pull/189))
-- **Release pipeline hardened**: tag validation on the AUR jobs, a checksum
-  that could be contaminated by progress output, and the publish long tail.
-  ([#158](https://github.com/fstubner/netscli/pull/158),
-  [#200](https://github.com/fstubner/netscli/pull/200))
-
-### Fixed
-
 - **MCP server handled one request at a time.** The read loop awaited each
   handler before parsing the next line, so a slow scan blocked every other
   request on the connection, including cancellation. Handlers now run
@@ -495,6 +393,116 @@ nothing.
   nothing to explain it, permanently. Selection now prefers an interface
   whose throughput can actually be read, and where none can, the bar says
   "no traffic data" instead of showing nothing.
+
+### Website
+
+- **The install guide has the verification steps the landing page promises.**
+  It advertised checksums and Sigstore signatures "see the install guide for
+  verification steps" and linked to a page with none of them on it.
+- **The changelog no longer dates a release that has not happened.** An entry
+  marked "Not yet released" was rendered beside a publication date taken from
+  this file's own heading.
+- **The docs table of contents is back in the right-hand rail.** It had been
+  moved under the page hero at every width, which is the mobile layout applied
+  to desktop.
+- **Release notes are in the page rather than painted in by script**, so the
+  changelog reads with JavaScript disabled and does not flash "Loading".
+- The website's colours are now covered by the contrast gate, which had been
+  measuring the desktop app's palette and reporting a pass for both.
+- **Docs pages are evenly padded.** The page frame was always centred, but
+  the two rails inset their text differently — the section list started 84px
+  from the edge while the contents list ended 40px from it. Both use the same
+  inset now, and the contents rail is wider so it did not lose its text to the
+  change.
+- **Headings are sized for reading rather than for a poster.** They were
+  42px and 35px against 16px body text; they are 34, 26 and 21 now.
+- **Anchor links move to the heading instead of jumping past it.** Following
+  a contents link or a shared deep link landed the heading behind the sticky
+  header, because the docs never loaded the rule that prevents it.
+- **The left nav's hover highlight lines up with the current page's.** Only
+  the current item sat on the rail, so hovering anything else drew a
+  highlight inset from it by 9px.
+- **The theme selector shows keyboard focus, and its dropdown is legible.**
+  Focus produced the hover treatment and removed the background rather than
+  drawing a ring, and the list itself was set in a translucent colour the
+  platform will not use, so it fell back to the browser default.
+- **The search button and the menu button match**, and the breadcrumb
+  separators sit level with their text.
+- **Search fills the screen on a phone.** The results stopped 151px above the
+  bottom, Cancel sat level with the middle of the results rather than with
+  the field, and the clear control floated short of the field's edge.
+- **The install section leads with `winget install netscli`.** The prominent
+  command was a `curl … | bash` pipeline until JavaScript ran, and stayed one
+  for anyone without it. The panel also lost a Cargo row repeated on all
+  three platforms and a hash note repeated four times in one panel, and the
+  direct-download button is no longer the loudest control in a section where
+  it is the least verified route.
+- **The interface coverage table says what it means.** Yes/No became ticks
+  and dashes with a legend, and the page now says that the CLI, terminal UI
+  and MCP server are one binary rather than three programs — a dash in the
+  MCP column never meant a second install. Rows that conflated two things
+  (setup with doctor, reading the ARP table with changing it) are split, and
+  dashes that meant "not applicable" say which.
+- **The FAQ answers two questions people actually search for**, from the
+  Search Console data rather than guesswork: whether there is a `netscan`
+  command, and whether this replaces nmap and has a terminal UI.
+
+### Changed (internal)
+
+- **The release pipeline verifies before it commits to anything.** The
+  three crates are now published in one command, so cargo packages and
+  compiles all of them before uploading any -- previously an upload of
+  `netscli-core` could succeed and leave that version permanent on
+  crates.io, which has no unpublish, while a later crate failed to package.
+  CI runs the same command as a dry run on every push, so packaging is
+  exercised long before a release rather than for the first time during
+  one. Release Drafter also resolves its version from tags instead of from
+  the last published release, which had it proposing v0.2.7 for a repo
+  already tagged v0.3.0.
+
+- **The Tauri render suite can run.** It had never passed: every run ended
+  at session creation, because msedgedriver looks for the debug port in a
+  `DevToolsActivePort` file inside its own temporary profile while wry
+  writes that file into Tauri's. The harness now starts the app itself and
+  attaches to it, which skips the lookup entirely. It does not pass yet --
+  the remaining failures are assertions to triage -- but it drives the real
+  app for the first time, and the throughput bug above is what it found.
+
+- **GUI architecture split into maintainable ownership modules.**
+  `App.tsx` and the old single CSS file were decomposed into workspace
+  state, tool presentation helpers, shell components, result/detail
+  components, Tauri services, and layered style files. The UI behavior
+  stays production-data driven; no mock/sample data is shipped in the
+  app.
+- **Core, CLI, TUI, MCP, and Tauri internals reduced from monolithic
+  files into facades plus focused modules.** The public Rust API, CLI
+  syntax, MCP schema, Tauri command payloads, GUI data shape, and SQLite
+  schema remain stable.
+- **CI tightened for future changes.** PR CI now includes GUI unit tests
+  before the GUI build, and a separate Tauri render workflow can run
+  manually, nightly, or on GUI/Tauri-related pull requests.
+- **Packaging templates and release workflows audited.** Release workflows
+  use the pinned Rust toolchain, AUR templates include runtime dependencies
+  and license installation, Winget/Scoop/Homebrew reference manifests were
+  refreshed, and packaging validation commands were added to the release
+  checklist.
+- **CI gates report unconditionally**, so branch protection can require them,
+  and both required checks were closed against a job that fails without
+  failing the gate. ([#161](https://github.com/fstubner/netscli/pull/161),
+  [#187](https://github.com/fstubner/netscli/pull/187))
+- **The end-to-end suite can now fail.** Several scenarios were structurally
+  incapable of it. ([#199](https://github.com/fstubner/netscli/pull/199))
+- **The Tauri render suite is schedule-only** and no longer gates releases.
+  ([#178](https://github.com/fstubner/netscli/pull/178))
+- **A dead-CSS budget runs in CI**, holding the docs override stack at its
+  current 126 provably shadowed declarations.
+  ([#207](https://github.com/fstubner/netscli/pull/207))
+- **Node 22, jsdom 30, ESLint 10, react-hooks 7**, and three Rust dependency
+  bumps. ([#187](https://github.com/fstubner/netscli/pull/187)–[#189](https://github.com/fstubner/netscli/pull/189))
+- **Release pipeline hardened**: tag validation on the AUR jobs, a checksum
+  that could be contaminated by progress output, and the publish long tail.
+  ([#158](https://github.com/fstubner/netscli/pull/158),
+  [#200](https://github.com/fstubner/netscli/pull/200))
 
 ## [0.2.6] — 2026-05-06
 


### PR DESCRIPTION
Since 0.2.6 in May there were three tiers of unreleased notes: `[Unreleased]`, an untagged `[0.3.1]`, and `[0.3.0]` dated 2026-08-20 whose release is a draft with no assets.

One undated section now, numbered 0.3.1 to match the version the crates and the desktop app already carry. Three features that had no entry anywhere are written in: tab reordering, destructive menu items marked red at rest, and scan/inspect opened from a result running on its own.

96 entries before, 99 after. Changelog gate passes.