### PR TITLE
Take the in-range fixes for six npm advisories

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -3334,9 +3334,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "151.0.5",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-151.0.5.tgz",
-      "integrity": "sha512-oPI/VtTeLePbkTOI5o4yvEOlcdpmqEdqQNLZbyu5ha6kpDQYfDRuliisDiph29hBK/UzHSmOyZFKX1mE3efYOQ==",
+      "version": "152.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-152.0.3.tgz",
+      "integrity": "sha512-6v3pquS2kgb1HedzALRZeaoFZVCgghW2u1QjlzaoZruw75QBxKQtv/PKzJ8Scb3L8Vx32gcFwvUKcHmW7xjIVg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3518,16 +3518,16 @@
       }
     },
     "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
+      "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
+        "css-what": "^7.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "nth-check": "^2.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
@@ -3563,9 +3563,9 @@
       }
     },
     "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
+      "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -4267,9 +4267,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -5227,9 +5227,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -8277,18 +8277,18 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
-      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.1.0.tgz",
+      "integrity": "sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
-        "css-select": "^5.1.0",
+        "css-select": "^6.0.0",
         "css-tree": "^3.0.1",
-        "css-what": "^6.1.0",
+        "css-what": "^7.0.0",
         "csso": "^5.0.5",
         "picocolors": "^1.1.1",
-        "sax": "^1.5.0"
+        "sax": "1.6.1"
       },
       "bin": {
         "svgo": "bin/svgo.js"


### PR DESCRIPTION
Lockfile only. All three bumps sit inside ranges the dependency tree already asks for, so `package.json` is untouched.

| Package | Was | Now | Wanted by |
|---|---|---|---|
| `svgo` | 4.0.2 | 4.1.0 | astro `^4.0.1` |
| `fast-uri` | 3.1.5 | 3.1.7 | ajv `^3.0.1` |
| `js-yaml` | 4.3.1 | 4.3.2 | astro / starlight `^4.3.0` |

Clears all six open Dependabot alerts (svgo ×2, fast-uri ×4) plus the js-yaml advisory `npm audit` reports and Dependabot has not raised.

## None of these is exploitable here

Taking them because they are free, not because anything is on fire.

- **svgo** — `removeScripts` fails to fully strip executable content from an SVG you handed it *expecting sanitisation*. Every SVG in this repo is first-party and checked in.
- **fast-uri** — SSRF and host confusion when parsing an attacker-controlled URI. Reached only through ajv resolving schema `$ref`s at build time.
- **js-yaml** — CPU exhaustion on malicious YAML. The YAML parsed here is ours.

The site ships static HTML, CSS and JS; no `node_modules` reach a visitor, so the entire exposure is the build host.

## Deliberately left alone

`adm-zip` 0.6.0 — three moderate alerts for symlink-following zip extraction, reached via `chromedriver` via `@axe-core/cli`. npm's only offered fix is `@axe-core/cli` 4.7.3, a **major downgrade** from the 4.13.0 in the tree. Trading a current accessibility runner for a two-year-old one, to silence a moderate advisory about extracting the ChromeDriver zip Google serves over TLS, is the worse deal. Revisit when `@axe-core/cli` ships a chromedriver with `adm-zip` > 0.6.0.

## Verification

**Not verified locally.** `npm ci` refuses to run on this machine — nvx's supply-chain guard blocks `astro@7.3.2` for being under 24 hours old, which is already in the lockfile and unrelated to this change. So the installed `node_modules` still holds the old versions, and a local build exercises those rather than these. **CI's `npm ci` is the check that this resolves** — treat a green Site build here as the verification, not anything I ran.