### PR TITLE
test(gui): give the e2e desktop window a 16:9 shape

### DIFF
--- a/apps/netscli-gui/e2e/tauri-render.mjs
+++ b/apps/netscli-gui/e2e/tauri-render.mjs
@@ -32,7 +32,16 @@ import {
 } from './tauri-render/scenarios.mjs';
 import { alignmentReport } from './tauri-render/scenarios/helpers/alignment.mjs';
 
-const DESKTOP_WINDOW = { x: 0, y: 0, width: 1000, height: 970 };
+/* 16:9, because that is the shape a desktop app is actually used in.
+ *
+ * This was 1000x970, very nearly square, which no monitor is. The captures
+ * came out 1250x1213 and anything showing them at 16:9 cropped the bottom
+ * third -- the detail pane, the command strip and the status bar, which is
+ * to say every part of the window a screenshot of a scan is taken FOR.
+ *
+ * The narrow window below stays as it is: it exists to exercise the
+ * responsive breakpoint, so its shape is the point rather than a mistake. */
+const DESKTOP_WINDOW = { x: 0, y: 0, width: 1600, height: 900 };
 const NARROW_WINDOW = { width: 520, height: 720 };
 
 let nativeDriverProcess;


### PR DESCRIPTION
`DESKTOP_WINDOW` was **1000x970** — a ratio of 1.03:1, very nearly square, and no monitor is. The captures came out 1250x1213, so anything displaying them at 16:9 cropped the bottom third: the detail pane, the command strip and the status bar. That's every part of the window a screenshot of a scan is taken *for*.

Now **1600x900**, so captures are **2000x1125** at the harness's 1.25 device pixel ratio — 16:9 exactly.

`NARROW_WINDOW` is untouched at 520x720. Its shape is the point rather than an oversight: it exercises the responsive breakpoint, and its capture stays 650x900.

## Verification

Ran the suite at the new size:

- exit 0, no assertion errors
- **no alignment drift reported**, so nothing in the layout checks depended on the old dimensions
- all 11 desktop captures are 2000x1125; the narrow one is unchanged
- `eslint` clean