### PR TITLE
Say when a command was copied, and grey packet capture everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,18 @@ its entries are here. There is no 0.3.0 release to look for.
 
 ### Fixed
 
+- **Copying the CLI command says that it did.** The button reported success
+  through an `interaction` toast, and those are off by default -- so at stock
+  settings the one action whose whole result is invisible, putting text on the
+  clipboard, gave no sign at all. The button now shows a tick for a moment,
+  borrowing the frame it already uses on hover so the only thing that changes
+  is the icon.
+- **Packet capture is greyed everywhere it is offered, not just in the menu
+  bar.** The menu bar greyed it and said why on a build that cannot capture;
+  the tab menu beside the tabs, and the picker on the empty workspace, offered
+  it as an ordinary item. Whichever one you happened to open decided whether
+  you were told. Two signals were in play -- a capability that removes an entry
+  and a reason that greys it -- and only the menu bar read the second.
 - **Stop actually stops a run now, and progress shows real counts.** Every
   command argument was sent under its Rust name (`op_id`, `max_concurrent`)
   where Tauri expects the camelCase form, so the keys never matched. Stop

--- a/apps/netscli-gui/src/App.tsx
+++ b/apps/netscli-gui/src/App.tsx
@@ -219,6 +219,7 @@ function App() {
         openMenu={openMenu}
         tabs={workspace.tabs}
         toolCapabilities={toolCapabilities}
+        toolDisabledReasons={packetCaptureUnavailable ? { pcap: packetCaptureUnavailable } : undefined}
         onAddScanTab={() => workspace.addTab('scan')}
         onAddToolTab={workspace.addTab}
         onCloseTab={workspace.closeTab}
@@ -234,6 +235,7 @@ function App() {
         commandBarVisible={commandBarVisible}
         pcapCapability={pcapCapability}
         toolCapabilities={toolCapabilities}
+        toolDisabledReasons={packetCaptureUnavailable ? { pcap: packetCaptureUnavailable } : undefined}
         workspace={workspace}
         onContentContextMenu={openContentContextMenu}
         onRequestRun={requestRun}

--- a/apps/netscli-gui/src/components/results/EmptyWorkspace.tsx
+++ b/apps/netscli-gui/src/components/results/EmptyWorkspace.tsx
@@ -8,12 +8,15 @@ import { useOverlayDismiss } from '../primitives/overlay';
 
 interface EmptyWorkspaceProps {
   toolCapabilities: ToolCapabilityMap;
+  /** Why a tool cannot run, per kind: greys it and says so, the same as the
+   *  menu bar and the tab menu. */
+  toolDisabledReasons?: Partial<Record<ToolKind, string>>;
   onAddToolTab: (kind: ToolKind) => void;
 }
 
 type PickerKind = 'scan' | 'tool';
 
-export function EmptyWorkspace({ onAddToolTab, toolCapabilities }: EmptyWorkspaceProps) {
+export function EmptyWorkspace({ onAddToolTab, toolCapabilities, toolDisabledReasons }: EmptyWorkspaceProps) {
   const [pickerKind, setPickerKind] = useState<PickerKind | null>(null);
   const pickerRef = useRef<HTMLDivElement | null>(null);
   const pickerPanelRef = useRef<HTMLDivElement | null>(null);
@@ -80,6 +83,7 @@ export function EmptyWorkspace({ onAddToolTab, toolCapabilities }: EmptyWorkspac
             <ToolPickerSection
               kinds={pickerConfig.kinds}
               label={pickerConfig.label}
+              reasons={toolDisabledReasons}
               onAddToolTab={onAddToolTab}
               onClose={() => setPickerKind(null)}
             />
@@ -93,11 +97,13 @@ export function EmptyWorkspace({ onAddToolTab, toolCapabilities }: EmptyWorkspac
 function ToolPickerSection({
   kinds,
   label,
+  reasons,
   onAddToolTab,
   onClose,
 }: {
   kinds: ToolKind[];
   label: string;
+  reasons?: Partial<Record<ToolKind, string>>;
   onAddToolTab: (kind: ToolKind) => void;
   onClose: () => void;
 }) {
@@ -107,9 +113,12 @@ function ToolPickerSection({
       {kinds.map((kind) => {
         const config = TOOL_CONFIG[kind];
         const Icon = config.Icon;
+        const reason = reasons?.[kind];
         return (
           <button
             key={kind}
+            className={reason ? 'muted' : undefined}
+            data-tooltip={reason ? `${reason} Open for setup instructions.` : undefined}
             type="button"
             role="menuitem"
             onClick={() => {

--- a/apps/netscli-gui/src/components/shell/CommandStrip.test.tsx
+++ b/apps/netscli-gui/src/components/shell/CommandStrip.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+// Copying the command says that it worked.
+//
+// It used to say so only through an `interaction` toast, and those are off by
+// default -- on purpose, so a new user is not met by a running commentary on
+// their own clicks. The result was that the one action whose entire outcome
+// is invisible, putting text on the clipboard, gave no sign at all at stock
+// settings. Feedback on the button needs no setting to be on.
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CommandStrip } from './CommandStrip';
+
+const button = () => screen.getByRole('button');
+
+describe('CommandStrip', () => {
+  it('marks itself copied when the copy succeeds', async () => {
+    render(<CommandStrip command="netscli discover" onCopy={() => Promise.resolve(true)} />);
+    expect(button().getAttribute('aria-label')).toBe('Copy command');
+
+    fireEvent.click(button());
+
+    await waitFor(() => expect(button().getAttribute('aria-label')).toBe('Copied'));
+    expect(button().getAttribute('data-copied')).toBe('true');
+    expect(button().getAttribute('data-tooltip')).toBe('Copied');
+  });
+
+  it('says nothing when the copy failed', async () => {
+    render(<CommandStrip command="netscli discover" onCopy={() => Promise.resolve(false)} />);
+
+    fireEvent.click(button());
+
+    // Give the promise a turn to settle before asserting the absence.
+    await Promise.resolve();
+    expect(button().getAttribute('aria-label')).toBe('Copy command');
+    expect(button().getAttribute('data-copied')).toBeNull();
+  });
+
+  it('reverts after the copied window', async () => {
+    vi.useFakeTimers();
+    try {
+      render(<CommandStrip command="netscli discover" onCopy={() => Promise.resolve(true)} />);
+      fireEvent.click(button());
+      await vi.waitFor(() => expect(button().getAttribute('data-copied')).toBe('true'));
+
+      vi.advanceTimersByTime(1500);
+
+      await vi.waitFor(() => expect(button().getAttribute('data-copied')).toBeNull());
+      expect(button().getAttribute('aria-label')).toBe('Copy command');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/netscli-gui/src/components/shell/CommandStrip.tsx
+++ b/apps/netscli-gui/src/components/shell/CommandStrip.tsx
@@ -1,22 +1,59 @@
-import { Copy, Terminal } from 'lucide-react';
+import { Check, Copy, Terminal } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 
 interface CommandStripProps {
   command: string;
-  onCopy: () => void;
+  onCopy: () => Promise<boolean>;
 }
 
+/** How long the button stays in its copied state.
+ *
+ *  Shorter than the website's 2500ms. A landing page holds it longer because
+ *  a visitor may be reading elsewhere on the page when they click; here the
+ *  pointer is on the control and the eye is already there, and a badge that
+ *  outstays the moment reads as a state the button is stuck in. */
+const COPIED_MS = 1400;
+
 export function CommandStrip({ command, onCopy }: CommandStripProps) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+  }, []);
+
+  // The button answers for itself.
+  //
+  // A successful copy used to say so through an `interaction` toast, and those
+  // are off by default -- deliberately, because a new user otherwise meets the
+  // app through a stream of notices about things they just did. The cost was
+  // that at stock settings the one gesture whose whole result is invisible --
+  // the clipboard -- gave no sign it had worked at all.
+  //
+  // Feedback on the control itself needs no setting, and it is where the eye
+  // already is. Failures still go through reportActionFailure, which is not
+  // gated.
+  const handleClick = async () => {
+    const ok = await onCopy();
+    if (!ok) return;
+    setCopied(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopied(false), COPIED_MS);
+  };
+
   return (
     <section className="command-strip" data-testid="command-strip">
       <Terminal size={14} />
       <code>{command}</code>
       <button
-        aria-label="Copy command"
-        data-tooltip="Copy Command"
+        aria-label={copied ? 'Copied' : 'Copy command'}
+        className={copied ? 'copied' : undefined}
+        data-copied={copied ? 'true' : undefined}
+        data-tooltip={copied ? 'Copied' : 'Copy Command'}
         data-tooltip-align="right"
-        onClick={onCopy}
+        onClick={() => void handleClick()}
       >
-        <Copy size={13} />
+        {copied ? <Check size={13} /> : <Copy size={13} />}
       </button>
     </section>
   );

--- a/apps/netscli-gui/src/components/shell/TabStrip.tsx
+++ b/apps/netscli-gui/src/components/shell/TabStrip.tsx
@@ -17,6 +17,7 @@ interface TabStripProps {
   activeTabId: string;
   openMenu: string | null;
   toolCapabilities: ToolCapabilityMap;
+  toolDisabledReasons?: Partial<Record<ToolKind, string>>;
   onAddScanTab: () => void;
   onAddToolTab: (kind: ToolKind) => void;
   onCloseTab: (tabId: string) => void;
@@ -33,6 +34,7 @@ export function TabStrip({
   activeTabId,
   openMenu,
   toolCapabilities,
+  toolDisabledReasons,
   onAddScanTab,
   onAddToolTab,
   onCloseTab,
@@ -246,6 +248,7 @@ export function TabStrip({
           position={toolMenuPosition}
           setOpenMenu={setOpenMenu}
           toolCapabilities={toolCapabilities}
+          toolDisabledReasons={toolDisabledReasons}
           triggerRef={chevronRef}
         />
       )}

--- a/apps/netscli-gui/src/components/shell/TabToolMenu.test.tsx
+++ b/apps/netscli-gui/src/components/shell/TabToolMenu.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+// A tool that cannot run looks the same wherever it is offered.
+//
+// It did not. The menu bar greyed packet capture and said why; this menu --
+// the chevron beside the tabs, three inches away -- offered it as an ordinary
+// item on a build that cannot capture. Whichever one a person happened to
+// open decided whether they were told.
+
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ToolCapabilityMap } from '../../tools/types';
+import { TabToolMenu } from './TabToolMenu';
+
+const ALL_AVAILABLE: ToolCapabilityMap = {} as ToolCapabilityMap;
+
+function renderMenu(reasons?: Record<string, string>) {
+  render(
+    <TabToolMenu
+      position={{ top: 0, left: 0, maxHeight: 400 }}
+      setOpenMenu={vi.fn()}
+      toolCapabilities={ALL_AVAILABLE}
+      toolDisabledReasons={reasons}
+      triggerRef={createRef<HTMLButtonElement>()}
+      onAddToolTab={vi.fn()}
+    />,
+  );
+}
+
+const item = (label: string) => screen.getByRole('menuitem', { name: new RegExp(label) });
+
+describe('TabToolMenu', () => {
+  it('greys a tool that cannot run, and says why', () => {
+    renderMenu({ pcap: 'This build has no packet capture.' });
+    const capture = item('Packet Capture');
+    expect(capture.className).toContain('muted');
+    expect(capture.getAttribute('data-tooltip')).toContain('This build has no packet capture.');
+  });
+
+  it('leaves the others alone', () => {
+    renderMenu({ pcap: 'This build has no packet capture.' });
+    expect(item('Port Scan').className).not.toContain('muted');
+    expect(item('DNS Lookup').getAttribute('data-tooltip')).toBeNull();
+  });
+
+  it('greys nothing when every tool can run', () => {
+    renderMenu();
+    expect(item('Packet Capture').className).not.toContain('muted');
+  });
+
+  // Greyed, not removed, and still clickable: the pane behind the entry
+  // carries the setup instructions, so an inert item would take away the one
+  // place that says how to fix what it is greyed for. Same reasoning as
+  // menuItems.ts.
+  it('keeps a greyed tool clickable', () => {
+    renderMenu({ pcap: 'This build has no packet capture.' });
+    expect((item('Packet Capture') as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/apps/netscli-gui/src/components/shell/TabToolMenu.tsx
+++ b/apps/netscli-gui/src/components/shell/TabToolMenu.tsx
@@ -10,10 +10,23 @@ interface TabToolMenuProps {
   position: PopoverPosition;
   setOpenMenu: (menu: string | null) => void;
   toolCapabilities: ToolCapabilityMap;
+  /** Why a tool cannot run, per kind. Greys the entry and explains it, the
+   *  same way the menu bar does -- see menuItems.ts for why these are greyed
+   *  rather than removed. Without it this menu offered packet capture as an
+   *  ordinary item on a build that cannot do it, while the menu bar three
+   *  inches away greyed the very same entry. */
+  toolDisabledReasons?: Partial<Record<ToolKind, string>>;
   triggerRef: RefObject<HTMLButtonElement | null>;
 }
 
-export function TabToolMenu({ onAddToolTab, position, setOpenMenu, toolCapabilities, triggerRef }: TabToolMenuProps) {
+export function TabToolMenu({
+  onAddToolTab,
+  position,
+  setOpenMenu,
+  toolCapabilities,
+  toolDisabledReasons,
+  triggerRef,
+}: TabToolMenuProps) {
   const menuRef = useRef<HTMLDivElement | null>(null);
   const closeMenu = () => setOpenMenu(null);
   const onKeyDown = useRovingFocus({
@@ -41,12 +54,14 @@ export function TabToolMenu({ onAddToolTab, position, setOpenMenu, toolCapabilit
       <ToolMenuSection
         kinds={SCAN_TOOL_KINDS}
         label="Scan operations"
+        reasons={toolDisabledReasons}
         onAddToolTab={onAddToolTab}
         setOpenMenu={setOpenMenu}
       />
       <ToolMenuSection
         kinds={availableToolKinds(LOOKUP_TOOL_KINDS, toolCapabilities)}
         label="Lookups and inventory"
+        reasons={toolDisabledReasons}
         onAddToolTab={onAddToolTab}
         setOpenMenu={setOpenMenu}
       />
@@ -57,11 +72,13 @@ export function TabToolMenu({ onAddToolTab, position, setOpenMenu, toolCapabilit
 function ToolMenuSection({
   kinds,
   label,
+  reasons,
   onAddToolTab,
   setOpenMenu,
 }: {
   kinds: ToolKind[];
   label: string;
+  reasons?: Partial<Record<ToolKind, string>>;
   onAddToolTab: (kind: ToolKind) => void;
   setOpenMenu: (menu: string | null) => void;
 }) {
@@ -71,9 +88,12 @@ function ToolMenuSection({
       {kinds.map((kind) => {
         const config = TOOL_CONFIG[kind];
         const Icon = config.Icon;
+        const reason = reasons?.[kind];
         return (
           <button
             key={kind}
+            className={reason ? 'muted' : undefined}
+            data-tooltip={reason ? `${reason} Open for setup instructions.` : undefined}
             role="menuitem"
             onClick={() => {
               onAddToolTab(kind);

--- a/apps/netscli-gui/src/components/shell/WorkspaceView.tsx
+++ b/apps/netscli-gui/src/components/shell/WorkspaceView.tsx
@@ -7,7 +7,7 @@ import { ResultTable } from '../results/ResultTable';
 import { WarningStrip, warningMessageFor } from '../results/WarningStrip';
 import { ToolForm } from '../tools/ToolForm';
 import { CommandStrip } from './CommandStrip';
-import type { ResultCellContext, ToolCapabilityMap } from '../../tools/types';
+import type { ResultCellContext, ToolCapabilityMap, ToolKind } from '../../tools/types';
 import type { PcapCapability } from '../../types/netscli';
 import type { WorkspaceModel } from '../../workspace/types';
 
@@ -15,6 +15,7 @@ interface WorkspaceViewProps {
   commandBarVisible: boolean;
   pcapCapability: PcapCapability;
   toolCapabilities: ToolCapabilityMap;
+  toolDisabledReasons?: Partial<Record<ToolKind, string>>;
   workspace: WorkspaceModel;
   onContentContextMenu: (event: MouseEvent<HTMLElement>, cell?: ResultCellContext) => void;
   onRequestRun: (tabId: string) => void;
@@ -24,6 +25,7 @@ export function WorkspaceView({
   commandBarVisible,
   pcapCapability,
   toolCapabilities,
+  toolDisabledReasons,
   workspace,
   onContentContextMenu,
   onRequestRun,
@@ -79,12 +81,13 @@ export function WorkspaceView({
           />
 
           {commandBarVisible && (
-            <CommandStrip command={workspace.commandPreview} onCopy={() => void workspace.copyCommand()} />
+            <CommandStrip command={workspace.commandPreview} onCopy={() => workspace.copyCommand()} />
           )}
         </>
       ) : (
         <EmptyWorkspace
           toolCapabilities={toolCapabilities}
+          toolDisabledReasons={toolDisabledReasons}
           onAddToolTab={workspace.addTab}
         />
       )}

--- a/apps/netscli-gui/src/styles/shell/toolbar.css
+++ b/apps/netscli-gui/src/styles/shell/toolbar.css
@@ -47,6 +47,25 @@
   border-color: var(--border-subtle);
 }
 
+/* The copy button keeps a frame while it says "Copied".
+ *
+ * These buttons carry `border: 1px solid transparent` and only show it on
+ * hover, which is right for a row of quiet icons -- but the copied state
+ * outlives the pointer. Clicking and moving away left a tick floating with
+ * no frame around it, reading as a glyph that had changed rather than a
+ * control reporting back.
+ *
+ * It borrows the HOVER frame rather than inventing one. An accent-tinted
+ * border was the first attempt and it read as a third state the button never
+ * has otherwise; matching hover means the only thing that changes on copy is
+ * the icon, which is the thing with something to say. */
+.command-strip button.copied,
+.command-strip button.copied:hover {
+  color: var(--mint);
+  background: var(--bg-elevated);
+  border-color: var(--border-subtle);
+}
+
 .icon-button.strong {
   color: var(--mint);
 }

--- a/apps/netscli-gui/src/workspace/types.ts
+++ b/apps/netscli-gui/src/workspace/types.ts
@@ -53,10 +53,10 @@ export interface WorkspaceModel {
   exportSelectedCsv: () => void;
   saveResultBundle: () => Promise<void>;
   openResultBundle: () => Promise<void>;
-  copyCellValue: (label: string, value: string) => Promise<void>;
+  copyCellValue: (label: string, value: string) => Promise<boolean>;
   openCaptureFile: (path: string) => Promise<void>;
   revealCaptureFile: (path: string) => Promise<void>;
-  copyCommand: () => Promise<void>;
+  copyCommand: () => Promise<boolean>;
   copySelectedDetails: () => Promise<void>;
   copySelectedRaw: () => Promise<void>;
   sortBy: (column: ResultColumn) => void;

--- a/apps/netscli-gui/src/workspace/useResultActions.ts
+++ b/apps/netscli-gui/src/workspace/useResultActions.ts
@@ -127,28 +127,33 @@ export function useResultActions({
    * and a missing `navigator.clipboard` (the optional chain made it a silent
    * no-op). The export path already reports its failures; this matches it.
    */
-  async function copyToClipboard(label: string, text: string) {
+  /** True when the text reached the clipboard. Callers with a control of
+   *  their own use it to show that it did; the toast is opt-in and off by
+   *  default, so it cannot be the only signal. */
+  async function copyToClipboard(label: string, text: string): Promise<boolean> {
     if (!navigator.clipboard) {
       reportActionFailure(`${label} failed: clipboard unavailable`);
-      return;
+      return false;
     }
     try {
       await navigator.clipboard.writeText(text);
       showToast({ message: `${label} copied`, kind: 'interaction' });
+      return true;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       reportActionFailure(`${label} copy failed: ${message}`);
+      return false;
     }
   }
 
-  async function copyCommand() {
-    if (!commandPreview) return;
-    await copyToClipboard('Command', commandPreview);
+  async function copyCommand(): Promise<boolean> {
+    if (!commandPreview) return false;
+    return copyToClipboard('Command', commandPreview);
   }
 
-  async function copyCellValue(label: string, value: string) {
-    if (!value) return;
-    await copyToClipboard(label, value);
+  async function copyCellValue(label: string, value: string): Promise<boolean> {
+    if (!value) return false;
+    return copyToClipboard(label, value);
   }
 
   async function openCaptureFile(path: string) {


### PR DESCRIPTION
Two defects found by running the app.

**Copy** reported success only through an `interaction` toast, which is off by default, so the one gesture with an invisible result said nothing. The button now shows a tick for 1400ms in its existing hover frame.

**Packet capture** was greyed in the menu bar but offered as an ordinary item in the tab menu and the empty-workspace picker: two signals exist for "cannot run" and only the menu bar read both.

7 tests added, one sabotage-checked. 200 pass, eslint and tsc clean.