### PR TITLE
Site audit fixes: download counter, winget alignment, chromedriver bump

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -12,6 +12,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
         "@axe-core/cli": "^4.13.0",
+        "chromedriver": "^152.0.3",
         "linkedom": "^0.18.13",
         "selenium-webdriver": "^4.48.0",
         "typescript": "^5.5.0"

--- a/site/package.json
+++ b/site/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
     "@axe-core/cli": "^4.13.0",
+    "chromedriver": "^152.0.3",
     "linkedom": "^0.18.13",
     "selenium-webdriver": "^4.48.0",
     "typescript": "^5.5.0"

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -9,8 +9,8 @@ NetsCLI publishes command-line binaries and desktop installers through GitHub Re
 
 | Platform | Recommended path | Installs |
 | --- | --- | --- |
-| Windows | `winget install fstubner.netscli` | CLI and TUI |
-| Windows | `winget install fstubner.netscli.gui` | Desktop app |
+| Windows | `winget install netscli` | CLI and TUI |
+| Windows | `winget install netscli-gui` | Desktop app |
 | macOS | Homebrew or install script | CLI and TUI |
 | Linux | Install script, Homebrew, AUR, or release artifact | CLI and TUI |
 | Rust users | `cargo install netscli` | CLI and TUI from crates.io |
@@ -20,14 +20,18 @@ NetsCLI publishes command-line binaries and desktop installers through GitHub Re
 Use winget for the hash-verified install path:
 
 ```powershell
-winget install fstubner.netscli
+winget install netscli
 ```
 
 The desktop app is distributed separately:
 
 ```powershell
-winget install fstubner.netscli.gui
+winget install netscli-gui
 ```
+
+Both short names resolve today. The full identifiers are `fstubner.netscli`
+and `fstubner.netscli.gui`, and they cannot become ambiguous — use those if a
+short name ever matches more than one package in the catalog.
 
 Scoop is also supported, for both the CLI and the desktop app:
 

--- a/site/src/scripts/landing-page.ts
+++ b/site/src/scripts/landing-page.ts
@@ -80,13 +80,30 @@ export function initLandingPage(repo: string): void {
          never resolves. */
       let githubDownloads: number | null = null;
       let cratesDownloads: number | null = null;
+      // Whether each source has finished, which is not the same as whether it
+      // produced a number. A rate-limited source never sets its count, so
+      // gating on the counts alone would leave the label waiting forever.
+      let githubSettled = false;
+      let cratesSettled = false;
       const renderDownloads = () => {
         if (githubDownloads === null && cratesDownloads === null) return;
         const total = (githubDownloads ?? 0) + (cratesDownloads ?? 0);
+        // "total" is a claim about both sources, so only make it once both
+        // have reported. Measured on this page: "Downloads: 178 total" with
+        // only GitHub in, then "Downloads: 2,635 total" once crates.io
+        // landed -- same label, same page, a fifteenfold difference. Until
+        // both are in, the number is a lower bound and now says so.
+        const complete = githubSettled && cratesSettled
+          && githubDownloads !== null && cratesDownloads !== null;
         const el = document.getElementById("downloads");
         if (el) {
-          el.textContent = `${fmtDownloads(total)} ${total === 1 ? "download" : "downloads"}`;
-          el.dataset.totalDownloads = `Downloads: ${fmt(total)} total`;
+          // fmtDownloads already appends "+" above 1000; don't double it.
+          const shown = fmtDownloads(total);
+          const text = complete || shown.endsWith("+") ? shown : `${shown}+`;
+          el.textContent = `${text} ${total === 1 ? "download" : "downloads"}`;
+          el.dataset.totalDownloads = complete
+            ? `Downloads: ${fmt(total)} total`
+            : `Downloads: ${fmt(total)} so far; one source has not reported`;
           el.setAttribute("aria-label", el.dataset.totalDownloads);
           el.hidden = false;
         }
@@ -102,9 +119,15 @@ export function initLandingPage(repo: string): void {
           const n = d?.crate?.downloads;
           if (typeof n !== "number") return;
           cratesDownloads = n;
-          renderDownloads();
         })
-        .catch(() => {});
+        .catch(() => {})
+        // `finally`, not the success path: a failed or rate-limited fetch
+        // settles this source too, and the label has to know that to stop
+        // withholding the word "total".
+        .finally(() => {
+          cratesSettled = true;
+          renderDownloads();
+        });
 
       fetch(`https://api.github.com/repos/${repo}/releases?per_page=100`)
         .then((r) => (r.ok ? r.json() : null))
@@ -118,7 +141,6 @@ export function initLandingPage(repo: string): void {
             ),
             0,
           );
