### PR TITLE
ci: run the site jobs for the files outside site/ that the build reads

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,8 +5,11 @@ name: Deploy GitHub Pages
 # deliberately NOT wired to push-to-main right now. site/ currently holds
 # a redesign that's still mid review/design-pass; auto-deploying on every
 # main merge shipped it to netscli.com prematurely once already. Restore
-# the `push: branches: [main], paths: ['site/**', ...]` trigger once the
-# redesign is actually approved to ship, then deploys resume automatically.
+# the push trigger once the redesign is actually approved to ship, then
+# deploys resume automatically. Copy the `paths:` list from site.yml rather
+# than writing `['site/**']`: the build also reads CHANGELOG.md,
+# scripts/install.ps1, scripts/install.sh and apps/netscli-gui/package.json,
+# so a site/**-only filter would leave changes to those undeployed.
 #
 # Until then: Actions tab → Deploy GitHub Pages → Run workflow, or
 # `gh workflow run pages.yml`.

--- a/.github/workflows/site-preview.yml
+++ b/.github/workflows/site-preview.yml
@@ -23,6 +23,10 @@ on:
     branches: [main]
     paths:
       - 'site/**'
+      - 'CHANGELOG.md'
+      - 'scripts/install.ps1'
+      - 'scripts/install.sh'
+      - 'apps/netscli-gui/package.json'
       - '.github/workflows/site-preview.yml'
   # Keep a `main` preview that tracks main, so there is always somewhere to
   # see the site as it currently is. It cannot come from the PR path: that
@@ -35,6 +39,10 @@ on:
     branches: [main]
     paths:
       - 'site/**'
+      - 'CHANGELOG.md'
+      - 'scripts/install.ps1'
+      - 'scripts/install.sh'
+      - 'apps/netscli-gui/package.json'
       - '.github/workflows/site-preview.yml'
 
 concurrency:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -3,8 +3,19 @@ name: Site
 on:
   push:
     branches: [main]
+    # Not just site/. The build reads four files from outside it: CHANGELOG.md
+    # (changelog.astro imports it with ?raw), scripts/install.ps1 and
+    # scripts/install.sh (served at /install.ps1 and /install.sh), and
+    # apps/netscli-gui/package.json (site-content/version.ts reads the version
+    # from it). Keep this list, the `changes` job's grep below, and
+    # site-preview.yml's two filters in step -- they are the same list three
+    # times and a media query cannot read a variable here either.
     paths:
       - 'site/**'
+      - 'CHANGELOG.md'
+      - 'scripts/install.ps1'
+      - 'scripts/install.sh'
+      - 'apps/netscli-gui/package.json'
   # NOTE: deliberately unfiltered, unlike the push trigger above. `Site
   # Gate` below is a required status check, and a required check that
   # never *reports* leaves a PR stuck on "Expected — waiting for status"
@@ -51,7 +62,8 @@ jobs:
           echo "Changed files:"
           echo "$files" | sed 's/^/  /'
 
-          if echo "$files" | grep -qE '^site/'; then
+          # Same set as the push trigger's paths list above.
+          if echo "$files" | grep -qE '^(site/|CHANGELOG\.md$|scripts/install\.(ps1|sh)$|apps/netscli-gui/package\.json$)'; then
             echo "site=true" >> "$GITHUB_OUTPUT"
           else
             echo "site=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
#375 touched only `CHANGELOG.md` and ran **four** checks instead of seven — the site build and the preview deploy both skipped. `site.yml` decides with `grep -qE '^site/'`, and the changelog isn't under `site/`.

But the site *renders* `CHANGELOG.md`, so a change that breaks the site build could merge without CI noticing. #375 was fine only because it happened to be built locally first.

## What the build reads from outside `site/`

| File | Read by |
|---|---|
| `CHANGELOG.md` | `pages/changelog.astro` imports it with `?raw` |
| `scripts/install.ps1` | served at `/install.ps1` by `pages/install.ps1.ts` |
| `scripts/install.sh` | served at `/install.sh` by `pages/install.sh.ts` |
| `apps/netscli-gui/package.json` | `site-content/version.ts` reads the displayed version from it |

All three filters now name the same five paths: `site.yml`'s push trigger, the grep in its `changes` job, and `site-preview.yml`'s two. The list is written three times because a workflow `paths:` can't reference a variable — each copy carries a note pointing at the others.

`pages.yml` gains only a comment. Its push trigger is still deliberately disabled; the note now says to copy `site.yml`'s list rather than the `['site/**']` it previously suggested, which would have left changes to those four files undeployed.

## Verification

The regex matches all five inputs and rejects `README.md`, `crates/**`, `docs/PUBLISHING.md`, `CHANGELOG.md.bak`, `package-lock.json`, `install.ps1.old` and `notsite/`.

All three workflows parse, and the parsed `paths:` lists are identical across the three filters.

This PR touches only `.github/workflows/**`, so the site jobs will skip on it — which is correct, and is the same filter working as intended.