### PR TITLE
Fix two wrong field tables in the result model

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -379,9 +379,19 @@ jobs:
 
   # ─── Winget GUI (microsoft/winget-pkgs) ────────────────────────────
   # Distinct PackageIdentifier `fstubner.netscli.gui` (the CLI is
-  # `fstubner.netscli`). Prefer the canonical command
-  # `winget install fstubner.netscli.gui`; the `netscli-gui` moniker may
-  # resolve after the package is accepted into the Winget catalog.
+  # `fstubner.netscli`).
+  #
+  # Both `winget install fstubner.netscli.gui` and the short
+  # `winget install netscli-gui` work. This used to say the moniker "may
+  # resolve after the package is accepted into the Winget catalog", written
+  # while the initial submission was still open. It was accepted: 0.2.6 is
+  # live at manifests/f/fstubner/netscli/gui/0.2.6/ and publishes
+  # `Moniker: netscli-gui`, exactly as the CLI publishes `Moniker: netscli`.
+  #
+  # The site relies on that. The landing hero and install section lead with
+  # the short form deliberately, and the install guide gives the identifier
+  # for anyone who wants to be unambiguous. Left as it was, this comment read
+  # as if the site were contradicting itself.
   winget-gui:
     name: Winget (GUI)
     runs-on: windows-latest
@@ -389,11 +399,12 @@ jobs:
     steps:
       # Same wait-then-submit pattern as the CLI Winget job above. The
       # GUI .msi takes longer to build than the CLI .exe (Tauri bundle
-      # + WiX compose), so this poll matters even more here. Note: this
-      # job will still fail until microsoft/winget-pkgs has accepted at
-      # least one version of `fstubner.netscli.gui` — the action checks
-      # for an existing package directory before doing anything else.
-      # PR #368471 is the initial submission gating that.
+      # + WiX compose), so this poll matters even more here.
+      #
+      # This used to warn that the job would fail until winget-pkgs had
+      # accepted a first version of `fstubner.netscli.gui`, since the action
+      # looks for an existing package directory before doing anything. That
+      # was resolved when PR #368471 landed 0.2.6; the directory exists.
       - name: Wait for Windows GUI release asset
         shell: bash
         env:

--- a/site/src/content/docs/docs/core-library.md
+++ b/site/src/content/docs/docs/core-library.md
@@ -82,6 +82,8 @@ Exact method signatures can change as operations gain richer structured data. Pr
 | `discover` | Host discovery over a subnet. |
 | `inspect` | Host profile data built from reachability, reverse DNS, and port checks. |
 | `sweep` | Discovery plus per-host port checks. |
+| `ping` | Reachability probing, with the ICMP and TCP-connect backends. |
+| `trace` | Route hops, over the platform trace tool. |
 | `dns` | Record lookup and reverse lookup behavior. |
 | `mdns` | Local mDNS/DNS-SD service discovery behind the `mdns` feature. |
 | `arp` | Local neighbor cache and MAC vendor enrichment. |

--- a/site/src/content/docs/docs/result-model.md
+++ b/site/src/content/docs/docs/result-model.md
@@ -142,14 +142,15 @@ carries — so both are given here.
 | Field | Desktop column | Meaning |
 | --- | --- | --- |
 | `name` | Interface | Interface name. |
-| `ips` | Addresses | Addresses assigned to the interface, with prefix length. |
+| `ips` | Addresses | Addresses, with prefix length. |
 | `mac` | MAC | MAC address when available. |
-| `is_up` | State | Whether the interface is up. Boolean in the data; the desktop app renders it as `up` or `down`. |
-| `is_loopback` | — | Whether the interface is loopback. Boolean in the data. The desktop app has no column for it directly; it feeds the Kind column below. |
+| `is_up` | State | Whether the interface is up. |
+| `is_loopback` | — | Whether the interface is loopback. |
 
