### PR TITLE
docs: give the README's TUI preview the same gradient span

### DIFF
--- a/docs/screenshots/tui-preview.svg
+++ b/docs/screenshots/tui-preview.svg
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="680" viewBox="0 0 1200 680" role="img" aria-label="NETSCLI TUI preview (idle)">
   <defs>
-    <linearGradient id="netscliGradient" x1="0" y1="0" x2="1200" y2="0" gradientUnits="userSpaceOnUse">
+    <!-- Spans each element it fills, not the canvas. Same change, and the
+         same reasoning, as tui-discover.svg: userSpaceOnUse across x=0..1200
+         left the logo sampling only the teal middle of the ramp, because the
+         word occupies the middle ~636px of that span. Per-element is also
+         what the TUI does -- gradient_text_line_with_left_pad and
+         draw_gradient_rounded_border in
+         apps/netscli-cli/src/tui/widgets/gradient.rs both walk t from 0 to 1
+         across the element's own width. -->
+    <linearGradient id="netscliGradient" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#005a1e"/>
       <stop offset="45%" stop-color="#0aae7a"/>
       <stop offset="100%" stop-color="#1edcff"/>


### PR DESCRIPTION
Follow-up to #363, same defect in the other TUI asset. `docs/screenshots/tui-preview.svg`'s gradient was `userSpaceOnUse` across the full 1200px canvas while the ASCII logo occupies only the middle ~636px, so the word sampled the teal middle of the ramp and reached neither end.

Rendered at 1640x930 through headless Chrome before and after, sampling the logo in five bands:

| | | | | | |
|---|---|---|---|---|---|
| Nav wordmark | `#047f46` | `#09a570` | `#0fba9b` | `#16cbcd` | `#1bd5eb` |
| Before | `#079963` | `#0aae7a` | `#0cb691` | `#0fc0ad` | `#12c8c4` |
| After | `#047e45` | `#09a570` | `#0eba9d` | `#0ea1ce` | `#17dbfc` |

The "after" row is identical to `tui-discover.svg`'s, so the README asset and the site asset now agree with each other and with the wordmark.

Stops untouched. The input box's border picks up the same correction, and both now match what the TUI draws — `gradient_text_line_with_left_pad` and `draw_gradient_rounded_border` walk `t` from 0 to 1 across each element's own width.

No raster to regenerate: `README.md:66` renders this SVG directly.