### PR TITLE
site: make the theme control a real menu, and group the docs bar's buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,5 +113,9 @@ NEXT_GEN_NETWORKING_PLAN.md
 site/.visual-baseline/
 site/.visual-current/
 site/.visual-diff/
+# Same tool's scratch dirs for its stability re-captures. Untracked but not
+# listed until now, so a record run left them showing up in `git status`.
+site/.visual-verify/
+site/.visual-confirm/
 # Captured runtime DOM for scripts/css-equivalence.mjs (capture-search).
 site/.css-equivalence/

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -46,6 +46,9 @@ export default defineConfig({
         Footer: './src/components/starlight/Footer.astro',
         MobileMenuFooter: './src/components/starlight/MobileMenuFooter.astro',
         PageSidebar: './src/components/starlight/PageSidebar.astro',
+        // Upstream's is a native <select>; its dropdown is drawn by the OS
+        // and cannot be styled or positioned. See ThemeControl.astro.
+        ThemeSelect: './src/components/starlight/ThemeSelect.astro',
       },
       // One file per region of the docs shell. None uses !important (the five
       // token remaps in code.css excepted, for inline styles): Starlight's own

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -1,4 +1,5 @@
 ---
+import ThemeControl from './ThemeControl.astro';
 import { site } from '../data/site';
 import { hrefFor, isCurrent, navGroupBreak, navLinks } from '../data/site-content/nav';
 const { branding, meta } = site;
@@ -45,59 +46,12 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
           {link.label}
         </a>
       ))}
-      {/*
-        Deliberately the same shape as Starlight's ThemeSelect -- label
-        wrapping a leading icon, a bare <select>, and a caret -- because
-        src/styles/theme-control.css styles both from one rule set and the
-        docs bar renders the upstream component, which this cannot reuse:
-        it lives inside Starlight and the landing page does not load it.
-
-        The two icons are Starlight's own `laptop` and `down-caret` paths,
-        copied rather than imported for the same reason. Option order and
-        labels match upstream too, so the list reads identically in both
-        bars.
-      */}
-      <div class="ui-theme-select">
-        <label>
-          <span class="sr-only">Select theme</span>
-          {/* All three icons, one shown at a time.
-              The docs bar swaps its icon through Starlight's ThemeProvider,
-              which clones from a `<template id="theme-icons">` and only
-              queries `starlight-theme-select`. Neither exists on the landing
-              page, so this control was stuck on the laptop glyph whatever you
-              picked. Rendering all three and hiding two is simpler than
-              importing that machinery, and it needs no JavaScript to be
-              correct on first paint -- the pre-paint script in Page.astro
-              already sets data-theme-choice before this is visible.
-              Starlight's own sun, moon and laptop paths, so the two bars show
-              the same glyphs. */}
-          <svg aria-hidden="true" class="icon label-icon" data-icon="light" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M5 12a1 1 0 0 0-1-1H3a1 1 0 0 0 0 2h1a1 1 0 0 0 1-1Zm.64 5-.71.71a1 1 0 0 0 0 1.41 1 1 0 0 0 1.41 0l.71-.71A1 1 0 0 0 5.64 17ZM12 5a1 1 0 0 0 1-1V3a1 1 0 0 0-2 0v1a1 1 0 0 0 1 1Zm5.66 2.34a1 1 0 0 0 .7-.29l.71-.71a1 1 0 1 0-1.41-1.41l-.66.71a1 1 0 0 0 0 1.41 1 1 0 0 0 .66.29Zm-12-.29a1 1 0 0 0 1.41 0 1 1 0 0 0 0-1.41l-.71-.71a1.004 1.004 0 1 0-1.43 1.41l.73.71ZM21 11h-1a1 1 0 0 0 0 2h1a1 1 0 0 0 0-2Zm-2.64 6A1 1 0 0 0 17 18.36l.71.71a1 1 0 0 0 1.41 0 1 1 0 0 0 0-1.41l-.76-.66ZM12 6.5a5.5 5.5 0 1 0 5.5 5.5A5.51 5.51 0 0 0 12 6.5Zm0 9a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm0 3.5a1 1 0 0 0-1 1v1a1 1 0 0 0 2 0v-1a1 1 0 0 0-1-1Z" />
-          </svg>
-          <svg aria-hidden="true" class="icon label-icon" data-icon="dark" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M21.64 13a1 1 0 0 0-1.05-.14 8.049 8.049 0 0 1-3.37.73 8.15 8.15 0 0 1-8.14-8.1 8.59 8.59 0 0 1 .25-2A1 1 0 0 0 8 2.36a10.14 10.14 0 1 0 14 11.69 1 1 0 0 0-.36-1.05Zm-9.5 6.69A8.14 8.14 0 0 1 7.08 5.22v.27a10.15 10.15 0 0 0 10.14 10.14 9.784 9.784 0 0 0 2.1-.22 8.11 8.11 0 0 1-7.18 4.32v-.04Z" />
-          </svg>
-          <svg aria-hidden="true" class="icon label-icon" data-icon="auto" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M21 14h-1V7a3 3 0 0 0-3-3H7a3 3 0 0 0-3 3v7H3a1 1 0 0 0-1 1v2a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3v-2a1 1 0 0 0-1-1ZM6 7a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v7H6V7Zm14 10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-1h16v1Z" />
-          </svg>
-          <select autocomplete="off" data-theme-select>
-            <option value="dark">Dark</option>
-            <option value="light">Light</option>
-            <option value="auto" selected>Auto</option>
-          </select>
-          <svg aria-hidden="true" class="icon caret" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M17 9.17a1 1 0 0 0-1.41 0L12 12.71 8.46 9.17a1 1 0 1 0-1.41 1.42l4.24 4.24a1.002 1.002 0 0 0 1.42 0L17 10.59a1.002 1.002 0 0 0 0-1.42Z" />
-          </svg>
-        </label>
-      </div>
+      <ThemeControl />
     </div>
   </div>
 </nav>
 
