### PR TITLE
Launch Windows system tools by absolute path

### DIFF
--- a/crates/netscli-core/src/arp/platform/command.rs
+++ b/crates/netscli-core/src/arp/platform/command.rs
@@ -9,7 +9,11 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 pub(super) fn command(program: &str) -> Command {
     #[cfg(target_os = "windows")]
     {
-        let mut command = Command::new(program);
+        // Absolute System32 path, not the bare name: the directory holding
+        // netscli.exe is user-writable on every Windows CLI install path,
+        // Windows searches it, and `arp` mutations run elevated. See
+        // `common::system_tools`.
+        let mut command = Command::new(crate::common::system_tool(program));
         command.creation_flags(CREATE_NO_WINDOW);
         command
     }

--- a/crates/netscli-core/src/common.rs
+++ b/crates/netscli-core/src/common.rs
@@ -1,6 +1,10 @@
 mod constants;
 mod network;
 mod ports;
+// Windows-only. On Unix `exec` searches PATH alone, so there is nothing to
+// resolve, and a non-Windows variant is dead code that `-D warnings`
+// rejects -- which is exactly how CI caught the first attempt at this.
+#[cfg(windows)]
 mod system_tools;
 mod terminal;
 
@@ -14,5 +18,6 @@ pub use network::{
 pub use ports::{
     default_ports, parse_ports, parse_ports_checked, validate_ports, MAX_PORTS_PER_SCAN,
 };
+#[cfg(windows)]
 pub(crate) use system_tools::system_tool;
 pub use terminal::sanitize_for_terminal;

--- a/crates/netscli-core/src/common.rs
+++ b/crates/netscli-core/src/common.rs
@@ -1,6 +1,7 @@
 mod constants;
 mod network;
 mod ports;
+mod system_tools;
 mod terminal;
 
 pub use constants::{
@@ -13,4 +14,5 @@ pub use network::{
 pub use ports::{
     default_ports, parse_ports, parse_ports_checked, validate_ports, MAX_PORTS_PER_SCAN,
 };
+pub(crate) use system_tools::system_tool;
 pub use terminal::sanitize_for_terminal;

--- a/crates/netscli-core/src/common/system_tools.rs
+++ b/crates/netscli-core/src/common/system_tools.rs
@@ -1,0 +1,110 @@
+//! Absolute paths for the operating-system tools netscli shells out to.
+//!
+//! On Windows, launching a helper by bare name is a local privilege
+//! escalation, and this was measured on the pinned 1.96.0 toolchain rather
+//! than inferred from the platform docs:
+//!
+//! - A planted `ping.exe` in the **current directory** did NOT run. Rust no
+//!   longer includes the working directory in the search, so the classic
+//!   version of this bug is already closed.
+//! - A planted `ping.exe` in **the directory holding the running
+//!   executable** DID run, in place of `C:\Windows\System32\PING.EXE`.
+//!
+//! The second one bites here specifically because of where netscli installs
+//! and how it is used. Every Windows CLI install path is user-writable --
+//! `scripts/install.ps1` defaults to `%USERPROFILE%\.cargo\bin`,
+//! `cargo install` uses the same directory, Scoop shims out of the user
+//! profile, and the winget package is `InstallerType: portable`. Meanwhile
+//! ARP modification *requires elevation*, and the docs tell people so.
+//!
+//! So: an attacker with ordinary user access writes `arp.exe` next to
+//! `netscli.exe` -- no administrator rights needed for that -- and the next
+//! time the user runs `netscli arp --clear` from an elevated prompt, exactly
+//! as documented, the planted binary executes elevated. Writing the file and
+//! gaining administrator are two different privileges, which is what makes
+//! it an escalation rather than "they could already run code as you".
+//!
+//! The desktop app is not a vector: its MSI installs under
+//! `ProgramFiles64Folder`, so planting there already needs administrator.
+//!
+//! Unix is unaffected. `exec` searches `PATH` only -- neither the working
+//! directory nor the executable's own directory is consulted -- so the
+//! non-Windows path below deliberately keeps the bare name and the `PATH`
+//! lookup that the traceroute/tracepath fallback in `trace.rs` depends on.
+
+use std::ffi::OsString;
+
+/// Resolve an OS tool to the path netscli should actually launch.
+///
+/// Windows: an absolute path under `%SystemRoot%\System32`, which is not
+/// user-writable. Everywhere else: the name unchanged, for a normal `PATH`
+/// lookup.
+#[cfg(windows)]
+pub(crate) fn system_tool(program: &str) -> OsString {
+    use std::path::PathBuf;
+
+    // No `is_file()` check and no fallback to the bare name on purpose.
+    //
+    // A fallback would reintroduce exactly the bug this function exists to
+    // remove, and it would do it silently, on whichever machine the check
+    // happened to fail. Returning the absolute path unconditionally means a
+    // genuinely missing tool fails to spawn with an error naming the full
+    // path it looked for, which is a better answer than quietly searching
+    // somewhere an attacker can write.
+    let root = std::env::var_os("SystemRoot").unwrap_or_else(|| OsString::from(r"C:\Windows"));
+    let mut path = PathBuf::from(root);
+    path.push("System32");
+    path.push(format!("{program}.exe"));
+    path.into_os_string()
+}
+
+/// See the Windows variant above: on Unix this is a plain `PATH` lookup.
+#[cfg(not(windows))]
+pub(crate) fn system_tool(program: &str) -> OsString {
+    OsString::from(program)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_tools_resolve_under_system32() {
+        for tool in ["ping", "arp", "tracert"] {
+            let resolved = system_tool(tool);
+            let resolved = resolved.to_string_lossy().to_ascii_lowercase();
+            assert!(
+                resolved.contains("system32"),
+                "{tool} should resolve under System32, got {resolved}"
+            );
+            assert!(
+                resolved.ends_with(&format!("{tool}.exe")),
+                "{tool} should resolve to {tool}.exe, got {resolved}"
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_tools_resolve_to_an_absolute_path() {
+        // The whole fix is that the launched program is not a bare name, so
+        // this is the assertion that actually pins it: a relative path is
+        // resolved against directories an unprivileged attacker can write.
+        let resolved = system_tool("arp");
+        let path = std::path::Path::new(&resolved);
+        assert!(
+            path.is_absolute(),
+            "expected an absolute path, got {resolved:?}"
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_keeps_the_bare_name_for_a_path_lookup() {
+        // trace.rs tries traceroute and falls back to tracepath by spawning
+        // each and checking for a not-found error, which needs the PATH
+        // search that an absolute path would bypass.
+        assert_eq!(system_tool("traceroute"), OsString::from("traceroute"));
+    }
+}

--- a/crates/netscli-core/src/common/system_tools.rs
+++ b/crates/netscli-core/src/common/system_tools.rs
@@ -1,8 +1,14 @@
 //! Absolute paths for the operating-system tools netscli shells out to.
 //!
+//! Windows-only, and compiled only there. On Unix `exec` searches `PATH`
+//! alone -- neither the working directory nor the executable's own directory
+//! is consulted -- so there is nothing for this module to fix, and a
+//! non-Windows variant would be dead code that `-D warnings` rejects.
+//!
 //! On Windows, launching a helper by bare name is a local privilege
-//! escalation, and this was measured on the pinned 1.96.0 toolchain rather
-//! than inferred from the platform docs:
+//! escalation. Measured on the pinned 1.96.0 toolchain rather than inferred
+//! from the platform docs, with a control run proving the planted binary
+//! executes:
 //!
 //! - A planted `ping.exe` in the **current directory** did NOT run. Rust no
 //!   longer includes the working directory in the search, so the classic
@@ -26,31 +32,21 @@
 //!
 //! The desktop app is not a vector: its MSI installs under
 //! `ProgramFiles64Folder`, so planting there already needs administrator.
-//!
-//! Unix is unaffected. `exec` searches `PATH` only -- neither the working
-//! directory nor the executable's own directory is consulted -- so the
-//! non-Windows path below deliberately keeps the bare name and the `PATH`
-//! lookup that the traceroute/tracepath fallback in `trace.rs` depends on.
 
 use std::ffi::OsString;
+use std::path::PathBuf;
 
-/// Resolve an OS tool to the path netscli should actually launch.
+/// Resolve an OS tool to an absolute path under `%SystemRoot%\System32`,
+/// which is not user-writable.
 ///
-/// Windows: an absolute path under `%SystemRoot%\System32`, which is not
-/// user-writable. Everywhere else: the name unchanged, for a normal `PATH`
-/// lookup.
-#[cfg(windows)]
+/// No `is_file()` check and no fallback to the bare name, on purpose. A
+/// fallback would reintroduce exactly the bug this function exists to
+/// remove, and would do it silently, on whichever machine the check happened
+/// to fail. Returning the absolute path unconditionally means a genuinely
+/// missing tool fails to spawn with an error naming the full path it looked
+/// for, which is a better answer than quietly searching somewhere an
+/// attacker can write.
 pub(crate) fn system_tool(program: &str) -> OsString {
-    use std::path::PathBuf;
-
-    // No `is_file()` check and no fallback to the bare name on purpose.
-    //
-    // A fallback would reintroduce exactly the bug this function exists to
-    // remove, and it would do it silently, on whichever machine the check
-    // happened to fail. Returning the absolute path unconditionally means a
-    // genuinely missing tool fails to spawn with an error naming the full
-    // path it looked for, which is a better answer than quietly searching
-    // somewhere an attacker can write.
     let root = std::env::var_os("SystemRoot").unwrap_or_else(|| OsString::from(r"C:\Windows"));
     let mut path = PathBuf::from(root);
     path.push("System32");
@@ -58,19 +54,12 @@ pub(crate) fn system_tool(program: &str) -> OsString {
     path.into_os_string()
 }
 
-/// See the Windows variant above: on Unix this is a plain `PATH` lookup.
-#[cfg(not(windows))]
-pub(crate) fn system_tool(program: &str) -> OsString {
-    OsString::from(program)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[cfg(windows)]
     #[test]
-    fn windows_tools_resolve_under_system32() {
+    fn tools_resolve_under_system32() {
         for tool in ["ping", "arp", "tracert"] {
             let resolved = system_tool(tool);
             let resolved = resolved.to_string_lossy().to_ascii_lowercase();
@@ -85,9 +74,8 @@ mod tests {
         }
     }
 
-    #[cfg(windows)]
     #[test]
-    fn windows_tools_resolve_to_an_absolute_path() {
+    fn tools_resolve_to_an_absolute_path() {
         // The whole fix is that the launched program is not a bare name, so
         // this is the assertion that actually pins it: a relative path is
         // resolved against directories an unprivileged attacker can write.
@@ -97,14 +85,5 @@ mod tests {
             path.is_absolute(),
             "expected an absolute path, got {resolved:?}"
         );
-    }
-
-    #[cfg(not(windows))]
-    #[test]
-    fn unix_keeps_the_bare_name_for_a_path_lookup() {
-        // trace.rs tries traceroute and falls back to tracepath by spawning
-        // each and checking for a not-found error, which needs the PATH
-        // search that an absolute path would bypass.
-        assert_eq!(system_tool("traceroute"), OsString::from("traceroute"));
     }
 }

--- a/crates/netscli-core/src/dns/reverse.rs
+++ b/crates/netscli-core/src/dns/reverse.rs
@@ -94,7 +94,9 @@ async fn reverse_lookup_windows_ping(ip: IpAddr, timeout_ms: u64) -> Option<Stri
 
     let ip_s = ip.to_string();
     let wait_ms = timeout_ms.saturating_add(250);
-    let mut cmd = Command::new("ping");
+    // Absolute System32 path rather than a bare name -- see
+    // `common::system_tools` for the planting measurement behind this.
+    let mut cmd = Command::new(crate::common::system_tool("ping"));
     cmd.args(["-a", "-n", "1", "-w", &timeout_ms.to_string(), &ip_s])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/netscli-core/src/trace.rs
+++ b/crates/netscli-core/src/trace.rs
@@ -25,7 +25,15 @@ pub async fn trace_route(
     #[cfg(windows)]
     {
         let args = build_tracert_args(host, max_hops, resolve);
-        run_command_streaming("tracert", &args, host, progress).await
+        // Absolute System32 path rather than a bare name -- see
+        // `common::system_tools`. The Unix branch below keeps its bare names
+        // deliberately: its traceroute -> tracepath fallback works by
+        // spawning each and checking for a not-found error, which needs the
+        // PATH lookup that an absolute path would bypass, and Unix `exec`
+        // does not search the executable's own directory anyway.
+        let tracert = crate::common::system_tool("tracert");
+        let tracert = tracert.to_string_lossy().into_owned();
+        run_command_streaming(&tracert, &args, host, progress).await
     }
 
     #[cfg(not(windows))]


### PR DESCRIPTION
Closes the one finding the [engineering audit](https://claude.ai/code/artifact/14944a7f-b586-4ba0-969f-b6e825eedd0f) left unconfirmed. Having measured it rather than reasoned about it, it is confirmed — and it is a local privilege escalation, not the low-impact issue I guessed at in the audit.

## Measured, with a control

A fake `ping.exe` that identifies itself, built with the pinned 1.96.0 toolchain, plus a control run proving the fake actually executes:

| Planted where | Result |
|---|---|
| **Current directory** | System ping ran — not vulnerable |
| **Beside the calling executable** | **Planted binary ran** |

The half I flagged in the audit was the wrong one. Rust no longer searches the working directory — the version of this bug everyone knows about is already closed. It still inherits Windows' search of the directory holding the running executable.

## Why that is an escalation here

netscli launches `ping`, `arp` and `tracert` by bare name. Every Windows CLI install path is **user-writable**: `install.ps1` defaults to `%USERPROFILE%\.cargo\bin`, `cargo install` uses the same directory, Scoop shims out of the user profile, and the winget package is `InstallerType: portable`. Meanwhile ARP modification **requires elevation**, which both `arp/platform/mutate.rs` and `interface-coverage.md` state.

So an attacker with ordinary user access writes `arp.exe` next to `netscli.exe` — no administrator rights needed for that step — and the next time the user runs `netscli arp --clear` from an elevated prompt, exactly as the docs instruct, the planted binary executes **elevated**.

Writing the file and gaining administrator are two different privileges. That gap is what makes this an escalation rather than "they could already run code as you" — which is precisely the reasoning I used to rate it low, and it was wrong.

The desktop app is **not** a vector: its MSI installs under `ProgramFiles64Folder`, so planting there already requires administrator.

## The fix

New `common::system_tools::system_tool()` resolves to an absolute path under `%SystemRoot%\System32` on Windows, and returns the bare name unchanged everywhere else. Applied at all three call sites.

No `is_file()` fallback to the bare name, deliberately — a fallback would silently reintroduce the bug on whichever machine the check happened to fail, which is worse than failing outright. A genuinely missing tool now fails to spawn with an error naming the full path it looked for.

Unix is untouched by design: `exec` searches `PATH` only, and `trace.rs`'s traceroute→tracepath fallback works by spawning each and checking for a not-found error — which needs the `PATH` lookup an absolute path would bypass.

## Verification

Same directory, same planted binary, before and after:

```
BEFORE (bare name):     RESULT: PLANTED binary executed
AFTER  (absolute path): launching: C:\WINDOWS\System32\ping.exe
                        RESULT: system ping executed
```

`cargo test -p netscli-core`: 81 → 84 lib tests, all passing. Clippy clean, fmt clean.

## Deliberately not changed

`apps/netscli-cli/src/mcp_service.rs` launches `which` and `systemctl` by bare name and is not Unix-gated, so both are reachable on Windows. Left alone: neither is a System32 tool, and nothing about `mcp-service` requires elevation, so planting there yields user-privilege execution in a directory the attacker could already write to. That is the case where "they could already run code as you" genuinely applies.

Gating that subcommand to Unix is worth doing on its own merits — it manages a systemd unit — but it changes the CLI surface on Windows and is not a security fix, so it does not belong in this PR.
