### PR TITLE
site: stop the changelog printing a release's intro prose twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ its heading and collects entries; the date and the link go on with the tag.
 
 ## [0.3.1]
 
-The first release since 0.2.6 in May, and a large one: four months of work on
+The first release since 0.2.6 in May, and a large one. Four months of work on
 the desktop app, the shared core and the website.
 
 The features are additive -- richer port-scan results, configurable probe

--- a/site/src/data/site-content/changelog.ts
+++ b/site/src/data/site-content/changelog.ts
@@ -28,7 +28,7 @@ export const changelogOgDescription = `Versioned ${meta.siteName} release notes 
  * this map to describe. */
 export const releaseSummaries: Record<string, string> = {
   'v0.3.1':
-    'Port-scan results carry more detail, probe concurrency is configurable on every interface, and the desktop workspace gains tab management. Four months of work since 0.2.6, with a long tail of fixes for code that reported success while doing nothing.',
+    'The desktop app is redesigned around a denser diagnostic workspace, with reorderable tabs, right-click tab management and a refreshed icon. Port scans return richer status data on every interface, probe concurrency is configurable everywhere, and the website and docs were rebuilt alongside. Four months of work since 0.2.6, and much of the long tail is fixes for code that reported success while doing nothing.',
   'v0.2.6':
     'Installed GUI builds now identify themselves correctly, and the Windows title-bar controls work. Also completes the CLI/TUI refactors that make future interface changes easier to review and test.',
   'v0.2.5':
@@ -44,7 +44,7 @@ export const releaseSummaries: Record<string, string> = {
   'v0.2.0':
     'Turns the initial scanner into something distributable. mDNS discovery and typed core errors on the product side; shell completions, man pages, package-manager templates and signed artifacts on the shipping side.',
   'v0.1.1':
-    'Cleans up the first public version: crate documentation, security notes and a structured changelog, plus the release workflow fixes that make binaries and pcap variants reproducible.',
+    'Cleans up the first public version with crate documentation, security notes and a structured changelog, plus the release workflow fixes that make binaries and pcap variants reproducible.',
   'v0.1.0':
-    'This is the first public NetsCLI release: one Rust core powers the CLI, terminal UI, desktop app, and MCP server, with structured output and cross-platform binaries for early users.',
+    'The first public NetsCLI release. One Rust core powers the CLI, terminal UI, desktop app, and MCP server, with structured output and cross-platform binaries for early users.',
 };

--- a/site/src/data/site-content/changelog.ts
+++ b/site/src/data/site-content/changelog.ts
@@ -28,7 +28,7 @@ export const changelogOgDescription = `Versioned ${meta.siteName} release notes 
  * this map to describe. */
 export const releaseSummaries: Record<string, string> = {
   'v0.3.1':
-    'Four months of work since 0.2.6: richer port-scan results, probe concurrency controls on every interface, and tab management in the desktop workspace — plus a long tail of fixes for code that reported success while doing nothing.',
+    'Port-scan results carry more detail, probe concurrency is configurable on every interface, and the desktop workspace gains tab management. Four months of work since 0.2.6, with a long tail of fixes for code that reported success while doing nothing.',
   'v0.2.6':
     'Installed GUI builds now identify themselves correctly, and the Windows title-bar controls work. Also completes the CLI/TUI refactors that make future interface changes easier to review and test.',
   'v0.2.5':

--- a/site/src/data/site-content/changelog.ts
+++ b/site/src/data/site-content/changelog.ts
@@ -16,9 +16,19 @@ export const changelogCopy: SectionCopy = {
 /** Shown when the page is shared. */
 export const changelogOgDescription = `Versioned ${meta.siteName} release notes and shipped changes.`;
 
+/* One curated line per release, shown above the expandable body.
+ *
+ * A tag with no entry here falls back to a summary derived from the release
+ * body, which is fine for a short entry and poor for a long one -- so any
+ * release whose CHANGELOG section opens with prose wants a line here, or the
+ * page prints that prose twice. See scripts/changelog/summarize.ts.
+ *
+ * No 'v0.3.0': it was tagged, its notes were drafted, and no release was ever
+ * published from it. Its entries are under 0.3.1 and there is no 0.3.0 for
+ * this map to describe. */
 export const releaseSummaries: Record<string, string> = {
-  'v0.3.0':
-    'The desktop workspace is redesigned, scan results carry richer status data, and interactive interfaces gain probe concurrency controls. Public docs are refreshed and packaging is fixed across release channels.',
+  'v0.3.1':
+    'Four months of work since 0.2.6: richer port-scan results, probe concurrency controls on every interface, and tab management in the desktop workspace — plus a long tail of fixes for code that reported success while doing nothing.',
   'v0.2.6':
     'Installed GUI builds now identify themselves correctly, and the Windows title-bar controls work. Also completes the CLI/TUI refactors that make future interface changes easier to review and test.',
   'v0.2.5':

--- a/site/src/scripts/changelog/summarize.ts
+++ b/site/src/scripts/changelog/summarize.ts
@@ -68,18 +68,25 @@ export function summarizeRelease(
   if (curated) return curated;
 
   const tag = release.tag_name || release.name || 'This release';
+  // Blank lines are KEPT, because a blank line is what separates one
+  // paragraph from the next. They used to be filtered out here, which left
+  // the loop below no way to tell where the first paragraph ended -- it ran
+  // until the next heading and returned the whole intro as the "summary".
+  // 0.3.1 is the first entry with multi-paragraph intro prose, so that is
+  // when it showed: the changelog page printed all three paragraphs as the
+  // summary and then again as the body.
   const lines = normalizeMarkdown(markdown)
     .split('\n')
     .map((line) => line.trim())
-    .filter((line) => line && !isGeneratedReleaseBoilerplate(line, release));
+    .filter((line) => !line || !isGeneratedReleaseBoilerplate(line, release));
 
   for (let index = 0; index < lines.length; index += 1) {
-    if (isBodyBoundary(lines[index])) {
+    if (!lines[index] || isBodyBoundary(lines[index])) {
       continue;
     }
 
     const paragraph = [];
-    while (index < lines.length && !isBodyBoundary(lines[index])) {
+    while (index < lines.length && lines[index] && !isBodyBoundary(lines[index])) {
       paragraph.push(lines[index]);
       index += 1;
     }


### PR DESCRIPTION
Caught while reviewing the site before deploying it. The v0.3.1 entry rendered its entire intro as the summary, then rendered the same prose again as the body.

Two causes:

**`summarizeRelease` filtered blank lines before splitting paragraphs.** With the blanks gone, the "first paragraph" loop had nothing to stop at, so it ran to the next `###` heading and returned the whole intro. Blank lines are kept now and end a paragraph. This bug is old; 0.3.1 is simply the first entry whose CHANGELOG section opens with prose.

**`v0.3.1` had no curated summary,** so it hit that derivation at all. The map held `v0.3.0` — tagged, never published, no release for the page to describe. Swapped for a `v0.3.1` line, with a note on the map that any release opening with prose needs one.

## Verification

Rebuilt and captured `/changelog/` before and after. Before: three intro paragraphs as the summary, then again below. After: one curated line, then the body.

`check:changelog` (8 entries render the date CHANGELOG.md declares), `check:css` (0 shadowed of 1116), `check:regions`, and `tsc --noEmit` filtered to `src` all pass.