### PR TITLE
site: cut the retrospective sentence from the 0.3.1 summary

### DIFF
--- a/site/src/data/site-content/changelog.ts
+++ b/site/src/data/site-content/changelog.ts
@@ -28,7 +28,7 @@ export const changelogOgDescription = `Versioned ${meta.siteName} release notes 
  * this map to describe. */
 export const releaseSummaries: Record<string, string> = {
   'v0.3.1':
-    'The desktop app is redesigned around a denser diagnostic workspace, with reorderable tabs, right-click tab management and a refreshed icon. Port scans return richer status data on every interface, probe concurrency is configurable everywhere, and the website and docs were rebuilt alongside. Four months of work since 0.2.6, and much of the long tail is fixes for code that reported success while doing nothing.',
+    'The desktop app is redesigned around a denser diagnostic workspace, with reorderable tabs, right-click tab management and a refreshed icon. Port scans return richer status data on every interface, probe concurrency is configurable everywhere, and the website and docs were rebuilt alongside.',
   'v0.2.6':
     'Installed GUI builds now identify themselves correctly, and the Windows title-bar controls work. Also completes the CLI/TUI refactors that make future interface changes easier to review and test.',
   'v0.2.5':


### PR DESCRIPTION
The summary ended:

> Four months of work since 0.2.6, and much of the long tail is fixes for code that reported success while doing nothing.

Two sentences describing the release, then a third narrating the work on it. That shift into retrospective voice is what made the card read like a debrief. "The long tail" also appeared twice on the same page, because the phrase came from the `CHANGELOG` body rendered directly beneath it.

Now:

> The desktop app is redesigned around a denser diagnostic workspace, with reorderable tabs, right-click tab management and a refreshed icon. Port scans return richer status data on every interface, probe concurrency is configurable everywhere, and the website and docs were rebuilt alongside.

Naming specific fixes instead was the alternative and reads defensively — the body lists all of them one click away, so the summary doesn't need to.

Also drops "four months of work since 0.2.6": the release date is already on the same card.

`check:changelog`, build and `tsc` over `src` pass.