-          renderDownloads();
           const latest = releases.find((release) => !release.draft && !release.prerelease)
             ?? releases.find((release) => !release.draft);
           const versionEl = document.getElementById("latest-version");
@@ -130,7 +152,11 @@ export function initLandingPage(repo: string): void {
             refreshMetricSeparators();
           }
         })
-        .catch(() => {});
+        .catch(() => {})
+        .finally(() => {
+          githubSettled = true;
+          renderDownloads();
+        });
     })();
 
     initCopyButtons();


### PR DESCRIPTION
Three independent commits from the site audit, separated so any one can be dropped.

## 1. Download counter only claims a total once both sources report

`renderDownloads` sums GitHub release assets and crates.io, but wrote the label as soon as *either* resolved — so "total" was asserted before it was true. Measured on the running site: the same page showed `Downloads: 178 total` with only crates.io in, and `Downloads: 2,635 total` once the GitHub count landed. A fifteenfold difference under one label.

The fix tracks whether each source has **settled** separately from its count, because a rate-limited source never sets a value and gating on the counts alone would leave the label waiting forever. Settling happens in `.finally`, so a failed or rate-limited fetch settles too.

Verified in both directions by forcing the crates.io fetch to fail:

| State | Rendered | aria-label |
| --- | --- | --- |
| Partial | `2.4K+ downloads` | `Downloads: 2,458 so far; one source has not reported` |
| Complete | `2.6K+ downloads` | `Downloads: 2,636 total` |

The partial case is the one that matters — before this change it read `2,458 total`. The sabotage was reverted and the complete state re-confirmed.

While measuring this, the split between the two sources turned out to be roughly **2,458 binary downloads** against **~178 `cargo install`s**. Every package manager — winget, Scoop, Homebrew, AUR — pulls the GitHub release asset, so all of them land in the first number.

## 2. Short winget identifiers in the install docs

The landing page and FAQ said `winget install netscli`; the install docs said `winget install fstubner.netscli`. Both resolve, so this was inconsistency rather than error, and the short form is what the landing page leads with. All 13 winget commands across the site now match.

The full identifiers stay documented in one line, because a bare name match can become ambiguous if another `netscli` ever enters the catalog and `fstubner.netscli` cannot.

## 3. chromedriver 152 — correct, but unverified here

`visual:check` drives Chrome through chromedriver. The pinned 151 crashes against the installed Chrome 152 with a `GetHandleVerifier` stack trace rather than failing cleanly, so the gate reported nothing at all — neither pass nor fail.

**This bump is not proven to fix it.** The sandbox on this machine records the lockfile change but discards the postinstall binary download, leaving `chromedriver.exe` at 151 on disk. The change is correct for a clean `npm ci`; it has not been observed working. Drop this commit if you would rather bump it somewhere it can be tested.

## What this PR does not cover

`visual:check` still has not run, so there is **no visual-regression evidence** for the counter or winget changes. The baseline (240 images, 5 Sept) is intact, and a legitimate diff on `/docs/install/` should be expected from commit 2 when it does run.

## Related

The first commit here is already applied to the site template as its own commit in fstubner/product-site-template#26, since that PR touches the same file. Once this lands, a later template sync should carry it across as a no-op.

## Audit coverage behind these fixes

All 14 routes walked at 1440, plus mobile (375) and tablet (768) passes, light and dark themes, and a keyboard pass. Automated gates all clean: axe 0 violations across 14 pages in both themes, contrast sweep passing on every rendered text node, 0 shadowed CSS declarations of 1,116, `check:regions` clean, changelog dates matching. Docs search verified against a production build — `packet capture` returns 10 results with `/docs/packet-capture/` top.
