### PR TITLE
Date 0.3.1 in the changelog and add its link reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ them: it printed "24 Aug 2026" for 0.3.1 for four days on the strength of a
 date written here when the notes were drafted. An in-flight version keeps
 its heading and collects entries; the date and the link go on with the tag.
 
-## [0.3.1]
+## [0.3.1] — 2026-09-11
 
 The first release since 0.2.6 in May, and a large one. Four months of work on
 the desktop app, the shared core and the website.
@@ -855,7 +855,8 @@ backed by the same core library.
 - Desktop app needs the WebView2 runtime on Windows. Most Windows
   10/11 systems have it preinstalled.
 
-[Unreleased]: https://github.com/fstubner/netscli/compare/v0.2.6...HEAD
+[Unreleased]: https://github.com/fstubner/netscli/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/fstubner/netscli/releases/tag/v0.3.1
 [0.2.6]: https://github.com/fstubner/netscli/releases/tag/v0.2.6
 [0.2.5]: https://github.com/fstubner/netscli/releases/tag/v0.2.5
 [0.2.4]: https://github.com/fstubner/netscli/releases/tag/v0.2.4


### PR DESCRIPTION
Last change before publishing.

The date and the link go on **with the tag**, not with the version bump. The note at the top of `CHANGELOG.md` says so, and it says so because 0.3.1 was once dated `2026-08-24` in a release commit, never tagged, and netscli.com showed that date against a tag page that 404d for four days.

`v0.3.1` now exists, so the claim is finally true.

## Changes

- `## [0.3.1]` → `## [0.3.1] — 2026-09-11`, the day the release is published
- adds `[0.3.1]: .../releases/tag/v0.3.1`
- repoints `[Unreleased]` to compare from `v0.3.1` rather than `v0.2.6`, so the unreleased link stops including everything that just shipped

## Verification

`npm run check:changelog` against a fresh build:

```
8 changelog entr(ies) render the date CHANGELOG.md declares.
```

That guard has two halves and both are load-bearing here. It checks that the **built page** renders exactly the date the source declares, and separately that a dated heading has a **matching git tag**. Run before `v0.3.1` was pushed, this change would have failed the second half with *"there is no v0.3.1 tag. The date goes on with the tag, not with the version bump."*

CI re-runs it in a clean checkout with `fetch-depth: 0`, which is the honest test of the tag half.

## Note on the tag

`v0.3.1` points at `c54f43c`; this commit lands after it. That is fine and the tag does not need moving: the only diff between the tag and `main` is `publish-preflight.yml`, a CI-only file, so the release binaries are unaffected. The site reads `CHANGELOG.md` from `main`, not from the tag.