### PR TITLE
Drop the 0.3.0 explanation from the 0.3.1 intro, and its dead links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,6 @@ is fixes, most of them found by using the desktop app on a real network
 rather than by reading the code. The recurring theme in that tail is code
 that reported success while doing nothing.
 
-It is numbered 0.3.1 because the crates, the desktop app and its Tauri
-manifest already carry that version. 0.3.0 was tagged and its notes drafted,
-but no release was ever published from it and no binary carries the number;
-its entries are here. There is no 0.3.0 release to look for.
-
 ### Added
 
 - **Tabs can be reordered.** Drag one along the strip, or move it with the
@@ -860,8 +855,7 @@ backed by the same core library.
 - Desktop app needs the WebView2 runtime on Windows. Most Windows
   10/11 systems have it preinstalled.
 
-[Unreleased]: https://github.com/fstubner/netscli/compare/v0.3.0...HEAD
-[0.3.0]: https://github.com/fstubner/netscli/releases/tag/v0.3.0
+[Unreleased]: https://github.com/fstubner/netscli/compare/v0.2.6...HEAD
 [0.2.6]: https://github.com/fstubner/netscli/releases/tag/v0.2.6
 [0.2.5]: https://github.com/fstubner/netscli/releases/tag/v0.2.5
 [0.2.4]: https://github.com/fstubner/netscli/releases/tag/v0.2.4


### PR DESCRIPTION
The intro paragraph explained why the release is numbered 0.3.1 and that 0.3.0 had been tagged but never published. The tag and its empty draft release are now both deleted, so there's nothing left for a reader to trip over — and the paragraph spent three sentences on repository bookkeeping in the first thing anyone reads about the release.

## Fallout from the tag deletion

Two link definitions at the bottom of the file pointed at nothing once `v0.3.0` was gone:

| | Was | Now |
|---|---|---|
| `[Unreleased]` | `compare/v0.3.0...HEAD` | `compare/v0.2.6...HEAD` |
| `[0.3.0]` | `releases/tag/v0.3.0` (404, and no heading used it) | removed |

## Verification

Every remaining `releases/tag/` target in the file was checked against `git ls-remote --tags origin` — v0.1.0 through v0.2.6, nine tags, all present.

`check:changelog` still reports 8 entries rendering the date `CHANGELOG.md` declares, and the site builds.

Deliberately left: one line inside a 0.3.1 entry describes Release Drafter proposing v0.2.7 "for a repo already tagged v0.3.0". That narrates a bug that did happen, which is what a changelog is for.