-The desktop table adds one column with no field behind it: **Kind**, derived
-from `is_loopback` and the interface name, showing `loopback`, `virtual`,
-`vpn` or `physical`.
+`is_up` and `is_loopback` are booleans in the data. The desktop app renders
+the first as `up` or `down`, and has no column for the second — it feeds the
+**Kind** column instead, which has no field of its own and shows `loopback`,
+`virtual`, `vpn` or `physical`, derived from `is_loopback` and the name.
 
 ### ARP entries
 
@@ -159,8 +160,8 @@ from `is_loopback` and the interface name, showing `loopback`, `virtual`,
 | --- | --- | --- |
 | `ip` | IP | Neighbor address. |
 | `mac` | MAC | Neighbor MAC address. |
-| `interface` | Interface | Interface the entry was learned on. |
-| `vendor` | Vendor | OUI vendor lookup for the MAC address. |
+| `interface` | Interface | Interface it was learned on. |
+| `vendor` | Vendor | OUI vendor lookup for the MAC. |
 
 Take the first column when reading `--json`, `--yaml` or MCP output, and the
 second when reading the desktop table.

--- a/site/src/content/docs/docs/result-model.md
+++ b/site/src/content/docs/docs/result-model.md
@@ -39,7 +39,7 @@ Banner, HTTP, TLS, and raw preview data are probe results. They are useful diagn
 
 ## Host inventory
 
-Discovery and sweep results describe hosts.
+Discovery and sweep results describe hosts. A host row carries:
 
 <div data-ui-table="row-headers"></div>
 
@@ -50,9 +50,37 @@ Discovery and sweep results describe hosts.
 | `mac` | MAC address when present in ARP/vendor data. |
 | `vendor` | OUI vendor lookup. |
 | `rtt_ms` | Reachability latency. |
-| `open_ports` | Sweep-only list of open port rows for that host. |
+| `found_by` | Which probe found the host. |
 
 Discovery prioritizes inventory. Sweep adds exposed-service data by scanning selected ports on discovered hosts.
+
+### Sweep nests the host
+
+`discover` returns those rows directly, so `.[]` is a host:
+
+```bash
+netscli discover --json | jq '.[].ip'
+```
+
+`sweep` returns a different shape. Each entry pairs a whole host object with
+the ports found open on it, so the host fields are one level down:
+
+```json
+[
+  {
+    "host": { "ip": "192.168.1.1", "hostname": "router.local", "rtt_ms": 3 },
+    "open_ports": [{ "port": 443, "open": true, "status": "open" }]
+  }
+]
+```
+
+```bash
+netscli sweep 192.168.1.0/24 -p 22,80,443 --json | jq '.[].host.ip'
+```
+
+This page used to list `open_ports` in the table above as a "sweep-only"
+field, which read as though it sat beside `ip`. It does not, on any surface —
+the CLI and the MCP `sweep_network` tool both serialize the nested form.
 
 ## DNS records
 
@@ -102,18 +130,47 @@ mDNS/DNS-SD returns service announcements rather than generic host rows. A singl
 
 ## Interfaces and ARP
 
-Interface rows describe local network interfaces. ARP rows describe the local neighbor cache.
+Interface rows describe local network interfaces. ARP rows describe the local
+neighbor cache. These are two different shapes, and unlike everywhere else on
+this page, the desktop app does not show them under the field names the data
+carries — so both are given here.
+
+### Interfaces
 
 <div data-ui-table="row-headers"></div>
 