-<script>
-  import { initThemeSelect } from '../scripts/theme-select';
-  initThemeSelect();
-</script>
+{/* The theme control wires itself -- see the script in ThemeControl.astro. */}
 
 {
   onHome && (
@@ -276,15 +230,17 @@ html[data-theme='light'] nav[data-site-nav]::after{
    which meant `border-inline-start` drew a 59px line floor to ceiling -- a
    divider that split the bar in two rather than grouping the links. The
    pseudo-element is 18px, centred on the text it sits between. */
+/* Margin, not padding: the current-page underline is a border on this box,
+   and padding put 20px of it to the left of the word. See the same note in
+   starlight/Header.astro, where the docs page shows it. */
 .nlinks a.nav-group-start{
   position:relative;
-  margin-inline-start:12px;
-  padding-inline-start:20px;
+  margin-inline-start:32px;
 }
 .nlinks a.nav-group-start::before{
   content:"";
   position:absolute;
-  inset-inline-start:0;
+  inset-inline-start:-16px;
   top:50%;
   width:1px;
   height:18px;

--- a/site/src/components/ThemeControl.astro
+++ b/site/src/components/ThemeControl.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * The theme control, for both top bars.
+ *
+ * A button and a menu, not a <select>. The select's list is drawn by the
+ * operating system: on Windows it renders as white rows with black text
+ * hanging off a dark bar, aligned by the platform rather than by the trigger,
+ * and no CSS reaches it. theme-control.css tried `option { background }` and
+ * that is honoured on some platforms and ignored on this one, which is how a
+ * control can look right on the machine it was written on and wrong on the
+ * next.
+ *
+ * The menu is the same shape as the hero's installer menu -- an absolutely
+ * positioned panel under a button, hidden until asked for -- so the two
+ * dropdowns on the site behave alike.
+ *
+ * Rendered by the landing nav and, through src/components/starlight/
+ * ThemeSelect.astro, by the docs bar. One component, so the two bars cannot
+ * drift apart.
+ *
+ * The icons are Starlight's own sun, moon, laptop and caret paths, copied
+ * because the landing page does not load Starlight.
+ */
+const OPTIONS = [
+  { value: 'dark', label: 'Dark' },
+  { value: 'light', label: 'Light' },
+  { value: 'auto', label: 'Auto' },
+] as const;
+---
+
+<div class="ui-theme-select" data-theme-control>
+  {/* The label is on the button, not a wrapping <label>: there is no form
+      control left to label, and a <label> around a button makes the click
+      target ambiguous. */}
+  <button
+    class="ui-theme-trigger"
+    type="button"
+    aria-expanded="false"
+    aria-haspopup="menu"
+    data-theme-trigger
+  >
+    <span class="sr-only">Select theme</span>
+    {/* All three icons, one shown at a time by the CSS, keyed off
+        data-theme-choice on <html>. The pre-paint script in Page.astro sets
+        that before this is visible, so the correct glyph is there on first
+        paint with no JavaScript of this component's own. */}
+    <svg aria-hidden="true" class="icon label-icon" data-icon="light" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M5 12a1 1 0 0 0-1-1H3a1 1 0 0 0 0 2h1a1 1 0 0 0 1-1Zm.64 5-.71.71a1 1 0 0 0 0 1.41 1 1 0 0 0 1.41 0l.71-.71A1 1 0 0 0 5.64 17ZM12 5a1 1 0 0 0 1-1V3a1 1 0 0 0-2 0v1a1 1 0 0 0 1 1Zm5.66 2.34a1 1 0 0 0 .7-.29l.71-.71a1 1 0 1 0-1.41-1.41l-.66.71a1 1 0 0 0 0 1.41 1 1 0 0 0 .66.29Zm-12-.29a1 1 0 0 0 1.41 0 1 1 0 0 0 0-1.41l-.71-.71a1.004 1.004 0 1 0-1.43 1.41l.73.71ZM21 11h-1a1 1 0 0 0 0 2h1a1 1 0 0 0 0-2Zm-2.64 6A1 1 0 0 0 17 18.36l.71.71a1 1 0 0 0 1.41 0 1 1 0 0 0 0-1.41l-.76-.66ZM12 6.5a5.5 5.5 0 1 0 5.5 5.5A5.51 5.51 0 0 0 12 6.5Zm0 9a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm0 3.5a1 1 0 0 0-1 1v1a1 1 0 0 0 2 0v-1a1 1 0 0 0-1-1Z" />
+    </svg>
+    <svg aria-hidden="true" class="icon label-icon" data-icon="dark" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M21.64 13a1 1 0 0 0-1.05-.14 8.049 8.049 0 0 1-3.37.73 8.15 8.15 0 0 1-8.14-8.1 8.59 8.59 0 0 1 .25-2A1 1 0 0 0 8 2.36a10.14 10.14 0 1 0 14 11.69 1 1 0 0 0-.36-1.05Zm-9.5 6.69A8.14 8.14 0 0 1 7.08 5.22v.27a10.15 10.15 0 0 0 10.14 10.14 9.784 9.784 0 0 0 2.1-.22 8.11 8.11 0 0 1-7.18 4.32v-.04Z" />
+    </svg>
+    <svg aria-hidden="true" class="icon label-icon" data-icon="auto" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M21 14h-1V7a3 3 0 0 0-3-3H7a3 3 0 0 0-3 3v7H3a1 1 0 0 0-1 1v2a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3v-2a1 1 0 0 0-1-1ZM6 7a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v7H6V7Zm14 10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-1h16v1Z" />
+    </svg>
+    {/* Server-rendered as Auto, then corrected by the script from what is
+        stored. Same reasoning as the icons: something readable is there
+        before any script runs. */}
+    <span class="ui-theme-label" data-theme-label>Auto</span>
+    <svg aria-hidden="true" class="icon caret" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M17 9.17a1 1 0 0 0-1.41 0L12 12.71 8.46 9.17a1 1 0 1 0-1.41 1.42l4.24 4.24a1.002 1.002 0 0 0 1.42 0L17 10.59a1.002 1.002 0 0 0 0-1.42Z" />
+    </svg>
+  </button>
+
+  {/* No id, and so no `aria-controls` on the trigger. A docs page renders
+      this twice -- the header bar and the mobile menu's footer -- and a fixed
+      id would be duplicated on every one of them. `aria-haspopup` plus
+      `aria-expanded` on a button whose menu is the next sibling is what the
+      pattern needs; `aria-controls` adds nothing a screen reader uses here. */}
+  <div class="ui-theme-menu" role="menu" data-theme-menu hidden>
+    {OPTIONS.map((option) => (
+      <button
+        class="ui-theme-option"
+        type="button"
+        role="menuitemradio"
+        aria-checked={option.value === 'auto' ? 'true' : 'false'}
+        data-theme-option={option.value}
+      >
+        <span class="ui-theme-tick" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        </span>
+        {option.label}
+      </button>
+    ))}
+  </div>
+</div>
+
+{/* The component wires itself, rather than each page that renders it.
+    Nav.astro used to make this call, which meant the landing bar's control
+    worked and the docs bar's -- rendered through starlight/ThemeSelect.astro,
+    which Nav.astro knows nothing about -- was a button that did nothing.
+    Astro bundles a component's script once per page however many instances
+    it renders, and initThemeSelect wires every [data-theme-control] it
+    finds, so one run covers the header and the mobile menu both. */}
+<script>
+  import { initThemeSelect } from '../scripts/theme-select';
+  initThemeSelect();
+</script>

--- a/site/src/components/starlight/Header.astro
+++ b/site/src/components/starlight/Header.astro
@@ -86,7 +86,6 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
       text-decoration: none;
       min-width: 0;
       height: var(--sl-nav-height);
-      margin: 0 auto 0 0;
       /* Cancels the wordmark asset's own transparent left margin. This was a
          flat -18px against a 12.4px margin, so the docs logo hung 5.5px
          further left than the identical logo on the landing bar. See
@@ -103,7 +102,16 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
       filter: var(--ui-mark-filter);
     }
 
+    /* The bar is two groups: identity and search on the left, navigation and
+       the theme control on the right. The auto margin is the seam.
+     *
+     * It used to sit on the wordmark, which put the whole gap immediately
+     * after it -- and since search is the next element, search came to rest
+     * near the middle of the bar, reading as a stray control belonging to
+     * neither side. Measured at a 1367px bar: search at x=704, which is the
+     * centre to within a few pixels. */
     .docs-nav-links {
+      margin-inline-start: auto;
       flex: 0 0 auto;
       display: flex;
       align-items: center;
@@ -134,17 +142,23 @@ function linkClass(link: (typeof navLinks)[number], index: number): string | und
 
     /* Same separator as the landing bar -- see Nav.astro, including why it is
        a short centred pseudo-element rather than a border: these links are the
-       full nav height, so a border ran floor to ceiling and split the bar. */
+       full nav height, so a border ran floor to ceiling and split the bar.
+     *
+     * The space it sits in is a MARGIN, not padding. It was padding, and the
+     * current-page underline is a border on this same box -- so on the docs
+     * page, where the group-start link is also the current one, the underline
+     * began 15px to the left of the word and read as misaligned. Margin puts
+     * the gap outside the box the border draws around; the pseudo-element
+     * sits in that margin, negatively inset. */
     .docs-nav-links a.nav-group-start {
       position: relative;
-      margin-inline-start: 0.35rem;
-      padding-inline-start: 0.95rem;
+      margin-inline-start: 1.3rem;
     }
 
     .docs-nav-links a.nav-group-start::before {
       content: "";
       position: absolute;
-      inset-inline-start: 0;
+      inset-inline-start: -0.65rem;
       top: 50%;
       width: 1px;
       height: 18px;

--- a/site/src/components/starlight/ThemeSelect.astro
+++ b/site/src/components/starlight/ThemeSelect.astro
@@ -1,0 +1,16 @@
+---
+/**
+ * Starlight's theme control, replaced with ours.
+ *
+ * Upstream renders <starlight-theme-select> around a native <select>, whose
+ * dropdown the operating system draws -- unstyled and positioned by the
+ * platform. See components/ThemeControl.astro.
+ *
+ * The storage key is unchanged (`starlight-theme`), so Starlight's own
+ * pre-paint ThemeProvider still applies the choice on load and a preference
+ * set in either bar holds across the whole site.
+ */
+import ThemeControl from '../ThemeControl.astro';
+---
+
+<ThemeControl />

--- a/site/src/scripts/theme-select.ts
+++ b/site/src/scripts/theme-select.ts
@@ -1,4 +1,4 @@
-/* The landing page's theme control.
+/* The theme control, on both top bars.
  *
  * Reads and writes `starlight-theme`, the same localStorage key the docs use,
  * so a choice made on either half of the site holds on the other. The
@@ -9,11 +9,18 @@
  * follows the operating system from then on. Storing "auto" would work too,
  * but then the stored value and the applied value are different things and
  * every reader of the key has to know that.
+ *
+ * The control is a button and a menu rather than a <select>, because a
+ * select's list is drawn by the platform and cannot be styled or positioned
+ * -- see components/ThemeControl.astro. That makes opening, closing and
+ * keyboard handling this file's job, which is the cost of the change.
  */
 
 type Theme = 'light' | 'dark';
+type Choice = Theme | 'auto';
 
 const KEY = 'starlight-theme';
+const LABELS: Record<Choice, string> = { dark: 'Dark', light: 'Light', auto: 'Auto' };
 
 function systemTheme(): Theme {
   return matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
@@ -33,19 +40,53 @@ function apply(theme: Theme): void {
 }
 
 export function initThemeSelect(): void {
-  const select = document.querySelector<HTMLSelectElement>('[data-theme-select]');
-  if (!select) return;
+  // Both bars render one of these; the docs bar has exactly one, and so does
+  // the landing page. Wiring every match keeps this correct if a layout ever
+  // shows two.
+  for (const root of document.querySelectorAll<HTMLElement>('[data-theme-control]')) {
+    initControl(root);
+  }
+}
+
+function initControl(root: HTMLElement): void {
+  const trigger = root.querySelector<HTMLButtonElement>('[data-theme-trigger]');
+  const menu = root.querySelector<HTMLElement>('[data-theme-menu]');
+  const label = root.querySelector<HTMLElement>('[data-theme-label]');
+  const options = Array.from(root.querySelectorAll<HTMLButtonElement>('[data-theme-option]'));
+  if (!trigger || !menu || !label || options.length === 0) return;
 
   // Reflect the current state rather than assuming the markup's default. The
-  // control renders with "Auto" selected, but the reader may have chosen
-  // something on a previous visit or in the docs.
-  select.value = stored() ?? 'auto';
+  // control renders with "Auto", but the reader may have chosen something on
+  // a previous visit or in the other half of the site.
+  let choice: Choice = stored() ?? 'auto';
 
-  select.addEventListener('change', () => {
-    const choice = select.value;
+  const reflect = (): void => {
+    label.textContent = LABELS[choice];
+    for (const option of options) {
+      option.setAttribute('aria-checked', option.dataset.themeOption === choice ? 'true' : 'false');
+    }
+  };
+
+  const close = (focusTrigger = false): void => {
+    if (menu.hidden) return;
+    menu.hidden = true;
+    trigger.setAttribute('aria-expanded', 'false');
+    if (focusTrigger) trigger.focus();
+  };
+
+  const open = (): void => {
+    menu.hidden = false;
+    trigger.setAttribute('aria-expanded', 'true');
+    // The current choice takes focus, so the keyboard starts where the eye is.
+    const current = options.find((option) => option.dataset.themeOption === choice);
+    (current ?? options[0]).focus();
+  };
+
+  const choose = (next: Choice): void => {
+    choice = next;
     try {
-      if (choice === 'auto') localStorage.removeItem(KEY);
-      else localStorage.setItem(KEY, choice);
+      if (next === 'auto') localStorage.removeItem(KEY);
+      else localStorage.setItem(KEY, next);
     } catch {
       // Storage blocked: the choice still applies to this page, it just will
       // not survive a navigation. Better than doing nothing.
@@ -53,8 +94,66 @@ export function initThemeSelect(): void {
     // The icon follows the CHOICE, not the applied theme: on "auto" the page
     // may be dark while the control should still show the laptop. See the
     // icon rules in styles/theme-control.css.
-    document.documentElement.dataset.themeChoice = choice;
-    apply(choice === 'auto' ? systemTheme() : (choice as Theme));
+    document.documentElement.dataset.themeChoice = next;
+    apply(next === 'auto' ? systemTheme() : next);
+    reflect();
+    close(true);
+  };
+
+  reflect();
+
+  trigger.addEventListener('click', () => {
+    if (menu.hidden) open();
+    else close();
+  });
+
+  for (const option of options) {
+    option.addEventListener('click', () => {
+      const next = option.dataset.themeOption;
+      if (next === 'dark' || next === 'light' || next === 'auto') choose(next);
+    });
+  }
+
+  // Arrow keys walk the menu, Escape leaves it, Home and End jump. Without
+  // this the menu is reachable by Tab but behaves like three loose buttons,
+  // which is not what `role="menu"` promises a screen reader.
+  menu.addEventListener('keydown', (event) => {
+    const index = options.indexOf(document.activeElement as HTMLButtonElement);
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close(true);
+    } else if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      const step = event.key === 'ArrowDown' ? 1 : -1;
+      const next = (index + step + options.length) % options.length;
+      options[next].focus();
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      options[0].focus();
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      options[options.length - 1].focus();
+    }
+  });
+
+  trigger.addEventListener('keydown', (event) => {
+    if (event.key === 'ArrowDown' && menu.hidden) {
+      event.preventDefault();
+      open();
+    }
+  });
+
+  // A click anywhere else closes it, and so does moving focus out -- the
+  // second matters for the keyboard, where there is no click to catch.
+  document.addEventListener('click', (event) => {
+    if (!root.contains(event.target as Node)) close();
+  });
+  root.addEventListener('focusout', () => {
+    // Deferred: at focusout time the new element is not focused yet, so
+    // `contains` would say the focus left when it only moved between items.
+    setTimeout(() => {
+      if (!root.contains(document.activeElement)) close();
+    }, 0);
   });
 
   // Follow the system while the reader is on "auto", so a theme change in the

--- a/site/src/styles/docs/header.css
+++ b/site/src/styles/docs/header.css
@@ -118,14 +118,30 @@ html[data-theme='light'][data-docs-scrolled='true'] header.header::after {
     padding-inline: 1rem;
   }
 
+  /* Collapsed, the search joins the controls on the right.
+   *
+   * Full width it is a labelled box beside the wordmark, which reads as part
+   * of the identity group. Collapsed to a 2.5rem icon it does not: measured
+   * at 1150px it sat at x=207 with the wordmark ending at 188 and the next
+   * element 454px further along, a lone square in the middle of nothing. It
+   * belongs with the theme control and the menu button, which are the other
+   * two icons that size.
+   *
+   * `order` rather than a second markup slot, so one component still renders
+   * one search. No auto margin here either -- two auto margins on one flex
+   * row split the free space between them, and the seam is .docs-nav-links. */
   .docs-header-search {
+    order: 2;
     display: flex;
     flex: 0 0 2.5rem;
     width: 2.5rem;
     max-width: 2.5rem;
     min-width: 2.5rem;
-    margin-left: auto;
-    margin-right: 0;
+    margin-inline: 0;
+  }
+
+  .docs-header-theme {
+    order: 3;
   }
 
   .docs-header-search site-search,
@@ -145,6 +161,16 @@ html[data-theme='light'][data-docs-scrolled='true'] header.header::after {
   .docs-header-search site-search button[data-open-modal] span,
   .docs-header-search site-search button[data-open-modal] kbd {
     display: none;
+  }
+}
+
+/* Between 800 and 900px the links and the theme control are both hidden
+   (Header.astro), so the seam that pushed search rightward goes with them and
+   it would fall back beside the wordmark. Search carries the auto margin
+   itself in that band -- there is nothing left for it to collide with. */
+@media (min-width: 50rem) and (max-width: 900px) {
+  .docs-header-search {
+    margin-inline-start: auto;
   }
 }
 

--- a/site/src/styles/docs/theme.css
+++ b/site/src/styles/docs/theme.css
@@ -107,8 +107,13 @@ html[data-theme='light'] ::backdrop {
   --ui-docs-toc-width: 15rem;
   --ui-docs-shell-gutter: clamp(1.25rem, 2vw, 2.5rem);
   /* How far a rail insets its text from the frame's outer edge. Both rails
-     read it; it was once declared twice with drifted values. */
-  --ui-sidebar-rail-inset: clamp(2.2rem, 3vw, 3.15rem);
+     read it, so the page keeps the same air down each side; it was once
+     declared twice with drifted values.
+     Was clamp(2.2rem, 3vw, 3.15rem), which put the section labels 50px in
+     from the viewport at a wide window -- more air than the rail needed and
+     less room for the link text. The rails' widths are fixed, so the text
+     column simply takes back what the padding gives up. */
+  --ui-sidebar-rail-inset: clamp(1.5rem, 2vw, 2.25rem);
   /* Height of the title band at the top of every docs page. The band's own
      min-height and the offset that starts the contents rail below it both
      read this, so they move together. Measured across all eleven docs pages

--- a/site/src/styles/docs/toc.css
+++ b/site/src/styles/docs/toc.css
@@ -42,7 +42,11 @@ html[data-theme='light'] .right-sidebar-panel :where(a[aria-current='location'])
   .right-sidebar-panel {
     flex-basis: var(--ui-docs-toc-width);
     width: var(--ui-docs-toc-width);
-    padding-inline: 1.85rem var(--ui-sidebar-rail-inset, clamp(2.2rem, 3vw, 3.15rem));
+    /* No fallback value. The token is declared unconditionally on :root in
+       docs/theme.css, so a fallback can never fire -- it can only be a second
+       copy of the number that drifts when the real one changes, which is what
+       it just did. */
+    padding-inline: 1.85rem var(--ui-sidebar-rail-inset);
     position: sticky;
     top: var(--sl-nav-height);
     max-height: calc(100vh - var(--sl-nav-height));

--- a/site/src/styles/theme-control.css
+++ b/site/src/styles/theme-control.css
@@ -1,25 +1,28 @@
-/* The theme select, for both top bars.
+/* The theme control, for both top bars.
  *
- * There are two of these controls on the site and there is no way to make it
- * one: the docs bar renders Starlight's <starlight-theme-select>, which owns
- * the localStorage key and the pre-paint provider, and the landing bar
- * renders its own markup because it does not load Starlight at all. Before
- * this file they also LOOKED like two controls -- the docs one an icon and a
- * caret in a bordered pill, the landing one a bare <select> with the
- * platform's own arrow -- so crossing between the two halves of the site
- * swapped the control in the corner of the bar.
+ * ONE control now, rendered by components/ThemeControl.astro in the landing
+ * nav and by components/starlight/ThemeSelect.astro in the docs bar. Before
+ * this it was two: Starlight's <starlight-theme-select> on one side and our
+ * own markup on the other, styled from one rule set that named both so they
+ * could not drift. That worked for everything except the part no CSS can
+ * reach.
  *
- * The markup is now the same shape on both sides (label > icon + select +
- * caret) and every rule below names both, so the two cannot drift apart
- * without someone editing a selector list that has the other one sitting
- * next to it.
+ * WHY IT IS NOT A <select>. The list a select drops down is drawn by the
+ * operating system. On Windows it is white rows with black text, positioned
+ * by the platform rather than under the trigger, and `option { background }`
+ * -- which this file used to set -- is honoured on some platforms and
+ * ignored there. So the control looked considered on the machine it was
+ * written on and unstyled on the next one. A button and a menu are ordinary
+ * elements and answer to ordinary rules.
  *
- * Registered last in astro.config.mjs's customCss and imported by
- * Page.astro. Last on purpose: this file is the control's definition, not an
- * override of one, and nothing later should be quietly re-styling it. The
- * docs half still inherits Starlight's own scoped layer underneath, which is
- * why several rules here restate a property that looks like it should
- * already be correct -- they are cancelling upstream, not decorating.
+ * The menu matches the hero's installer menu: a panel under its trigger,
+ * hidden until asked for. Two dropdowns on the site, one behaviour.
+ *
+ * Registered last in astro.config.mjs's customCss and imported by Page.astro.
+ * Last on purpose: this file is the control's definition, not an override of
+ * one. The docs half still has Starlight's own scoped layer underneath, which
+ * is why a few rules restate what looks like it should already be true --
+ * they are cancelling upstream, not decorating.
  */
 
 /* The control's own colours.
@@ -28,186 +31,169 @@
  * nothing else reads them -- and because tokens.css is at the 300-line guard,
  * where the answer is to split by ownership rather than to raise the limit.
  * The cross-stack values the control also uses (the accent, the text ramp,
- * --ui-hover-border, --ui-lift-rgb) stay there: those are shared.
- *
- * The option colours are stated opaquely and per theme on purpose. The
- * dropdown list is drawn by the platform, which will not use a translucent
- * colour: --sl-color-bg-nav is rgba(17,17,17,.92), and given that, the option
- * rows fell back to the browser default -- white rows with black text hanging
- * off a dark header, which is what "the dropdown is unstyled" looks like. */
+ * --ui-hover-border, --ui-lift-rgb) stay there: those are shared. */
 :root {
   --ui-control-border: rgba(var(--ui-lift-rgb), 0.1);
   --ui-control-bg: rgba(var(--ui-lift-rgb), 0.03);
-  --ui-control-option-fg: #f4f4f4;
-  --ui-control-option-bg: #1a1f27;
+  /* Declared once. --ui-surface-raised is already per-theme in tokens.css, so
+     restating this under html[data-theme='light'] would be a second copy that
+     can only drift from the first. */
+  --ui-control-menu-bg: var(--ui-surface-raised);
 }
 
 html[data-theme='light'] {
-  /* Not the lift channel at a different alpha, unlike the dark pair above: a
-     wash of the light theme's near-black reads grey-blue and heavy on a white
-     bar, so these keep the hand-picked values the docs control already used. */
-  --ui-control-border: rgba(70, 89, 120, 0.24);
-  --ui-control-bg: rgba(255, 255, 255, 0.58);
-  --ui-control-option-fg: #132033;
-  --ui-control-option-bg: #f4f7fb;
+  --ui-control-border: rgba(var(--ui-lift-rgb), 0.12);
+  --ui-control-bg: rgba(var(--ui-lift-rgb), 0.04);
 }
 
-/* Structure. Starlight's Select.astro supplies this for the docs control
-   through its own scoped styles; the landing control has no such source, so
-   it is stated here for both rather than left to one side's component. */
-starlight-theme-select label,
-.ui-theme-select label {
-  --sl-label-icon-size: 0.875rem;
-  --sl-caret-size: 1.25rem;
-  --sl-inline-padding: 0.5rem;
-  --sl-select-width: 6.25em;
+.ui-theme-select {
   position: relative;
+  color: var(--ui-text);
+}
+
+/* The trigger.
+ *
+ * Sized to the search button beside it in the docs bar: 2.35rem tall and
+ * 0.875rem text, which is the other bordered control on that row. The nav
+ * links are 13px; this is deliberately the button's size, not the links'. */
+.ui-theme-trigger {
   display: flex;
   align-items: center;
   gap: 0.45rem;
-  /* Matches the search button beside it in the docs bar. The <select> inside
-     has its block padding zeroed (below), so without this the label collapses
-     to its 17.2px line box -- which is what the landing control did, having no
-     equivalent of the docs-only rule this came from. */
   min-height: 2.35rem;
   min-width: 5.35rem;
   padding-inline: 0.65rem;
   border: 1px solid var(--ui-control-border);
   border-radius: 6px;
   background: var(--ui-control-bg);
-  color: var(--ui-text);
+  color: inherit;
+  font: inherit;
+  font-size: 0.875rem;
+  line-height: 1.2;
+  cursor: pointer;
 }
 
-starlight-theme-select,
-.ui-theme-select {
-  color: var(--ui-text);
-}
-
-starlight-theme-select label .icon,
-.ui-theme-select label .icon {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  pointer-events: none;
+.ui-theme-trigger .icon {
   width: 1em;
   height: 1em;
+  flex: 0 0 auto;
 }
 
-/* Upstream pins the leading icon at `inset-inline-start: 0`, which is the
-   label's PADDING box -- so it ignored the 0.65rem inline padding and sat 1px
-   from the border, visibly crowding the edge. Pin it to the same inset as the
-   padding instead. The <select> keeps its own left padding, so its text still
-   clears the icon. */
-starlight-theme-select label .label-icon,
-.ui-theme-select label .label-icon {
-  font-size: var(--sl-label-icon-size);
-  inset-inline-start: 0.65rem;
-}
-
-/* Same 0.65rem inset as the leading icon above, for the same reason.
-   Upstream pins both against the padding box, and the rule above had already
-   moved the leading one in to clear the border -- leaving the caret alone at
-   0. Measured: the icon sat 11.2px from the label's left edge and the caret
-   0.8px from its right, inside 10.4px of padding on both sides. */
-starlight-theme-select label .caret,
-.ui-theme-select label .caret {
-  font-size: var(--sl-caret-size);
-  inset-inline-end: 0.65rem;
-}
-
-starlight-theme-select select,
-.ui-theme-select select {
-  border: 0;
-  color: inherit;
-  background: transparent;
-  font: inherit;
-  /* 14px, and stated because `font: inherit` above is a shorthand that resets
-     font-size along with everything else.
-
-     That is how the docs control ended up at 16px: Starlight sets
-     `font-size: var(--sl-text-sm)` (0.875rem) on this select, our override
-     stack set `font: inherit` afterwards, and unlayered beats layered -- so
-     the size upstream chose was silently replaced by the inherited body size,
-     leaving the control's text visibly larger than everything around it.
-
-     0.875rem restores that and matches the search button beside it in the
-     docs bar, which is the other bordered control on the row and the same
-     37.6px tall. The nav links are 13px; this is deliberately the button's
-     size rather than the links'. */
+.ui-theme-trigger .label-icon {
   font-size: 0.875rem;
-  cursor: pointer;
-  appearance: none;
-  text-overflow: ellipsis;
-  width: calc(var(--sl-select-width) + var(--sl-inline-padding) * 2);
-  margin-inline: calc(var(--sl-inline-padding) * -1);
-  /* Upstream pads the <select> 10px top and bottom, which forced the label
-     that wraps it to 60px -- against the 37.6px search button beside it, so
-     the bordered box looked oversized and misaligned in the header. The
-     label's own min-height sets the height now. */
-  padding-block: 0;
-  line-height: 1.2;
-  /* Upstream's inline padding assumes the icon is pinned at inset 0. Having
-     moved it in by the label's 0.65rem padding, the text needs the same
-     shift or it ends up 4px from the icon. */
-  padding-inline-start: calc(1.625rem + 0.65rem);
-  padding-inline-end: calc(var(--sl-caret-size) + var(--sl-inline-padding) + 0.25rem);
 }
 
-starlight-theme-select label:hover,
-.ui-theme-select label:hover {
+.ui-theme-trigger .caret {
+  font-size: 1.25rem;
+  margin-inline-start: auto;
+}
+
+.ui-theme-label {
+  white-space: nowrap;
+}
+
+.ui-theme-trigger:hover {
   color: var(--ui-text-strong);
   border-color: var(--ui-hover-border);
-  background: transparent;
 }
 
 /* Keyboard focus needs a ring, not a border tint.
  *
- * `:focus-within` was once grouped with `:hover`, so tabbing to the control
- * produced the hover treatment: a slightly different border colour and the
- * background *removed*. That is not a focus indicator -- it is barely a
- * change, it disappears against the header, and it is the one state a
- * keyboard user has nothing else to go on. The <select> inside has
- * `appearance: none` and no border of its own, so its own ring has nothing
- * to draw around.
- *
- * One ring, at the same alpha the search button beside it uses. An earlier
- * version stacked a solid 2px outline AND an accent border AND a 10% accent
- * background, which is three signals for one state and read as an error
- * rather than a cursor position. */
-starlight-theme-select label:focus-within,
-.ui-theme-select label:focus-within {
+ * An earlier version gave focus the hover treatment -- a slightly different
+ * border colour -- which is barely a change, disappears against the header,
+ * and is the one state a keyboard user has nothing else to go on. One ring,
+ * at the alpha the search button beside it uses. */
+.ui-theme-trigger:focus-visible {
   color: var(--ui-text-strong);
   border-color: rgba(var(--ui-accent-rgb), 0.45);
   box-shadow: 0 0 0 2px rgba(var(--ui-accent-rgb), 0.22);
   outline: 0;
 }
 
-starlight-theme-select select:focus-visible,
-.ui-theme-select select:focus-visible {
-  outline: 0;
-}
-
-/* Opaque, per theme -- see the note on the tokens at the top of this file. */
-starlight-theme-select option,
-.ui-theme-select option {
-  color: var(--ui-control-option-fg);
-  background-color: var(--ui-control-option-bg);
-}
-
-html[data-theme='light'] starlight-theme-select label:hover,
-html[data-theme='light'] starlight-theme-select label:focus-within,
-html[data-theme='light'] .ui-theme-select label:hover,
-html[data-theme='light'] .ui-theme-select label:focus-within {
+html[data-theme='light'] .ui-theme-trigger:hover,
+html[data-theme='light'] .ui-theme-trigger:focus-visible {
   border-color: rgba(var(--ui-accent-rgb), 0.34);
 }
 
-/* The landing bar's theme icon, one of three.
+/* The menu.
  *
- * The docs bar gets this from Starlight's ThemeProvider, which clones the
- * matching glyph out of a `<template id="theme-icons">` and only looks for
- * `starlight-theme-select`. Neither the template nor that element exists on
- * the landing page, so its control sat on the laptop glyph no matter what was
- * selected.
+ * Right-aligned to the trigger because the control sits at the end of both
+ * bars, where a left-aligned panel would hang off the edge on a narrow
+ * window. Opaque, not translucent: it overlaps page content, and the bar
+ * behind it is already semi-transparent. */
+.ui-theme-menu {
+  position: absolute;
+  inset-inline-end: 0;
+  top: calc(100% + 6px);
+  z-index: 60;
+  min-width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  border: 1px solid var(--ui-control-border);
+  border-radius: 8px;
+  background: var(--ui-control-menu-bg);
+  box-shadow: var(--ui-lift-md);
+}
+
+/* `hidden` has to be restated, or the menu is permanently open.
+ *
+ * The attribute's `display: none` lives in the browser's own stylesheet, and
+ * ANY author rule beats that -- so the `display: flex` above silently
+ * cancelled it and the panel rendered on every page load. The script was
+ * setting `menu.hidden` correctly the whole time; nothing was listening. */
+.ui-theme-menu[hidden] {
+  display: none;
+}
+
+.ui-theme-option {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.55rem;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--ui-text);
+  font: inherit;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  text-align: start;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.ui-theme-option:hover {
+  background: rgba(var(--ui-lift-rgb), 0.06);
+  color: var(--ui-text-strong);
+}
+
+.ui-theme-option:focus-visible {
+  outline: 0;
+  background: rgba(var(--ui-lift-rgb), 0.08);
+  color: var(--ui-text-strong);
+  box-shadow: inset 0 0 0 1px rgba(var(--ui-accent-rgb), 0.45);
+}
+
+/* The chosen row keeps the tick and the accent; the others reserve the tick's
+   width so the labels line up in a column rather than shifting as the choice
+   moves. */
+.ui-theme-tick {
+  display: inline-flex;
+  width: 14px;
+  flex: 0 0 14px;
+  opacity: 0;
+}
+
+.ui-theme-option[aria-checked='true'] {
+  color: var(--ui-accent);
+}
+
+.ui-theme-option[aria-checked='true'] .ui-theme-tick {
+  opacity: 1;
+}
+
+/* The trigger's icon, one of three.
  *
  * Driven by data-theme-choice on <html>, which the pre-paint script in
  * Page.astro sets before anything renders -- so the correct icon is right on
@@ -215,13 +201,13 @@ html[data-theme='light'] .ui-theme-select label:focus-within {
  * the case where that script did not run at all (storage blocked and it threw
  * before the assignment): auto is the honest default there, because auto is
  * what an unset preference means. */
-.ui-theme-select .label-icon {
+.ui-theme-trigger .label-icon {
   display: none;
 }
 
-html:not([data-theme-choice]) .ui-theme-select .label-icon[data-icon='auto'],
-html[data-theme-choice='auto'] .ui-theme-select .label-icon[data-icon='auto'],
-html[data-theme-choice='light'] .ui-theme-select .label-icon[data-icon='light'],
-html[data-theme-choice='dark'] .ui-theme-select .label-icon[data-icon='dark'] {
+html:not([data-theme-choice]) .ui-theme-trigger .label-icon[data-icon='auto'],
+html[data-theme-choice='auto'] .ui-theme-trigger .label-icon[data-icon='auto'],
+html[data-theme-choice='light'] .ui-theme-trigger .label-icon[data-icon='light'],
+html[data-theme-choice='dark'] .ui-theme-trigger .label-icon[data-icon='dark'] {
   display: block;
 }


### PR DESCRIPTION
The theme control was a native `<select>` on both bars. The list a select drops down is drawn by the operating system — on Windows, white rows with black text, positioned by the platform rather than under the trigger, and no CSS reaches it. It is a button and a menu now, in one component both bars render.

## Bugs fixed

| | |
|---|---|
| Menu permanently open | `.ui-theme-menu` sets `display: flex`, and `hidden`'s `display: none` lives in the browser's own stylesheet, which any author rule beats. The script was setting `menu.hidden` all along; nothing was listening. |
| Control inert on docs pages | Only `Nav.astro` called the init, and the docs bar renders through `starlight/ThemeSelect.astro`. The component wires itself now. |
| Duplicate menu id | A docs page renders the control twice (header + mobile menu). Dropped the id and `aria-controls`. |
| Collapsed search stranded | At ≤72rem it sat beside the wordmark with 454px of nothing after it (measured at 1150px: x=207, wordmark ending at 188). It joins the theme control and menu button. |
| Nav underline misaligned | The separator's space was padding on the same box the current-page border draws around, so the underline began 15px left of the word. Margin now, on both bars. |

Also drops the sidebar rail inset from 2.2–3.15rem to 1.5–2.25rem (the table of contents mirrors it — both rails read one token), and deletes two stale duplicate copies of numbers that had drifted or could.

## Verification

Run against the built site:

- Contrast sweep: clean across 14 routes in both themes
- axe: 0 violations on all 14 pages in both themes
- `check:css`: 0 shadowed declarations of 1116, budget 0
- `check:regions`, `check:wordmark`: pass
- `tsc --noEmit` filtered to `src`: clean
- Visual baseline re-recorded (240 captures, confirmed on a second pass) — deliberate change, and the baseline is gitignored

Behaviour driven in a browser: opens on click, right-aligns to its trigger, closes on Escape and on an outside click, choosing Light applies and persists. Bar layout measured at 700 / 880 / 1000 / 1150 / 1400px.