-| Field | Meaning |
-| --- | --- |
-| `name` / `interface` | Interface name or interface address associated with the row. |
-| `ips` / `addresses` | Interface addresses. |
-| `mac` | MAC address when available. |
-| `state` | Interface state such as up or down. |
-| `loopback` | Whether the interface is loopback where known. |
-| `vendor` | OUI vendor lookup for MAC addresses where available. |
+| Field | Desktop column | Meaning |
+| --- | --- | --- |
+| `name` | Interface | Interface name. |
+| `ips` | Addresses | Addresses assigned to the interface, with prefix length. |
+| `mac` | MAC | MAC address when available. |
+| `is_up` | State | Whether the interface is up. Boolean in the data; the desktop app renders it as `up` or `down`. |
+| `is_loopback` | — | Whether the interface is loopback. Boolean in the data. The desktop app has no column for it directly; it feeds the Kind column below. |
+
+The desktop table adds one column with no field behind it: **Kind**, derived
+from `is_loopback` and the interface name, showing `loopback`, `virtual`,
+`vpn` or `physical`.
+
+### ARP entries
+
+<div data-ui-table="row-headers"></div>
+
+| Field | Desktop column | Meaning |
+| --- | --- | --- |
+| `ip` | IP | Neighbor address. |
+| `mac` | MAC | Neighbor MAC address. |
+| `interface` | Interface | Interface the entry was learned on. |
+| `vendor` | Vendor | OUI vendor lookup for the MAC address. |
+
+Take the first column when reading `--json`, `--yaml` or MCP output, and the
+second when reading the desktop table.
+
+This section previously merged the two shapes into one list and gave
+`addresses`, `state` and `loopback` as field names. None of the three is a
+field: `addresses` is a column *header* over `ips`, `state` is a desktop row
+key derived from `is_up`, and `loopback` is a desktop row key that is not even
+shown as a column. `vendor` was also listed as though it applied to
+interfaces, which it does not.
 
 ARP is not full discovery. It reports entries already known to the operating system.
 


### PR DESCRIPTION
From auditing all 11 docs pages, the FAQ and the 404 against the code they describe. Two defects, both on the one page whose job is telling a consumer what comes back.

## Interfaces and ARP named three fields that do not exist

The page merged two different shapes into one table and gave `addresses`, `state` and `loopback` as result fields. None of the three is a field:

- `addresses` is the desktop app's column **header** over the `ips` field
- `state` and `loopback` are desktop row keys derived from `is_up` and `is_loopback` — and `loopback` isn't even shown as a column
- `vendor` was listed as if it applied to interfaces; it's an ARP field

Now two tables, one per shape, with a second column for the desktop heading where it differs. Everywhere else on the page the wire name and the displayed name coincide — here they don't, and the page was silently merging them.

## Sweep's shape was documented flat and is nested

The host table listed `open_ports` as a "sweep-only" field, reading as a sibling of `ip`. `SweepEntry` has no serde flatten, so the CLI and the MCP `sweep_network` tool both emit:

```json
{ "host": { "ip": "…" }, "open_ports": [ … ] }
```

Anyone following the table writes `jq '.[].ip'` — correct for `discover`, empty for `sweep`. Now its own subsection with the real JSON and the `jq '.[].host.ip'` that works.

## Also

`found_by` added to the host table, `ip` to the ARP table, `ping` and `trace` to the core-library module map. All exist; all were simply missing.

## The rest of the audit came back clean

All 18 CLI subcommands and all 13 MCP tool names match exactly. Every documented flag exists. The four safety numbers (`/16`, 4096 ports, 500 ms, concurrency 256) match the constants. The other 44 documented field names are real. The Rust example matches `scan_ports`' actual signature. Every internal link and anchor resolves.

## One reported defect that wasn't one

I also flagged the FAQ and the install page disagreeing on how to install the desktop app — moniker vs full identifier. That was wrong, and the second commit here explains why: both monikers are live in the catalog, and the split is deliberate and documented in `hero.ts`. What misled me was a stale comment in `publish.yml`, written while the submission was open, saying the moniker "may resolve after the package is accepted". It was accepted. Comment corrected; the site is untouched.

## Verification

Each table read against the structs in `netscli-core` and `columns.ts`/`rows.ts` in the desktop app. Site builds, `astro check` reports 0 errors, and the rendered HTML was inspected to confirm both tables and the new subsection come out right.